### PR TITLE
fix(security): use timing-safe comparison for API key

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -2,7 +2,7 @@ name: Production
 on:
     push:
         tags:
-            - '*.*.*' # Triggers on version tags like v1.0.0
+            - 'v*.*.*' # Triggers on version tags like v1.0.0
 permissions:
     contents: read
     packages: write

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - develop
 permissions:
     contents: write
     packages: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,10 @@ For every phase or feature, create both files in `docs/superpowers/`:
 
 | Topic                              | Location                                       |
 | ---------------------------------- | ---------------------------------------------- |
-| Docker, CI/CD, init flow, env vars | `docs/01-infrastructure.md`                    |
-| Database schema & relationships    | `docs/02-database-schema.md`                   |
-| Data pipeline & worker lifecycle   | `docs/03-data-flow.md`                         |
-| API endpoints & authentication     | `docs/04-api-reference.md`                     |
-| Utilities & Zod validators         | `docs/05-utilities-reference.md`               |
-| Testing infrastructure             | `docs/06-testing.md`                           |
+| Docker, CI/CD, init flow, env vars | [Wiki: Infrastructure](https://github.com/elfensky/helldivers.bot/wiki/Infrastructure) |
+| Database schema & relationships    | [Wiki: Database-Schema](https://github.com/elfensky/helldivers.bot/wiki/Database-Schema) |
+| Data pipeline & worker lifecycle   | [Wiki: Data-Flow](https://github.com/elfensky/helldivers.bot/wiki/Data-Flow) |
+| API endpoints & authentication     | [Wiki: API-Reference](https://github.com/elfensky/helldivers.bot/wiki/API-Reference) |
+| Utilities & Zod validators         | [Wiki: Utilities-Reference](https://github.com/elfensky/helldivers.bot/wiki/Utilities-Reference) |
+| Testing infrastructure             | [Wiki: Testing](https://github.com/elfensky/helldivers.bot/wiki/Testing) |
 | Frontend design system & tokens    | `/brandkit` (visual) + `src/styles/tokens.css` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,34 @@ Next.js 16 app that caches the official Helldivers 1 API, stores historic game d
 - **Chrome DevTools MCP** is available for debugging live pages. Use `evaluate_script` to inspect DOM state (e.g., sector CSS classes) and extract RSC payload data. Useful for verifying map state, comparing field values, and debugging visual issues without screenshots.
 - Commands are in `package.json` (`npm run` to list). Env vars are in `.example.env`.
 
+## Git Workflow
+
+**Branching model:** Simplified Git Flow — no release branches.
+
+| Branch | Purpose | Deploys to | Protected |
+|--------|---------|-----------|-----------|
+| `main` | Production releases | Production (via tags) | Yes — PR only |
+| `develop` | Integration/staging | Staging (auto) | Yes — PR only |
+| `feature/<desc>` | New functionality | — | No |
+| `bugfix/<desc>` | Non-urgent fixes | — | No |
+| `hotfix/<semver>` | Emergency prod fixes | — | No |
+
+**Rules:**
+1. **Never push directly to `main` or `develop`** — always use pull requests
+2. **Create feature/bugfix branches from `develop`**, merge back to `develop` via PR
+3. **Release process:** Merge `develop` → `main` via PR → tag `vX.Y.0` on main
+4. **Hotfix process:** Cut `hotfix/X.Y.Z` from `main` → fix → PR to `main` → tag `vX.Y.Z` → merge back to `develop`
+5. **Semver tagging:** `v<major>.<minor>.<patch>` on `main` only (always use `v` prefix)
+6. **After merging hotfix to `main`:** Always merge back to `develop` to prevent drift
+
+**Git Flow automation (git-workflow skill):**
+- `/git-workflow:feature <desc>` — create feature branch from `develop`
+- `/git-workflow:hotfix <semver>` — create hotfix branch from `main`
+- `/git-workflow:finish` — merge current branch to correct target(s), tag, cleanup
+- `/git-workflow:flow-status` — show branch status, stale branches, version info
+
+Prefer these commands over manual git operations.
+
 ## Conventions
 
 ### Error Handling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to Helldivers Bot
+
+## Branching Strategy
+
+Helldivers Bot uses a **simplified Git Flow** model:
+
+```
+main ──────●────────●────────●──── (tagged releases, production)
+            \      ↑          ↑
+             \   merge    hotfix/*
+              \  /
+develop ──────●──●──●──●──●──── (staging auto-deploy)
+               \   ↑     \
+              feature/*  bugfix/*
+```
+
+| Branch | Created from | Merges to | Lifetime |
+|--------|-------------|-----------|----------|
+| `main` | — | — | Permanent (production) |
+| `develop` | — | — | Permanent (staging) |
+| `feature/<desc>` | `develop` | `develop` | Days (max 1-2 weeks) |
+| `bugfix/<desc>` | `develop` | `develop` | Days |
+| `hotfix/<semver>` | `main` | `main` + `develop` | Hours |
+
+### Branch Naming
+
+- `feature/<short-desc>` — e.g., `feature/war-event-tracking`
+- `bugfix/<short-desc>` — e.g., `bugfix/dispatch-parser`
+- `hotfix/<semver>` — e.g., `hotfix/0.16.1`
+- `chore/<short-desc>` — e.g., `chore/upgrade-discord-js`
+
+## Git Flow Commands (Claude Code)
+
+```bash
+/git-workflow:feature war-event-tracking  # Create feature branch from develop
+/git-workflow:hotfix 0.16.1               # Create hotfix branch from main
+/git-workflow:finish                       # Merge current branch, tag, cleanup
+/git-workflow:flow-status                  # Show branch status and version info
+```
+
+## Workflow
+
+1. Create a branch from `develop`
+2. Make changes, commit with conventional commits (`feat:`, `fix:`, `chore:`)
+3. Push and open a pull request to `develop`
+4. Merge when CI passes
+5. Changes deploy to staging
+
+## Release Process
+
+1. Ensure `develop` is stable
+2. Open PR from `develop` → `main`
+3. Bump version in `package.json`, update CHANGELOG.md
+4. Merge
+5. Tag `main`: `git tag -a vX.Y.0 -m "Release X.Y.0"` and push
+6. GitHub Actions builds Docker images and creates release
+
+## Hotfix Process
+
+1. Cut `hotfix/<semver>` from `main`
+2. Fix, commit with tests
+3. PR to `main`, merge
+4. Tag and push (triggers production build)
+5. Merge `main` back to `develop`
+
+## Versioning
+
+Semantic versioning with `v` prefix (`vMAJOR.MINOR.PATCH`):
+- **Major**: Breaking API changes, Discord.js major upgrade
+- **Minor**: New commands, features, event handlers
+- **Patch**: Bug fixes, dependency updates
+
+**Important:** Always use `v` prefix on tags (e.g., `v0.16.1`, not `0.16.1`).
+
+## Commit Messages
+
+Use conventional commits:
+
+```
+feat: add war event tracking
+fix: correct dispatch message parsing
+chore: upgrade discord.js to v15
+refactor: extract event handler base class
+```
+
+## CI/CD
+
+| Event | Action |
+|-------|--------|
+| Push to `main` or `develop` | Build + deploy staging Docker image |
+| Tag `v*.*.*` | Build production Docker image + GitHub Release |

--- a/docs/02-database-schema.md
+++ b/docs/02-database-schema.md
@@ -115,13 +115,13 @@ erDiagram
 
     h1_introduction_order {
         String id    PK
-        Int    season FK-UK
+        Int    season FK "unique"
         Int[]  order
     }
 
     h1_points_max {
         String id     PK
-        Int    season FK-UK
+        Int    season FK "unique"
         Int[]  points
     }
 
@@ -201,7 +201,7 @@ erDiagram
 
     Account {
         String id               PK
-        String userId           FK-UK
+        String userId           FK "unique"
         String provider
         String providerAccountId
     }

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import Link from 'next/link';
 import DocsClient from '@/components/layout/OpenAPI/DocsClient';
 
 export const metadata = {
@@ -16,6 +17,7 @@ export default function AboutPage() {
     return (
         <div className="gutters relative mb-8 flex flex-col flex-wrap gap-8">
             <About />
+            <Architecture />
             <Discord />
             <Api />
             <Docs openapi={openapi} />
@@ -45,6 +47,25 @@ function About() {
                 I work on this project in my spare time as a hobby, combining my love for
                 the game with my passion for coding and learning new technologies.
             </p>
+        </section>
+    );
+}
+
+function Architecture() {
+    return (
+        <section className="card w-full rounded-md p-2 sm:max-w-1/2 md:p-4">
+            <h2 className="font-[family-name:var(--font-display)]">Architecture</h2>
+            <p>
+                Curious how the data pipeline works? See the interactive diagram showing
+                how data flows from the official Helldivers API through validation,
+                storage, and normalization to the frontend.
+            </p>
+            <Link
+                href="/architecture"
+                className="mt-2 inline-block text-[var(--color-primary)] hover:underline"
+            >
+                View data flow diagram &rarr;
+            </Link>
         </section>
     );
 }

--- a/src/app/api/h1/update/route.js
+++ b/src/app/api/h1/update/route.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { tryCatch } from '@/utils/tryCatch';
 import { performance } from 'perf_hooks';
 import { roundedPerformanceTime } from '@/utils/time';
@@ -13,7 +14,9 @@ export async function GET(request) {
     const key = header?.startsWith('Bearer ') ? header.slice(7) : null;
     if (!key) return errorResponse(401, start);
     const secret = process.env.UPDATE_KEY;
-    if (key !== secret) return errorResponse(401, start);
+    const actual = crypto.createHash('sha256').update(key).digest();
+    const expected = crypto.createHash('sha256').update(secret).digest();
+    if (!crypto.timingSafeEqual(actual, expected)) return errorResponse(401, start);
 
     //STATUS
     const { data: statusData, error: statusError } = await tryCatch(updateStatus());

--- a/src/app/architecture/page.jsx
+++ b/src/app/architecture/page.jsx
@@ -1,0 +1,71 @@
+import DataFlowDiagram from '@/components/layout/DataFlowDiagram/DataFlowDiagram';
+
+export const metadata = {
+    title: 'Architecture | Helldivers Bot',
+    description:
+        'Data flow architecture diagram for helldivers.bot — see how data moves from the official API through processing and storage to the frontend.',
+};
+
+export default function ArchitecturePage() {
+    return (
+        <div className="gutters relative mb-8 flex flex-col gap-8">
+            <section className="card w-full p-2 md:p-4">
+                <h2 className="font-[family-name:var(--font-display)]">
+                    Data Flow Architecture
+                </h2>
+                <p className="text-[var(--color-text-muted)]">
+                    How data moves from the official Helldivers 1 API through validation,
+                    storage, and normalization to the frontend. Click any node for
+                    details.
+                </p>
+                <DataFlowDiagram />
+            </section>
+
+            <section className="card w-full p-2 md:p-4">
+                <h2 className="font-[family-name:var(--font-display)]">Key Concepts</h2>
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <h3 className="text-sm font-semibold text-[var(--color-faction-bugs)]">
+                            Two-Table Strategy
+                        </h3>
+                        <p className="text-sm text-[var(--color-text-muted)]">
+                            Raw API responses are stored in rebroadcast tables (faithful
+                            JSON), while normalized h1_* tables enable filtering, joining,
+                            and aggregation. Both coexist to avoid trade-offs.
+                        </p>
+                    </div>
+                    <div>
+                        <h3 className="text-sm font-semibold text-[var(--color-primary)]">
+                            Worker Thread
+                        </h3>
+                        <p className="text-sm text-[var(--color-text-muted)]">
+                            A dedicated thread polls the official API every 5-15 seconds
+                            using setTimeout (not setInterval) to prevent overlapping
+                            requests. Validates with Zod before any database writes.
+                        </p>
+                    </div>
+                    <div>
+                        <h3 className="text-sm font-semibold text-[var(--color-success)]">
+                            Confirm Pattern
+                        </h3>
+                        <p className="text-sm text-[var(--color-text-muted)]">
+                            Each update cycle creates an unconfirmed season row, writes
+                            all child data, then confirms by setting last_updated. This
+                            ensures partial writes are detectable.
+                        </p>
+                    </div>
+                    <div>
+                        <h3 className="text-sm font-semibold text-[var(--color-faction-illuminate)]">
+                            On-Demand Fetching
+                        </h3>
+                        <p className="text-sm text-[var(--color-text-muted)]">
+                            Missing seasons are fetched from the official API on first
+                            request. The /war page derives available seasons from the
+                            current season number, not a database query.
+                        </p>
+                    </div>
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/src/components/layout/DataFlowDiagram/DataFlowDiagram.css
+++ b/src/components/layout/DataFlowDiagram/DataFlowDiagram.css
@@ -1,0 +1,374 @@
+/* DataFlowDiagram — Architecture visualization */
+
+.diagram-wrapper {
+    width: 100%;
+    overflow: hidden;
+}
+
+/* Filter controls */
+.diagram-controls {
+    display: flex;
+    gap: var(--space-2);
+    padding: var(--space-4) 0;
+    flex-wrap: wrap;
+}
+
+.diagram-controls button {
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-surface-3);
+    background: var(--color-surface-1);
+    color: var(--color-text-muted);
+    font-family: var(--font-body);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.diagram-controls button:hover {
+    border-color: var(--color-surface-4);
+    color: var(--color-text);
+}
+
+.diagram-controls button.active {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    background: rgba(255, 224, 0, 0.08);
+}
+
+/* SVG canvas */
+.diagram-canvas {
+    position: relative;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+svg.diagram-flow {
+    width: 100%;
+    min-width: 700px;
+    height: auto;
+    display: block;
+}
+
+/* Node styles */
+.diagram-node rect {
+    transition: all 0.3s;
+}
+
+.diagram-node {
+    cursor: pointer;
+}
+
+.diagram-node:hover rect {
+    filter: brightness(1.2);
+}
+
+/* Category colors */
+.cat-api rect {
+    fill: var(--color-surface-2);
+    stroke: #3b82f6;
+    stroke-width: 1.5;
+}
+
+.cat-api text.label {
+    fill: #60a5fa;
+}
+
+.cat-worker rect {
+    fill: var(--color-surface-1);
+    stroke: #a855f7;
+    stroke-width: 1.5;
+}
+
+.cat-worker text.label {
+    fill: #c084fc;
+}
+
+.cat-raw rect {
+    fill: var(--color-surface-1);
+    stroke: var(--color-faction-bugs);
+    stroke-width: 1.5;
+}
+
+.cat-raw text.label {
+    fill: var(--color-faction-bugs);
+}
+
+.cat-norm rect {
+    fill: var(--color-surface-1);
+    stroke: var(--color-success);
+    stroke-width: 1.5;
+}
+
+.cat-norm text.label {
+    fill: #4ade80;
+}
+
+.cat-seed rect {
+    fill: var(--color-surface-1);
+    stroke: #ec4899;
+    stroke-width: 1.5;
+}
+
+.cat-seed text.label {
+    fill: #f472b6;
+}
+
+.cat-frontend rect {
+    fill: var(--color-surface-1);
+    stroke: #06b6d4;
+    stroke-width: 1.5;
+}
+
+.cat-frontend text.label {
+    fill: #22d3ee;
+}
+
+/* Arrow styles */
+.diagram-arrow {
+    stroke-width: 1.5;
+    fill: none;
+}
+
+.arrow-api {
+    stroke: #3b82f6;
+}
+
+.arrow-worker {
+    stroke: #a855f7;
+}
+
+.arrow-amber {
+    stroke: var(--color-faction-bugs);
+}
+
+.arrow-green {
+    stroke: var(--color-success);
+}
+
+.arrow-seed {
+    stroke: #ec4899;
+}
+
+.arrow-frontend {
+    stroke: #06b6d4;
+}
+
+.arrow-dashed {
+    stroke-dasharray: 6 4;
+}
+
+/* Dim/highlight for filter views */
+.diagram-dimmed {
+    opacity: 0.12;
+    transition: opacity 0.3s;
+}
+
+.diagram-highlighted {
+    opacity: 1;
+    transition: opacity 0.3s;
+}
+
+/* Annotations */
+.diagram-annotation {
+    font-family: var(--font-body);
+    font-size: 11px;
+    fill: var(--color-text-muted);
+}
+
+.diagram-annotation-bg {
+    fill: var(--color-surface-0);
+}
+
+/* Legend */
+.diagram-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+    padding: var(--space-4) 0;
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
+.diagram-legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.diagram-legend-dot {
+    width: 10px;
+    height: 10px;
+    flex-shrink: 0;
+}
+
+/* Detail panel (slide-in from right) */
+.diagram-detail-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 40;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+.diagram-detail-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.diagram-detail-panel {
+    position: fixed;
+    top: 0;
+    right: -420px;
+    width: min(400px, 90vw);
+    height: 100vh;
+    background: var(--color-surface-1);
+    border-left: 1px solid var(--color-surface-3);
+    padding: var(--space-8);
+    overflow-y: auto;
+    transition: right 0.3s ease;
+    z-index: 50;
+}
+
+.diagram-detail-panel.open {
+    right: 0;
+}
+
+.diagram-detail-panel h3 {
+    font-family: var(--font-display);
+    font-size: 16px;
+    color: var(--color-text);
+    margin-bottom: var(--space-1);
+}
+
+.diagram-detail-subtitle {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-6);
+}
+
+.diagram-detail-close {
+    position: absolute;
+    top: var(--space-4);
+    right: var(--space-4);
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 18px;
+    cursor: pointer;
+    padding: var(--space-2);
+}
+
+.diagram-detail-close:hover {
+    color: var(--color-text);
+}
+
+.diagram-detail-panel p {
+    font-size: 13px;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+    margin: var(--space-2) 0;
+    white-space: pre-line;
+}
+
+.diagram-detail-panel pre {
+    background: var(--color-surface-0);
+    border: 1px solid var(--color-surface-3);
+    padding: var(--space-4);
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--color-text);
+    overflow-x: auto;
+    white-space: pre;
+    margin: var(--space-2) 0;
+}
+
+.diagram-detail-heading {
+    color: var(--color-text-muted);
+    margin-top: var(--space-6);
+    font-size: 12px;
+    font-weight: 500;
+}
+
+/* Tags */
+.diagram-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 500;
+    margin: 2px;
+}
+
+.tag-interval {
+    background: rgba(168, 85, 247, 0.12);
+    color: #c084fc;
+}
+
+.tag-upsert {
+    background: rgba(34, 197, 94, 0.12);
+    color: #4ade80;
+}
+
+.tag-once {
+    background: rgba(236, 72, 153, 0.12);
+    color: #f472b6;
+}
+
+.tag-read {
+    background: rgba(6, 182, 212, 0.12);
+    color: #22d3ee;
+}
+
+/* Schema table in detail panel */
+.diagram-schema-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: var(--space-2) 0;
+}
+
+.diagram-schema-table th {
+    text-align: left;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--color-surface-3);
+}
+
+.diagram-schema-table td {
+    font-size: 12px;
+    padding: 4px 8px;
+    color: var(--color-text);
+    font-family: var(--font-mono);
+}
+
+.diagram-schema-table tr:nth-child(even) td {
+    background: rgba(19, 19, 19, 0.4);
+}
+
+/* Layer labels in SVG */
+.diagram-layer-label {
+    font-size: 11px;
+    fill: var(--color-text-muted);
+    font-weight: 500;
+}
+
+.diagram-sublabel {
+    font-size: 9px;
+}
+
+/* Mobile: horizontal scroll hint */
+@media (max-width: 768px) {
+    .diagram-canvas::after {
+        content: 'Scroll \u2192';
+        position: absolute;
+        top: var(--space-2);
+        right: var(--space-2);
+        font-size: 11px;
+        color: var(--color-text-muted);
+        background: var(--color-surface-1);
+        padding: 2px 8px;
+        opacity: 0.8;
+        pointer-events: none;
+    }
+}

--- a/src/components/layout/DataFlowDiagram/DataFlowDiagram.jsx
+++ b/src/components/layout/DataFlowDiagram/DataFlowDiagram.jsx
@@ -1,0 +1,840 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { detailData } from './detailData';
+import './DataFlowDiagram.css';
+
+const VIEWS = [
+    { key: 'all', label: 'All Flows' },
+    { key: 'live', label: 'Live Polling (5-15s)' },
+    { key: 'snapshot', label: 'Snapshot Sync' },
+    { key: 'seed', label: 'Seed (Bootstrap)' },
+    { key: 'refresh', label: 'Force Refresh' },
+    { key: 'read', label: 'Frontend Reads' },
+];
+
+const FLOW_MAP = {
+    live: ['live'],
+    snapshot: ['snapshot'],
+    seed: ['seed'],
+    refresh: ['refresh'],
+    read: ['read-map', 'read-stats', 'read-events'],
+};
+
+const LEGEND = [
+    { color: '#3b82f6', label: 'Official API' },
+    { color: '#a855f7', label: 'Worker / Processing' },
+    { color: '#f59e0b', label: 'Raw Cache (rebroadcast)' },
+    { color: '#22c55e', label: 'Normalized (h1_*)' },
+    { color: '#ec4899', label: 'Seed Files (past wars)' },
+    { color: '#06b6d4', label: 'Frontend Components' },
+];
+
+function getVisibilityClass(elementFlows, activeView) {
+    if (activeView === 'all') return '';
+    const activeFlows = FLOW_MAP[activeView] || [activeView];
+    const flows = elementFlows.split(' ');
+    const matches = flows.some((f) => activeFlows.includes(f));
+    return matches ? 'diagram-highlighted' : 'diagram-dimmed';
+}
+
+function DetailSection({ section }) {
+    if (section.type === 'text') {
+        return <p>{section.content}</p>;
+    }
+    if (section.type === 'heading') {
+        return <h4 className="diagram-detail-heading">{section.content}</h4>;
+    }
+    if (section.type === 'code') {
+        return <pre>{section.content}</pre>;
+    }
+    if (section.type === 'tags') {
+        return (
+            <div>
+                {section.items.map((tag) => (
+                    <span key={tag.text} className={`diagram-tag ${tag.cls}`}>
+                        {tag.text}
+                    </span>
+                ))}
+            </div>
+        );
+    }
+    if (section.type === 'table') {
+        return (
+            <table className="diagram-schema-table">
+                <thead>
+                    <tr>
+                        {section.headers.map((h) => (
+                            <th key={h}>{h}</th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {section.rows.map((row, i) => (
+                        <tr key={i}>
+                            {row.map((cell, j) => (
+                                <td key={j}>{cell}</td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        );
+    }
+    return null;
+}
+
+function DetailPanel({ nodeId, onClose }) {
+    const data = nodeId ? detailData[nodeId] : null;
+    const isOpen = Boolean(data);
+
+    return (
+        <>
+            <div
+                className={`diagram-detail-overlay ${isOpen ? 'open' : ''}`}
+                onClick={onClose}
+            />
+            <div className={`diagram-detail-panel ${isOpen ? 'open' : ''}`}>
+                <button
+                    className="diagram-detail-close"
+                    onClick={onClose}
+                    aria-label="Close detail panel"
+                >
+                    &times;
+                </button>
+                {data && (
+                    <>
+                        <h3>{data.title}</h3>
+                        <div className="diagram-detail-subtitle">{data.subtitle}</div>
+                        {data.sections.map((section, i) => (
+                            <DetailSection key={i} section={section} />
+                        ))}
+                    </>
+                )}
+            </div>
+        </>
+    );
+}
+
+function DiagramNode({
+    x,
+    y,
+    w,
+    h,
+    id,
+    flows,
+    category,
+    label,
+    sublabel,
+    sublabel2,
+    sublabel3,
+    activeView,
+    onSelect,
+}) {
+    const vis = getVisibilityClass(flows, activeView);
+    return (
+        <g
+            className={`diagram-node ${category} ${vis}`}
+            tabIndex={0}
+            role="button"
+            aria-label={label}
+            onClick={(e) => {
+                e.stopPropagation();
+                onSelect(id);
+            }}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSelect(id);
+                }
+            }}
+        >
+            <rect x={x} y={y} width={w} height={h} rx={0} ry={0} />
+            <text
+                className="label"
+                x={x + w / 2}
+                y={y + 22}
+                textAnchor="middle"
+                fontSize={13}
+                fontWeight={600}
+            >
+                {label}
+            </text>
+            {sublabel && (
+                <text
+                    x={x + w / 2}
+                    y={y + 40}
+                    textAnchor="middle"
+                    fontSize={11}
+                    fill="#666"
+                >
+                    {sublabel}
+                </text>
+            )}
+            {sublabel2 && (
+                <text
+                    x={x + w / 2}
+                    y={y + 58}
+                    textAnchor="middle"
+                    fontSize={11}
+                    fill="#666"
+                >
+                    {sublabel2}
+                </text>
+            )}
+            {sublabel3 && (
+                <text
+                    x={x + w / 2}
+                    y={y + 74}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fill="#555"
+                >
+                    {sublabel3}
+                </text>
+            )}
+        </g>
+    );
+}
+
+function DiagramArrow({ d, flows, arrowClass, markerEnd, activeView, dashed }) {
+    const vis = getVisibilityClass(flows, activeView);
+    return (
+        <path
+            className={`diagram-arrow ${arrowClass} ${dashed ? 'arrow-dashed' : ''} ${vis}`}
+            d={d}
+            markerEnd={markerEnd}
+        />
+    );
+}
+
+function Annotation({ x, y, bgW, text, flows, activeView }) {
+    const vis = getVisibilityClass(flows, activeView);
+    return (
+        <g className={vis}>
+            <rect
+                className="diagram-annotation-bg"
+                x={x - bgW / 2}
+                y={y - 11}
+                width={bgW}
+                height={16}
+            />
+            <text className="diagram-annotation" x={x} y={y} textAnchor="middle">
+                {text}
+            </text>
+        </g>
+    );
+}
+
+export default function DataFlowDiagram() {
+    const [activeView, setActiveView] = useState('all');
+    const [selectedNode, setSelectedNode] = useState(null);
+
+    const handleNodeSelect = useCallback((id) => {
+        setSelectedNode(id);
+    }, []);
+
+    const handleCloseDetail = useCallback(() => {
+        setSelectedNode(null);
+    }, []);
+
+    useEffect(() => {
+        if (!selectedNode) return;
+        const handler = (e) => {
+            if (e.key === 'Escape') handleCloseDetail();
+        };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, [selectedNode, handleCloseDetail]);
+
+    return (
+        <div className="diagram-wrapper">
+            {/* Filter controls */}
+            <div className="diagram-controls">
+                {VIEWS.map((view) => (
+                    <button
+                        key={view.key}
+                        className={activeView === view.key ? 'active' : ''}
+                        onClick={() => setActiveView(view.key)}
+                    >
+                        {view.label}
+                    </button>
+                ))}
+            </div>
+
+            {/* SVG diagram */}
+            <div className="diagram-canvas">
+                <svg
+                    className="diagram-flow"
+                    viewBox="0 0 1100 560"
+                    role="img"
+                    aria-label="Data flow architecture diagram showing how data moves from the official Helldivers API through processing, validation, database storage, and frontend display"
+                >
+                    <title>Helldivers Bot Data Flow Architecture</title>
+                    <desc>
+                        Interactive diagram showing 4 data sources (live API, snapshots,
+                        seed files, force refresh) flowing through worker threads and
+                        validation into raw cache and normalized database tables, then
+                        consumed by frontend components.
+                    </desc>
+
+                    {/* Arrow markers */}
+                    <defs>
+                        {[
+                            { id: 'ah-blue', fill: '#3b82f6' },
+                            { id: 'ah-amber', fill: '#f59e0b' },
+                            { id: 'ah-green', fill: '#22c55e' },
+                            { id: 'ah-pink', fill: '#ec4899' },
+                            { id: 'ah-cyan', fill: '#06b6d4' },
+                        ].map((m) => (
+                            <marker
+                                key={m.id}
+                                id={m.id}
+                                markerWidth={8}
+                                markerHeight={6}
+                                refX={8}
+                                refY={3}
+                                orient="auto"
+                            >
+                                <polygon points="0 0, 8 3, 0 6" fill={m.fill} />
+                            </marker>
+                        ))}
+                    </defs>
+
+                    {/* Layer labels */}
+                    <text
+                        className="diagram-layer-label"
+                        x={120}
+                        y={24}
+                        textAnchor="middle"
+                    >
+                        DATA SOURCES
+                    </text>
+                    <text
+                        className="diagram-layer-label"
+                        x={430}
+                        y={24}
+                        textAnchor="middle"
+                    >
+                        PROCESSING
+                    </text>
+                    <text
+                        className="diagram-layer-label"
+                        x={720}
+                        y={20}
+                        textAnchor="middle"
+                    >
+                        DATABASE
+                    </text>
+                    <text
+                        className="diagram-layer-label"
+                        x={1000}
+                        y={200}
+                        textAnchor="middle"
+                    >
+                        FRONTEND
+                    </text>
+                    <text
+                        className="diagram-sublabel"
+                        x={615}
+                        y={44}
+                        textAnchor="end"
+                        fill="rgba(245,158,11,0.25)"
+                    >
+                        RAW
+                    </text>
+                    <text
+                        className="diagram-sublabel"
+                        x={615}
+                        y={186}
+                        textAnchor="end"
+                        fill="rgba(34,197,94,0.25)"
+                    >
+                        NORMALIZED
+                    </text>
+
+                    {/* LAYER 1: DATA SOURCES */}
+                    <DiagramNode
+                        x={20}
+                        y={40}
+                        w={200}
+                        h={56}
+                        id="api-status"
+                        flows="live"
+                        category="cat-api"
+                        label="get_campaign_status"
+                        sublabel="Live war state + stats"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={20}
+                        y={130}
+                        w={200}
+                        h={56}
+                        id="api-snapshot"
+                        flows="snapshot"
+                        category="cat-api"
+                        label="get_snapshots"
+                        sublabel="Historical time-series"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={20}
+                        y={260}
+                        w={200}
+                        h={56}
+                        id="seed-files"
+                        flows="seed"
+                        category="cat-seed"
+                        label="prisma/seed/seasons/*.json"
+                        sublabel="Bootstrap (first deploy)"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={20}
+                        y={350}
+                        w={200}
+                        h={56}
+                        id="api-refresh"
+                        flows="refresh"
+                        category="cat-api"
+                        label="get_snapshots (forced)"
+                        sublabel="Re-fetch any season"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+
+                    {/* LAYER 2: PROCESSING */}
+                    <DiagramNode
+                        x={340}
+                        y={40}
+                        w={180}
+                        h={86}
+                        id="worker"
+                        flows="live snapshot"
+                        category="cat-worker"
+                        label="Worker Thread"
+                        sublabel="cron.js"
+                        sublabel2="setTimeout loop"
+                        sublabel3="poll > validate > upsert"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={340}
+                        y={260}
+                        w={180}
+                        h={56}
+                        id="seed-script"
+                        flows="seed"
+                        category="cat-seed"
+                        label="Seed Script"
+                        sublabel="prisma db seed / startup"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={340}
+                        y={350}
+                        w={180}
+                        h={56}
+                        id="refresh-handler"
+                        flows="refresh"
+                        category="cat-api"
+                        label="updateSeason()"
+                        sublabel="fetch + validate + upsert"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+
+                    {/* LAYER 3: RAW CACHE */}
+                    <DiagramNode
+                        x={620}
+                        y={30}
+                        w={200}
+                        h={48}
+                        id="rb-status"
+                        flows="live"
+                        category="cat-raw"
+                        label="rebroadcast_status"
+                        sublabel="1 row/season - raw JSON"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={620}
+                        y={90}
+                        w={200}
+                        h={48}
+                        id="rb-snapshot"
+                        flows="snapshot refresh"
+                        category="cat-raw"
+                        label="rebroadcast_snapshot"
+                        sublabel="1 row/season - raw JSON"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+
+                    {/* LAYER 4: NORMALIZED DB */}
+                    <DiagramNode
+                        x={620}
+                        y={170}
+                        w={200}
+                        h={40}
+                        id="h1-season"
+                        flows="live snapshot seed refresh"
+                        category="cat-norm"
+                        label="h1_season"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={620}
+                        y={222}
+                        w={200}
+                        h={48}
+                        id="h1-live"
+                        flows="live read-map read-stats"
+                        category="cat-norm"
+                        label="h1_live"
+                        sublabel="campaigns + stats + map"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={620}
+                        y={282}
+                        w={200}
+                        h={40}
+                        id="h1-event"
+                        flows="live snapshot seed refresh read-events"
+                        category="cat-norm"
+                        label="h1_event"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={620}
+                        y={334}
+                        w={200}
+                        h={40}
+                        id="h1-intro"
+                        flows="live snapshot seed refresh"
+                        category="cat-norm"
+                        label="h1_introduction_order"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={620}
+                        y={386}
+                        w={200}
+                        h={40}
+                        id="h1-points"
+                        flows="live snapshot seed refresh"
+                        category="cat-norm"
+                        label="h1_points_max"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+
+                    {/* LAYER 5: FRONTEND */}
+                    <DiagramNode
+                        x={920}
+                        y={222}
+                        w={160}
+                        h={72}
+                        id="fe-live"
+                        flows="read-map read-stats"
+                        category="cat-frontend"
+                        label="Live Dashboard"
+                        sublabel="map + stats + players"
+                        sublabel2="reads h1_live (3 rows)"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+                    <DiagramNode
+                        x={920}
+                        y={310}
+                        w={160}
+                        h={52}
+                        id="fe-events"
+                        flows="read-events"
+                        category="cat-frontend"
+                        label="Event Alerts"
+                        sublabel="active defend/attack"
+                        activeView={activeView}
+                        onSelect={handleNodeSelect}
+                    />
+
+                    {/* ARROWS: Data Sources → Processing */}
+                    <DiagramArrow
+                        d="M220,68 L340,68"
+                        flows="live"
+                        arrowClass="arrow-api"
+                        markerEnd="url(#ah-blue)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M220,158 L310,158 Q330,158 330,138 L330,100 Q330,83 340,83"
+                        flows="snapshot"
+                        arrowClass="arrow-api"
+                        markerEnd="url(#ah-blue)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M220,288 L340,288"
+                        flows="seed"
+                        arrowClass="arrow-seed"
+                        markerEnd="url(#ah-pink)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M220,378 L340,378"
+                        flows="refresh"
+                        arrowClass="arrow-api"
+                        markerEnd="url(#ah-blue)"
+                        activeView={activeView}
+                    />
+
+                    {/* ARROWS: Processing → Raw Cache */}
+                    <DiagramArrow
+                        d="M520,60 L620,54"
+                        flows="live"
+                        arrowClass="arrow-amber"
+                        markerEnd="url(#ah-amber)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,80 L580,80 Q600,80 600,100 L600,114 L620,114"
+                        flows="snapshot"
+                        arrowClass="arrow-amber"
+                        markerEnd="url(#ah-amber)"
+                        activeView={activeView}
+                    />
+
+                    {/* ARROWS: Worker → Normalized */}
+                    <DiagramArrow
+                        d="M520,70 L570,70 Q590,70 590,170 L590,190 L620,190"
+                        flows="live"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,75 L565,75 Q585,75 585,200 L585,246 L620,246"
+                        flows="live"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,80 L560,80 Q580,80 580,240 L580,302 L620,302"
+                        flows="live"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,85 L555,85 Q575,85 575,280 L575,354 L620,354"
+                        flows="live"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,90 L550,90 Q570,90 570,320 L570,406 L620,406"
+                        flows="live"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+
+                    {/* ARROWS: Snapshot → Normalized */}
+                    <DiagramArrow
+                        d="M520,90 L560,90 Q575,90 575,240 L575,302 L620,302"
+                        flows="snapshot"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,95 L555,95 Q570,95 570,300 L570,354 L620,354"
+                        flows="snapshot"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,100 L550,100 Q565,100 565,340 L565,406 L620,406"
+                        flows="snapshot"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+
+                    {/* ARROWS: Seed → Normalized */}
+                    <DiagramArrow
+                        d="M520,275 L570,275 Q590,275 590,200 L590,190 L620,190"
+                        flows="seed"
+                        arrowClass="arrow-seed"
+                        markerEnd="url(#ah-pink)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,280 L565,280 Q580,280 580,302 L620,302"
+                        flows="seed"
+                        arrowClass="arrow-seed"
+                        markerEnd="url(#ah-pink)"
+                        activeView={activeView}
+                        dashed
+                    />
+                    <DiagramArrow
+                        d="M520,285 L560,285 Q575,285 575,340 L575,354 L620,354"
+                        flows="seed"
+                        arrowClass="arrow-seed"
+                        markerEnd="url(#ah-pink)"
+                        activeView={activeView}
+                        dashed
+                    />
+                    <DiagramArrow
+                        d="M520,290 L555,290 Q570,290 570,380 L570,406 L620,406"
+                        flows="seed"
+                        arrowClass="arrow-seed"
+                        markerEnd="url(#ah-pink)"
+                        activeView={activeView}
+                        dashed
+                    />
+
+                    {/* ARROWS: Refresh → Raw + Normalized */}
+                    <DiagramArrow
+                        d="M520,365 L580,365 Q600,365 600,140 L600,114 L620,114"
+                        flows="refresh"
+                        arrowClass="arrow-amber"
+                        markerEnd="url(#ah-amber)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,370 L570,370 Q585,370 585,200 L585,190 L620,190"
+                        flows="refresh"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,375 L565,375 Q580,375 580,302 L620,302"
+                        flows="refresh"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,380 L560,380 Q575,375 575,354 L620,354"
+                        flows="refresh"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M520,385 L555,385 Q570,385 570,406 L620,406"
+                        flows="refresh"
+                        arrowClass="arrow-green"
+                        markerEnd="url(#ah-green)"
+                        activeView={activeView}
+                    />
+
+                    {/* ARROWS: DB → Frontend */}
+                    <DiagramArrow
+                        d="M820,246 L880,246 Q900,246 900,260 L900,268 L920,268"
+                        flows="read-map read-stats"
+                        arrowClass="arrow-frontend"
+                        markerEnd="url(#ah-cyan)"
+                        activeView={activeView}
+                    />
+                    <DiagramArrow
+                        d="M820,302 L880,302 Q900,302 900,340 L900,364 L920,364"
+                        flows="read-events"
+                        arrowClass="arrow-frontend"
+                        markerEnd="url(#ah-cyan)"
+                        activeView={activeView}
+                    />
+
+                    {/* ANNOTATIONS */}
+                    <Annotation
+                        x={265}
+                        y={53}
+                        bgW={60}
+                        text="5-15s"
+                        flows="live"
+                        activeView={activeView}
+                    />
+                    <Annotation
+                        x={265}
+                        y={159}
+                        bgW={60}
+                        text="~1h"
+                        flows="snapshot"
+                        activeView={activeView}
+                    />
+                    <Annotation
+                        x={265}
+                        y={289}
+                        bgW={60}
+                        text="once"
+                        flows="seed"
+                        activeView={activeView}
+                    />
+                    <Annotation
+                        x={271}
+                        y={379}
+                        bgW={72}
+                        text="on demand"
+                        flows="refresh"
+                        activeView={activeView}
+                    />
+                    <Annotation
+                        x={583}
+                        y={41}
+                        bgW={56}
+                        text="upsert"
+                        flows="live snapshot"
+                        activeView={activeView}
+                    />
+                    <Annotation
+                        x={873}
+                        y={235}
+                        bgW={56}
+                        text="read"
+                        flows="read-map read-stats read-events"
+                        activeView={activeView}
+                    />
+                </svg>
+            </div>
+
+            {/* Legend */}
+            <div className="diagram-legend">
+                {LEGEND.map((item) => (
+                    <div key={item.label} className="diagram-legend-item">
+                        <div
+                            className="diagram-legend-dot"
+                            style={{ background: item.color }}
+                        />
+                        <span>{item.label}</span>
+                    </div>
+                ))}
+                <div
+                    className="diagram-legend-item"
+                    style={{ color: 'var(--color-text-muted)', fontSize: 10 }}
+                >
+                    Click any node for details
+                </div>
+            </div>
+
+            {/* Detail panel */}
+            <DetailPanel nodeId={selectedNode} onClose={handleCloseDetail} />
+        </div>
+    );
+}

--- a/src/components/layout/DataFlowDiagram/detailData.js
+++ b/src/components/layout/DataFlowDiagram/detailData.js
@@ -1,0 +1,384 @@
+/**
+ * Static detail panel content for each node in the data-flow diagram.
+ * Each key maps to a node's data-id attribute.
+ */
+export const detailData = {
+    'api-status': {
+        title: 'get_campaign_status',
+        subtitle: 'Official Helldivers 1 API',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Returns the live state of the current war. Polled every 5-15 seconds.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: '5-15s poll', cls: 'tag-interval' }],
+            },
+            { type: 'heading', content: 'Response shape' },
+            {
+                type: 'code',
+                content:
+                    '{\n  campaign_status: [{\n    season, points, points_taken,\n    points_max, status, introduction_order\n  }],\n  defend_event: {\n    event_id, region, enemy,\n    points, points_max, status\n  },\n  attack_events: [{ event_id, enemy, ... }],\n  statistics: [{\n    enemy, players, missions, kills,\n    deaths, accidentals, shots, hits\n  }]\n}',
+            },
+        ],
+    },
+    'api-snapshot': {
+        title: 'get_snapshots',
+        subtitle: 'Official Helldivers 1 API',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Returns the full history of a war: time-series snapshots + all events. For past wars, data is immutable.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: '~1h poll (current war)', cls: 'tag-interval' }],
+            },
+            { type: 'heading', content: 'Response shape' },
+            {
+                type: 'code',
+                content:
+                    '{\n  introduction_order: [2, 1, 0],\n  points_max: [30000, 30000, 30000],\n  snapshots: [{\n    season, time,\n    data: "[{points, points_taken, status}, ...]"\n  }],\n  defend_events: [{ event_id, region, ... }],\n  attack_events: [{ event_id, enemy, ... }]\n}',
+            },
+        ],
+    },
+    'seed-files': {
+        title: 'Seed Files',
+        subtitle: 'prisma/seed/seasons/*.json',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Static JSON files that bootstrap the app on first deploy. Same shape as get_snapshots response \u2014 processed through the same normalization pipeline.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'first deploy only', cls: 'tag-once' }],
+            },
+            {
+                type: 'text',
+                content:
+                    'Does NOT replace the ability to re-fetch from the API. Seed gets the app running without API dependency; force refresh updates data from the live API.',
+            },
+            {
+                type: 'code',
+                content:
+                    'prisma/seed/seasons/\n  001.json\n  002.json\n  ...\n  155.json',
+            },
+        ],
+    },
+    'api-refresh': {
+        title: 'get_snapshots (forced)',
+        subtitle: 'On-demand season refresh',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Re-fetch any season from the live API to update or correct data. Triggered by admin action (e.g., /api/h1/update?season=148&force=true).',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'on demand', cls: 'tag-interval' }],
+            },
+            {
+                type: 'text',
+                content:
+                    'Use cases: pick up a newly completed season, correct corrupted data, backfill a season not in seed files. Goes through the same normalization pipeline as the regular snapshot sync.',
+            },
+        ],
+    },
+    'refresh-handler': {
+        title: 'updateSeason()',
+        subtitle: 'src/update/season.mjs',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Same function used by the regular snapshot sync. Fetches get_snapshots for the specified season, validates with Zod, upserts into rebroadcast_snapshot + all normalized h1_* tables.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'fetch + validate + upsert', cls: 'tag-upsert' }],
+            },
+            {
+                type: 'text',
+                content:
+                    'Overwrites existing data for that season (idempotent via unique constraints).',
+            },
+        ],
+    },
+    worker: {
+        title: 'Worker Thread',
+        subtitle: 'public/workers/cron.js',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Uses setTimeout (not setInterval) to prevent overlapping requests.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: '5-15s loop', cls: 'tag-interval' }],
+            },
+            { type: 'heading', content: 'Update cycle' },
+            {
+                type: 'text',
+                content:
+                    '1. Fetch API response\n2. Validate with Zod schemas\n3. Upsert raw JSON into rebroadcast table\n4. Normalize into h1_* tables\n5. Schedule next poll via setTimeout',
+            },
+        ],
+    },
+    'seed-script': {
+        title: 'Seed Script',
+        subtitle: 'prisma db seed',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Runs on first deploy to populate the database from static JSON files. Processes each season file through the same normalization pipeline used by live updates.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'first deploy only', cls: 'tag-once' }],
+            },
+        ],
+    },
+    'rb-status': {
+        title: 'rebroadcast_status',
+        subtitle: 'Raw cache layer',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Stores the latest raw API response per season. Upserted on every poll. No history.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'upsert by season', cls: 'tag-upsert' }],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type', 'Note'],
+                rows: [
+                    ['season', 'Int', '@unique'],
+                    ['last_updated', 'DateTime', 'poll timestamp'],
+                    ['json', 'JSONB', 'full response'],
+                ],
+            },
+        ],
+    },
+    'rb-snapshot': {
+        title: 'rebroadcast_snapshot',
+        subtitle: 'Raw cache layer',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Stores the latest raw snapshot response per season. Not time-series \u2014 that is h1_snapshot.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'upsert by season', cls: 'tag-upsert' }],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type', 'Note'],
+                rows: [
+                    ['season', 'Int', '@unique'],
+                    ['last_updated', 'DateTime', 'poll timestamp'],
+                    ['json', 'JSONB', 'full response'],
+                ],
+            },
+        ],
+    },
+    'h1-season': {
+        title: 'h1_season',
+        subtitle: 'Root anchor for all game data',
+        sections: [
+            {
+                type: 'text',
+                content: 'Every normalized table FKs back to this via season (Int).',
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type'],
+                rows: [
+                    ['season', 'Int @unique'],
+                    ['last_updated', 'DateTime?'],
+                ],
+            },
+        ],
+    },
+    'h1-live': {
+        title: 'h1_live',
+        subtitle: 'Current season live state',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'One row per (season, enemy). Merges campaign_status + statistics + computed map data. Overwritten every 5-15s poll. Current season only \u2014 not populated for past seasons.',
+            },
+            {
+                type: 'tags',
+                items: [
+                    { text: 'upsert by (season, enemy)', cls: 'tag-upsert' },
+                    { text: 'Live Dashboard', cls: 'tag-read' },
+                ],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type'],
+                rows: [
+                    ['season', 'Int FK'],
+                    ['enemy', 'Int (0/1/2)'],
+                    ['points / points_max', 'Int'],
+                    ['status', 'String'],
+                    ['players', 'Int'],
+                    ['kills / deaths', 'BigInt'],
+                    ['missions', 'Int'],
+                    ['map', 'Json?'],
+                ],
+            },
+            {
+                type: 'text',
+                content:
+                    'Replaces h1_campaign + h1_statistic + App.map (v1 consolidation). Frontend reads 3 rows for full live dashboard.',
+            },
+        ],
+    },
+    'h1-event': {
+        title: 'h1_event',
+        subtitle: 'Unified events (attack + defend)',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Single table with type discriminator. Region 1-10 = sectors, 11 = homeworld.',
+            },
+            {
+                type: 'tags',
+                items: [
+                    { text: 'upsert by event_id', cls: 'tag-upsert' },
+                    { text: 'Event Alerts + Timeline', cls: 'tag-read' },
+                ],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type'],
+                rows: [
+                    ['type', '"attack" | "defend"'],
+                    ['event_id', 'Int @unique'],
+                    ['season', 'Int FK'],
+                    ['region', 'Int'],
+                    ['enemy', 'Int'],
+                    ['points / points_max', 'Int'],
+                    ['status', 'String'],
+                    ['players_at_start', 'Int?'],
+                ],
+            },
+            {
+                type: 'text',
+                content: 'Replaces h1_defend_event + h1_attack_event (v1 consolidation)',
+            },
+        ],
+    },
+    'h1-intro': {
+        title: 'h1_introduction_order',
+        subtitle: 'Faction war-entry ordering per season',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'One row per season. Which factions entered the war and in what order. Indexed by enemy: [Bugs, Cyborgs, Illuminate].',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'upsert by season', cls: 'tag-upsert' }],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type'],
+                rows: [
+                    ['season', 'Int @unique FK'],
+                    ['order', 'Int[]'],
+                ],
+            },
+            {
+                type: 'text',
+                content:
+                    'Populated from campaign_status (current season) or get_snapshots (past seasons). Redundant json field dropped in v1.',
+            },
+        ],
+    },
+    'h1-points': {
+        title: 'h1_points_max',
+        subtitle: 'Max liberation points per season',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'One row per season. Max points needed to trigger homeworld assault per faction. Indexed by enemy: [Bugs, Cyborgs, Illuminate].',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'upsert by season', cls: 'tag-upsert' }],
+            },
+            {
+                type: 'table',
+                headers: ['Field', 'Type'],
+                rows: [
+                    ['season', 'Int @unique FK'],
+                    ['points', 'Int[]'],
+                ],
+            },
+            {
+                type: 'text',
+                content:
+                    'Populated from campaign_status (current season) or get_snapshots (past seasons). Redundant json field dropped in v1.',
+            },
+        ],
+    },
+    'fe-live': {
+        title: 'Live Dashboard',
+        subtitle: 'Map + Stats + Players',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Reads all 3 h1_live rows for the active season. Renders galaxy map (3 factions x 11 regions), stat cards (kills, deaths, accuracy), and player counts.',
+            },
+            {
+                type: 'tags',
+                items: [{ text: 'reads h1_live', cls: 'tag-read' }],
+            },
+            {
+                type: 'text',
+                content:
+                    "Each h1_live row contains one faction's campaign progress, statistics, and pre-computed map slice. Frontend assembles the full view from all 3 rows.",
+            },
+        ],
+    },
+    'fe-events': {
+        title: 'Event Alerts',
+        subtitle: 'Active defend/attack events',
+        sections: [
+            {
+                type: 'text',
+                content:
+                    'Shows alerts for ongoing events with progress and countdown timer.',
+            },
+            {
+                type: 'tags',
+                items: [
+                    {
+                        text: 'reads h1_event WHERE status = active',
+                        cls: 'tag-read',
+                    },
+                ],
+            },
+        ],
+    },
+};


### PR DESCRIPTION
## Summary
- Replaces plain `===` string comparison with `crypto.timingSafeEqual` for the `UPDATE_KEY` check in `/api/h1/update`
- Hashes both values with SHA-256 first to normalize buffer lengths
- Eliminates theoretical timing side-channel on secret comparison

## Context
Flagged by Aikido SAST (issue 21030966). Low practical severity (internal cron endpoint, network jitter dominates), but defense-in-depth with zero risk.

## Test plan
- [ ] `npm run build` passes
- [ ] `/api/h1/update` still returns 401 for invalid keys
- [ ] `/api/h1/update` still succeeds with valid `UPDATE_KEY`

After merge: tag `v0.7.4`, merge `main` back to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)