### PR TITLE
chore: update doc references to wiki, fix Mermaid syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,10 @@ For every phase or feature, create both files in `docs/superpowers/`:
 
 | Topic                              | Location                                       |
 | ---------------------------------- | ---------------------------------------------- |
-| Docker, CI/CD, init flow, env vars | `docs/01-infrastructure.md`                    |
-| Database schema & relationships    | `docs/02-database-schema.md`                   |
-| Data pipeline & worker lifecycle   | `docs/03-data-flow.md`                         |
-| API endpoints & authentication     | `docs/04-api-reference.md`                     |
-| Utilities & Zod validators         | `docs/05-utilities-reference.md`               |
-| Testing infrastructure             | `docs/06-testing.md`                           |
+| Docker, CI/CD, init flow, env vars | [Wiki: Infrastructure](https://github.com/elfensky/helldivers.bot/wiki/Infrastructure) |
+| Database schema & relationships    | [Wiki: Database-Schema](https://github.com/elfensky/helldivers.bot/wiki/Database-Schema) |
+| Data pipeline & worker lifecycle   | [Wiki: Data-Flow](https://github.com/elfensky/helldivers.bot/wiki/Data-Flow) |
+| API endpoints & authentication     | [Wiki: API-Reference](https://github.com/elfensky/helldivers.bot/wiki/API-Reference) |
+| Utilities & Zod validators         | [Wiki: Utilities-Reference](https://github.com/elfensky/helldivers.bot/wiki/Utilities-Reference) |
+| Testing infrastructure             | [Wiki: Testing](https://github.com/elfensky/helldivers.bot/wiki/Testing) |
 | Frontend design system & tokens    | `/brandkit` (visual) + `src/styles/tokens.css` |

--- a/docs/02-database-schema.md
+++ b/docs/02-database-schema.md
@@ -115,13 +115,13 @@ erDiagram
 
     h1_introduction_order {
         String id    PK
-        Int    season FK-UK
+        Int    season FK "unique"
         Int[]  order
     }
 
     h1_points_max {
         String id     PK
-        Int    season FK-UK
+        Int    season FK "unique"
         Int[]  points
     }
 
@@ -201,7 +201,7 @@ erDiagram
 
     Account {
         String id               PK
-        String userId           FK-UK
+        String userId           FK "unique"
         String provider
         String providerAccountId
     }


### PR DESCRIPTION
## Summary
- Update CLAUDE.md reference table to point to GitHub wiki URLs instead of local `docs/` paths
- Fix `FK-UK` → `FK "unique"` in Mermaid ER diagram (`docs/02-database-schema.md`) — GitHub's Mermaid parser doesn't support compound keywords with hyphens

## Wiki changes (pushed separately)
- Added Mermaid flowchart to [Data-Flow](https://github.com/elfensky/helldivers.bot/wiki/Data-Flow) (pipeline visualization with color-coded subgraphs)
- Added Mermaid diagram to [Infrastructure](https://github.com/elfensky/helldivers.bot/wiki/Infrastructure) (Docker startup order)
- Added [Unofficial API Documentation](https://github.com/elfensky/helldivers.bot/wiki/Unofficial-API-Documentation) page (XTC upstream docs + sample JSON responses)
- Updated wiki Home and Sidebar with new page

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:unit:run` — 222/222 pass
- [ ] Verify wiki Mermaid diagrams render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)