### PR TITLE
chore: desloppify cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,13 @@ develop ──────●──●──●──●──●──── (s
               feature/*  bugfix/*
 ```
 
-| Branch | Created from | Merges to | Lifetime |
-|--------|-------------|-----------|----------|
-| `main` | — | — | Permanent (production) |
-| `develop` | — | — | Permanent (staging) |
-| `feature/<desc>` | `develop` | `develop` | Days (max 1-2 weeks) |
-| `bugfix/<desc>` | `develop` | `develop` | Days |
-| `hotfix/<semver>` | `main` | `main` + `develop` | Hours |
+| Branch            | Created from | Merges to          | Lifetime               |
+| ----------------- | ------------ | ------------------ | ---------------------- |
+| `main`            | —            | —                  | Permanent (production) |
+| `develop`         | —            | —                  | Permanent (staging)    |
+| `feature/<desc>`  | `develop`    | `develop`          | Days (max 1-2 weeks)   |
+| `bugfix/<desc>`   | `develop`    | `develop`          | Days                   |
+| `hotfix/<semver>` | `main`       | `main` + `develop` | Hours                  |
 
 ### Branch Naming
 
@@ -66,6 +66,7 @@ develop ──────●──●──●──●──●──── (s
 ## Versioning
 
 Semantic versioning with `v` prefix (`vMAJOR.MINOR.PATCH`):
+
 - **Major**: Breaking API changes, Discord.js major upgrade
 - **Minor**: New commands, features, event handlers
 - **Patch**: Bug fixes, dependency updates
@@ -85,7 +86,7 @@ refactor: extract event handler base class
 
 ## CI/CD
 
-| Event | Action |
-|-------|--------|
-| Push to `main` or `develop` | Build + deploy staging Docker image |
-| Tag `v*.*.*` | Build production Docker image + GitHub Release |
+| Event                       | Action                                         |
+| --------------------------- | ---------------------------------------------- |
+| Push to `main` or `develop` | Build + deploy staging Docker image            |
+| Tag `v*.*.*`                | Build production Docker image + GitHub Release |

--- a/docs/superpowers/plans/2026-03-30-phase-7-tablet-responsive.md
+++ b/docs/superpowers/plans/2026-03-30-phase-7-tablet-responsive.md
@@ -15,6 +15,7 @@
 ### Task 1: Gutters — add md: breakpoint
 
 **Files:**
+
 - Modify: `src/app/layout.css:48-66`
 
 - [ ] **Step 1: Add md: gutter value**
@@ -72,6 +73,7 @@ git commit -m "feat: add md: gutter breakpoint and lg:pb-0 on main (#167)"
 ### Task 2: BottomNav — hide at lg:
 
 **Files:**
+
 - Modify: `src/components/layout/BottomNav/BottomNav.jsx:15`
 
 - [ ] **Step 1: Add lg:hidden to nav**
@@ -99,6 +101,7 @@ git commit -m "feat: hide BottomNav at lg: breakpoint (#167)"
 ### Task 3: Header — add page navigation links at lg:
 
 **Files:**
+
 - Modify: `src/components/layout/Navigation/Navigation.jsx`
 - Modify: `src/components/layout/BottomNav/BottomNav.css` (reuse `live-blink` keyframes)
 
@@ -305,6 +308,7 @@ git commit -m "feat: add header page navigation links at lg: (#167)"
 ### Task 4: Alerts — horizontal scroll at md:
 
 **Files:**
+
 - Modify: `src/components/h1/Alerts/Alerts.css:1-5`
 
 - [ ] **Step 1: Add md: horizontal scroll**
@@ -347,6 +351,7 @@ git commit -m "feat: alerts horizontal scroll at md: (#167)"
 ### Task 5: StatGrid — 4 columns at md:
 
 **Files:**
+
 - Modify: `src/components/h1/StatGrid/StatGrid.css:1-5`
 
 - [ ] **Step 1: Add md: 4-column grid**
@@ -386,6 +391,7 @@ git commit -m "feat: StatGrid 4 columns at md: (#167)"
 ### Task 6: Galaxy Map — max-width at md:
 
 **Files:**
+
 - Modify: `src/components/h1/Galaxy/Galaxy.jsx:10-13`
 
 - [ ] **Step 1: Add md: max-width and lg: reset**
@@ -418,6 +424,7 @@ git commit -m "feat: Galaxy map max-width at md:, reset at lg: (#167)"
 This is the largest task. At lg:, the dashboard switches from single column to map+sidebar.
 
 **Files:**
+
 - Modify: `src/components/h1/Dashboard/DashboardClient.jsx`
 - Modify: `src/components/h1/Dashboard/DashboardClient.css`
 - Modify: `src/components/h1/StatGrid/StatGrid.css`
@@ -480,102 +487,106 @@ Update `src/components/h1/Dashboard/DashboardClient.jsx` to wrap map and sidebar
 Replace the return statement (keep all the logic above unchanged):
 
 ```jsx
-    return (
-        <div className="gutters flex flex-col gap-4 pb-4">
-            <h1 className="sr-only">Live Campaign</h1>
-            <Alerts data={data} />
-            {timeAgo && (
-                <p
-                    className="font-mono text-xs"
-                    style={{ color: 'var(--color-text-muted)' }}
-                    suppressHydrationWarning
-                >
-                    {timeAgo}
-                </p>
-            )}
-            <div className="dashboard-main">
-                <div className="dashboard-map">
-                    <Galaxy mapState={mapState} />
-                </div>
-                <div className="dashboard-sidebar">
-                    <ul className="sector-grid list-none p-0">
-                        {factionIndices.map((index) => {
-                            const campaignData = data.live?.find((l) => l.enemy === index);
-                            const frontier = computeFrontier(campaignData, mapState[index]);
-                            if (!frontier) return null;
-
-                            const isDefending = frontier.event === 'active';
-                            const label = isDefending ? 'DEFENDING' : 'CAPTURING';
-                            const activeEvent =
-                                isDefending ?
-                                    events?.find(
-                                        (e) =>
-                                            e.enemy === index &&
-                                            e.type === 'defend' &&
-                                            e.status === 'active',
-                                    )
-                                :   null;
-
-                            return (
-                                <li key={`frontier-${index}`}>
-                                    <EventCard
-                                        label={label}
-                                        region={frontier.region}
-                                        percent={frontier.percent}
-                                        points={frontier.points}
-                                        pointsMax={frontier.pointsMax}
-                                        factionIndex={index}
-                                        pace={activeEvent ? evaluateProgress(activeEvent) : null}
-                                    />
-                                </li>
-                            );
-                        })}
-                        {factionIndices.map((index) => {
-                            const homeworld = mapState[index]?.[11];
-                            if (homeworld?.event !== 'active') return null;
-                            const attackEvent = events?.find(
-                                (e) =>
-                                    e.enemy === index &&
-                                    e.type === 'attack' &&
-                                    e.status === 'active',
-                            );
-
-                            return (
-                                <li key={`attack-${index}`}>
-                                    <EventCard
-                                        label="ATTACKING"
-                                        region={homeworld.region}
-                                        percent={homeworld.percent}
-                                        points={homeworld.points}
-                                        pointsMax={homeworld.points_max}
-                                        factionIndex={index}
-                                        pace={attackEvent ? evaluateProgress(attackEvent) : null}
-                                    />
-                                </li>
-                            );
-                        })}
-                    </ul>
-                    <section className="flex flex-col gap-2">
-                        <h2>Stats</h2>
-                        <FactionTabs active={faction} onChange={setFaction} />
-                        <StatGrid live={data.live} faction={faction} />
-                    </section>
-                </div>
+return (
+    <div className="gutters flex flex-col gap-4 pb-4">
+        <h1 className="sr-only">Live Campaign</h1>
+        <Alerts data={data} />
+        {timeAgo && (
+            <p
+                className="font-mono text-xs"
+                style={{ color: 'var(--color-text-muted)' }}
+                suppressHydrationWarning
+            >
+                {timeAgo}
+            </p>
+        )}
+        <div className="dashboard-main">
+            <div className="dashboard-map">
+                <Galaxy mapState={mapState} />
             </div>
-            {events?.length > 0 && (
-                <section className="flex flex-col gap-2">
-                    <h2>Event Timeline</h2>
-                    <ul className="flex list-none flex-col gap-2 p-0">
-                        {events.map((event) => (
-                            <li key={event.event_id}>
-                                <Event event={event} />
+            <div className="dashboard-sidebar">
+                <ul className="sector-grid list-none p-0">
+                    {factionIndices.map((index) => {
+                        const campaignData = data.live?.find((l) => l.enemy === index);
+                        const frontier = computeFrontier(campaignData, mapState[index]);
+                        if (!frontier) return null;
+
+                        const isDefending = frontier.event === 'active';
+                        const label = isDefending ? 'DEFENDING' : 'CAPTURING';
+                        const activeEvent =
+                            isDefending ?
+                                events?.find(
+                                    (e) =>
+                                        e.enemy === index &&
+                                        e.type === 'defend' &&
+                                        e.status === 'active',
+                                )
+                            :   null;
+
+                        return (
+                            <li key={`frontier-${index}`}>
+                                <EventCard
+                                    label={label}
+                                    region={frontier.region}
+                                    percent={frontier.percent}
+                                    points={frontier.points}
+                                    pointsMax={frontier.pointsMax}
+                                    factionIndex={index}
+                                    pace={
+                                        activeEvent ? evaluateProgress(activeEvent) : null
+                                    }
+                                />
                             </li>
-                        ))}
-                    </ul>
+                        );
+                    })}
+                    {factionIndices.map((index) => {
+                        const homeworld = mapState[index]?.[11];
+                        if (homeworld?.event !== 'active') return null;
+                        const attackEvent = events?.find(
+                            (e) =>
+                                e.enemy === index &&
+                                e.type === 'attack' &&
+                                e.status === 'active',
+                        );
+
+                        return (
+                            <li key={`attack-${index}`}>
+                                <EventCard
+                                    label="ATTACKING"
+                                    region={homeworld.region}
+                                    percent={homeworld.percent}
+                                    points={homeworld.points}
+                                    pointsMax={homeworld.points_max}
+                                    factionIndex={index}
+                                    pace={
+                                        attackEvent ? evaluateProgress(attackEvent) : null
+                                    }
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+                <section className="flex flex-col gap-2">
+                    <h2>Stats</h2>
+                    <FactionTabs active={faction} onChange={setFaction} />
+                    <StatGrid live={data.live} faction={faction} />
                 </section>
-            )}
+            </div>
         </div>
-    );
+        {events?.length > 0 && (
+            <section className="flex flex-col gap-2">
+                <h2>Event Timeline</h2>
+                <ul className="flex list-none flex-col gap-2 p-0">
+                    {events.map((event) => (
+                        <li key={event.event_id}>
+                            <Event event={event} />
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        )}
+    </div>
+);
 ```
 
 - [ ] **Step 4: Verify build**

--- a/src/__tests__/unit/components/computeFrontier.test.mjs
+++ b/src/__tests__/unit/components/computeFrontier.test.mjs
@@ -1,0 +1,98 @@
+import { computeFrontier } from '@/components/h1/Galaxy/EventCard';
+
+describe('computeFrontier', () => {
+    const makeCampaign = (points, pointsMax, status = 'active') => ({
+        points,
+        points_max: pointsMax,
+        status,
+        enemy: 0,
+    });
+
+    const makeFactionMap = (overrides = {}) => {
+        const map = {};
+        for (let i = 1; i <= 10; i++) {
+            map[i] = { region: `Region ${i}`, event: 'idle', ...overrides[i] };
+        }
+        return map;
+    };
+
+    test('returns null when campaignData is null', () => {
+        expect(computeFrontier(null, makeFactionMap())).toBeNull();
+    });
+
+    test('returns null when campaignData is undefined', () => {
+        expect(computeFrontier(undefined, makeFactionMap())).toBeNull();
+    });
+
+    test('returns null when factionMap is null', () => {
+        expect(computeFrontier(makeCampaign(50000, 100000), null)).toBeNull();
+    });
+
+    test('returns null when status is not active', () => {
+        expect(
+            computeFrontier(makeCampaign(50000, 100000, 'defeated'), makeFactionMap()),
+        ).toBeNull();
+    });
+
+    test('50k/100k points returns sector 6 frontier with correct percent', () => {
+        const result = computeFrontier(makeCampaign(50000, 100000), makeFactionMap());
+        expect(result.sector).toBe(6);
+        expect(result.percent).toBe(0); // exactly at boundary
+        expect(result.region).toBe('Region 6');
+    });
+
+    test('zero points returns sector 1 frontier', () => {
+        const result = computeFrontier(makeCampaign(0, 100000), makeFactionMap());
+        expect(result.sector).toBe(1);
+        expect(result.percent).toBe(0);
+    });
+
+    test('all sectors captured returns null', () => {
+        expect(
+            computeFrontier(makeCampaign(100000, 100000), makeFactionMap()),
+        ).toBeNull();
+    });
+
+    test('points exceeding max returns null', () => {
+        expect(
+            computeFrontier(makeCampaign(120000, 100000), makeFactionMap()),
+        ).toBeNull();
+    });
+
+    test('points_max of 0 defaults to 1 avoiding division by zero', () => {
+        const result = computeFrontier(makeCampaign(0, 0), makeFactionMap());
+        // points_max becomes 1, points=0, frontier=1
+        expect(result).not.toBeNull();
+        expect(result.sector).toBe(1);
+    });
+
+    test('returns region from factionMap sector data', () => {
+        const factionMap = makeFactionMap({ 3: { region: 'Kepler Prime' } });
+        const result = computeFrontier(makeCampaign(20000, 100000), factionMap);
+        // 20k/100k = 2 sectors earned, frontier = 3
+        expect(result.sector).toBe(3);
+        expect(result.region).toBe('Kepler Prime');
+    });
+
+    test('falls back to Sector N when no region in factionMap', () => {
+        const factionMap = makeFactionMap();
+        delete factionMap[3].region;
+        const result = computeFrontier(makeCampaign(20000, 100000), factionMap);
+        expect(result.region).toBe('Sector 3');
+    });
+
+    test('returns event status from factionMap sector data', () => {
+        const factionMap = makeFactionMap({ 6: { event: 'active' } });
+        const result = computeFrontier(makeCampaign(50000, 100000), factionMap);
+        expect(result.event).toBe('active');
+    });
+
+    test('partial progress within a sector computes correct percent', () => {
+        // 55000/100000: 5.5 sectors earned, frontier = 6, 50% into sector
+        const result = computeFrontier(makeCampaign(55000, 100000), makeFactionMap());
+        expect(result.sector).toBe(6);
+        expect(result.percent).toBe(50);
+        expect(result.points).toBe(5000);
+        expect(result.pointsMax).toBe(10000);
+    });
+});

--- a/src/__tests__/unit/components/warTimeline.test.mjs
+++ b/src/__tests__/unit/components/warTimeline.test.mjs
@@ -1,0 +1,242 @@
+import {
+    buildTimeline,
+    computeMomentMapState,
+} from '@/components/h1/WarTimeline/WarTimeline';
+
+// ─── buildTimeline ──────────────────────────────────────────
+
+describe('buildTimeline', () => {
+    test('empty data returns empty array', () => {
+        expect(buildTimeline({})).toEqual([]);
+    });
+
+    test('snapshots only produces snapshot moments sorted by time', () => {
+        const data = {
+            snapshots: [
+                { time: 300, data: '[]' },
+                { time: 100, data: '[]' },
+                { time: 200, data: '[]' },
+            ],
+        };
+        const moments = buildTimeline(data);
+        expect(moments).toHaveLength(3);
+        expect(moments.every((m) => m.kind === 'snapshot')).toBe(true);
+        expect(moments.map((m) => m.time)).toEqual([100, 200, 300]);
+    });
+
+    test('resolved events produce start and end moments', () => {
+        const data = {
+            events: [
+                {
+                    start_time: 100,
+                    end_time: 200,
+                    status: 'success',
+                    enemy: 0,
+                    type: 'defend',
+                },
+            ],
+        };
+        const moments = buildTimeline(data);
+        expect(moments).toHaveLength(2);
+        expect(moments[0].kind).toBe('event_start');
+        expect(moments[1].kind).toBe('event_end');
+    });
+
+    test('active events produce start moment only', () => {
+        const data = {
+            events: [
+                {
+                    start_time: 100,
+                    end_time: 100,
+                    status: 'active',
+                    enemy: 0,
+                    type: 'defend',
+                },
+            ],
+        };
+        const moments = buildTimeline(data);
+        expect(moments).toHaveLength(1);
+        expect(moments[0].kind).toBe('event_start');
+    });
+
+    test('events with same start and end time do not produce end moment', () => {
+        const data = {
+            events: [
+                {
+                    start_time: 100,
+                    end_time: 100,
+                    status: 'fail',
+                    enemy: 1,
+                    type: 'defend',
+                },
+            ],
+        };
+        const moments = buildTimeline(data);
+        expect(moments).toHaveLength(1);
+        expect(moments[0].kind).toBe('event_start');
+    });
+
+    test('same-time moments sort by kind priority: snapshot < event_start < event_end', () => {
+        const data = {
+            snapshots: [{ time: 100, data: '[]' }],
+            events: [
+                {
+                    start_time: 100,
+                    end_time: 200,
+                    status: 'success',
+                    enemy: 0,
+                    type: 'defend',
+                },
+                {
+                    start_time: 50,
+                    end_time: 100,
+                    status: 'fail',
+                    enemy: 1,
+                    type: 'attack',
+                },
+            ],
+        };
+        const moments = buildTimeline(data);
+        // At time 100: snapshot, event_start (defend), event_end (attack)
+        const atTime100 = moments.filter((m) => m.time === 100);
+        expect(atTime100.map((m) => m.kind)).toEqual([
+            'snapshot',
+            'event_start',
+            'event_end',
+        ]);
+    });
+});
+
+// ─── computeMomentMapState ──────────────────────────────────
+
+describe('computeMomentMapState', () => {
+    test('no snapshots returns hidden state for all factions', () => {
+        const moment = { time: 100 };
+        const data = { snapshots: [], events: [] };
+        const result = computeMomentMapState(moment, data);
+        // All three factions should have sector 1 with status 'lost' (hidden input → lost output)
+        expect(result).toBeDefined();
+        expect(result[0]).toBeDefined();
+        expect(result[1]).toBeDefined();
+        expect(result[2]).toBeDefined();
+    });
+
+    test('finds nearest snapshot at or before moment time', () => {
+        const moment = { time: 250 };
+        const data = {
+            snapshots: [
+                {
+                    time: 100,
+                    data: [
+                        { enemy: 0, points: 10000, points_max: 100000, status: 'active' },
+                        { enemy: 1, points: 20000, points_max: 100000, status: 'active' },
+                        { enemy: 2, points: 30000, points_max: 100000, status: 'active' },
+                    ],
+                },
+                {
+                    time: 200,
+                    data: [
+                        { enemy: 0, points: 50000, points_max: 100000, status: 'active' },
+                        { enemy: 1, points: 60000, points_max: 100000, status: 'active' },
+                        { enemy: 2, points: 70000, points_max: 100000, status: 'active' },
+                    ],
+                },
+                {
+                    time: 300,
+                    data: [
+                        { enemy: 0, points: 90000, points_max: 100000, status: 'active' },
+                        { enemy: 1, points: 90000, points_max: 100000, status: 'active' },
+                        { enemy: 2, points: 90000, points_max: 100000, status: 'active' },
+                    ],
+                },
+            ],
+            events: [],
+            points_max: { points: [100000, 100000, 100000] },
+        };
+        const result = computeMomentMapState(moment, data);
+        // Should use the time=200 snapshot (50k points for bugs = 5 sectors)
+        expect(result[0][5].status).toBe('captured');
+        expect(result[0][6].status).toBe('in_progress');
+    });
+
+    test('parses both string JSON and object snapshot data', () => {
+        const makeFactions = (pts) => [
+            { enemy: 0, points: pts, points_max: 100000, status: 'active' },
+            { enemy: 1, points: pts, points_max: 100000, status: 'active' },
+            { enemy: 2, points: pts, points_max: 100000, status: 'active' },
+        ];
+        const base = { events: [], points_max: { points: [100000, 100000, 100000] } };
+
+        // String JSON
+        const strResult = computeMomentMapState(
+            { time: 100 },
+            {
+                ...base,
+                snapshots: [{ time: 100, data: JSON.stringify(makeFactions(30000)) }],
+            },
+        );
+        expect(strResult[0][3].status).toBe('captured');
+        expect(strResult[0][4].status).toBe('in_progress');
+
+        // Pre-parsed object
+        const objResult = computeMomentMapState(
+            { time: 100 },
+            {
+                ...base,
+                snapshots: [{ time: 100, data: makeFactions(30000) }],
+            },
+        );
+        expect(objResult[0][3].status).toBe('captured');
+        expect(objResult[0][4].status).toBe('in_progress');
+    });
+
+    test('filters active and completed events at moment time', () => {
+        const moment = { time: 150 };
+        const data = {
+            snapshots: [
+                {
+                    time: 100,
+                    data: [
+                        { enemy: 0, points: 50000, points_max: 100000, status: 'active' },
+                        { enemy: 1, points: 50000, points_max: 100000, status: 'active' },
+                        { enemy: 2, points: 50000, points_max: 100000, status: 'active' },
+                    ],
+                },
+            ],
+            events: [
+                {
+                    type: 'defend',
+                    enemy: 0,
+                    region: 5,
+                    start_time: 120,
+                    end_time: 200,
+                    status: 'active',
+                },
+                {
+                    type: 'defend',
+                    enemy: 1,
+                    region: 3,
+                    start_time: 80,
+                    end_time: 140,
+                    status: 'fail',
+                },
+                {
+                    type: 'defend',
+                    enemy: 2,
+                    region: 4,
+                    start_time: 300,
+                    end_time: 400,
+                    status: 'active',
+                },
+            ],
+            points_max: { points: [100000, 100000, 100000] },
+        };
+        const result = computeMomentMapState(moment, data);
+        // Event for faction 0 is active at time 150 (120-200)
+        expect(result[0][5].event).toBe('active');
+        // Event for faction 1 ended at 140, completed with fail → sectors lost
+        expect(result[1][3].status).toBe('lost');
+        // Event for faction 2 hasn't started yet (300) → should not appear
+        expect(result[2][4].event).not.toBe('active');
+    });
+});

--- a/src/__tests__/unit/utils/time.test.mjs
+++ b/src/__tests__/unit/utils/time.test.mjs
@@ -5,7 +5,7 @@ import {
     timeSince,
     elapsedSeasonTime,
     elapsedSeconds,
-    elapsedDateTime,
+    elapsedMilliseconds,
 } from '@/utils/time.mjs';
 
 describe('performanceTime', () => {
@@ -171,10 +171,10 @@ describe('elapsedSeconds', () => {
     });
 });
 
-describe('elapsedDateTime', () => {
+describe('elapsedMilliseconds', () => {
     test('returns milliseconds since past date', () => {
         const fiveSecsAgo = new Date(Date.now() - 5000);
-        const result = elapsedDateTime(fiveSecsAgo);
+        const result = elapsedMilliseconds(fiveSecsAgo);
         expect(result).toBeGreaterThanOrEqual(4900);
         expect(result).toBeLessThanOrEqual(5200);
     });

--- a/src/app/api/h1/campaign/route.js
+++ b/src/app/api/h1/campaign/route.js
@@ -67,13 +67,14 @@ export async function GET(request) {
         }
 
         //2. fetch local data
-        const { data: campaignData2, error: campaignError2 } = await tryCatch(
+        const { data: retriedCampaignData, error: retriedCampaignError } = await tryCatch(
             getCampaign(season),
         );
-        if (campaignError2) return errorResponse(500, start, campaignError2?.message);
+        if (retriedCampaignError)
+            return errorResponse(500, start, retriedCampaignError?.message);
 
         //3. set result to variable
-        data = campaignData2;
+        data = retriedCampaignData;
     }
     //4. return response
     return successResponse(200, start, data);

--- a/src/app/api/h1/update/route.js
+++ b/src/app/api/h1/update/route.js
@@ -41,7 +41,10 @@ export async function GET(request) {
         updated: {
             status: statusData,
             season: seasonData,
-            // wait: wait,
+        },
+        timing: {
+            statusMs: statusTime,
+            seasonMs: seasonTime,
         },
     });
 }

--- a/src/components/h1/Dashboard/DashboardClient.jsx
+++ b/src/components/h1/Dashboard/DashboardClient.jsx
@@ -38,8 +38,13 @@ export default function DashboardClient({ data, mapState }) {
                 <div className="dashboard-sidebar">
                     <ul className="sector-grid list-none p-0">
                         {factionIndices.map((index) => {
-                            const campaignData = data.live?.find((l) => l.enemy === index);
-                            const frontier = computeFrontier(campaignData, mapState[index]);
+                            const campaignData = data.live?.find(
+                                (l) => l.enemy === index,
+                            );
+                            const frontier = computeFrontier(
+                                campaignData,
+                                mapState[index],
+                            );
                             if (!frontier) return null;
 
                             const isDefending = frontier.event === 'active';
@@ -63,7 +68,11 @@ export default function DashboardClient({ data, mapState }) {
                                         points={frontier.points}
                                         pointsMax={frontier.pointsMax}
                                         factionIndex={index}
-                                        pace={activeEvent ? evaluateProgress(activeEvent) : null}
+                                        pace={
+                                            activeEvent ?
+                                                evaluateProgress(activeEvent)
+                                            :   null
+                                        }
                                     />
                                 </li>
                             );
@@ -87,7 +96,11 @@ export default function DashboardClient({ data, mapState }) {
                                         points={homeworld.points}
                                         pointsMax={homeworld.points_max}
                                         factionIndex={index}
-                                        pace={attackEvent ? evaluateProgress(attackEvent) : null}
+                                        pace={
+                                            attackEvent ?
+                                                evaluateProgress(attackEvent)
+                                            :   null
+                                        }
                                     />
                                 </li>
                             );

--- a/src/components/h1/WarTimeline/WarTimeline.jsx
+++ b/src/components/h1/WarTimeline/WarTimeline.jsx
@@ -8,7 +8,7 @@ import factions from '@/enums/factions';
 
 const KIND_PRIORITY = { snapshot: 0, event_start: 1, event_end: 2 };
 
-function formatEventLabel(event, phase) {
+export function formatEventLabel(event, phase) {
     const factionName = factions[event.enemy]?.name ?? `Faction ${event.enemy}`;
     const typeLabel = event.type === 'defend' ? 'Defend' : 'Attack';
 
@@ -20,7 +20,7 @@ function formatEventLabel(event, phase) {
     return `${typeLabel} ${outcome}: ${factionName}`;
 }
 
-function buildTimeline(data) {
+export function buildTimeline(data) {
     const moments = [];
 
     for (const s of data.snapshots ?? []) {
@@ -54,7 +54,7 @@ function buildTimeline(data) {
     return moments;
 }
 
-function computeMomentMapState(moment, data) {
+export function computeMomentMapState(moment, data) {
     const snapshots = data.snapshots ?? [];
 
     const nearest = snapshots
@@ -102,7 +102,7 @@ function computeMomentMapState(moment, data) {
     return computeMapState(factionStates, activeEvents);
 }
 
-function formatTimestamp(unixSeconds) {
+export function formatTimestamp(unixSeconds) {
     return new Date(unixSeconds * 1000).toLocaleString(undefined, {
         year: 'numeric',
         month: 'short',
@@ -180,7 +180,11 @@ export default function WarTimeline({ data, defaultMapState }) {
         if (!container) return;
         const activeCard = container.querySelector('.timeline-card.active');
         if (activeCard) {
-            activeCard.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+            activeCard.scrollIntoView({
+                behavior: 'smooth',
+                inline: 'center',
+                block: 'nearest',
+            });
         }
     }, [activeIndex]);
 

--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -1,12 +1,7 @@
 .footer {
     background: var(--color-surface-1);
     border-top: 2px solid;
-    border-image: linear-gradient(
-            90deg,
-            var(--color-primary) 40%,
-            transparent 40%
-        )
-        1;
+    border-image: linear-gradient(90deg, var(--color-primary) 40%, transparent 40%) 1;
     padding-top: var(--space-12);
 }
 

--- a/src/components/layout/Wings/Wings.jsx
+++ b/src/components/layout/Wings/Wings.jsx
@@ -3,9 +3,5 @@ import './Wings.css';
 export default function Wings({ as = 'h2', children }) {
     const Heading = as;
 
-    return (
-        <Heading className="flex w-full flex-col items-center">
-            {children}
-        </Heading>
-    );
+    return <Heading className="flex w-full flex-col items-center">{children}</Heading>;
 }

--- a/src/utils/evaluateProgress.mjs
+++ b/src/utils/evaluateProgress.mjs
@@ -46,8 +46,8 @@ export function evaluateProgress(event) {
         currentRate,
         requiredRate,
         label:
-            status === 'on_track' ?
-                'On track'
-            :   `${STATUS_LABELS[status]} by ${delta} points`,
+            status === 'on_track' ? 'On track' : (
+                `${STATUS_LABELS[status]} by ${delta} points`
+            ),
     };
 }

--- a/src/utils/getWarOutcome.mjs
+++ b/src/utils/getWarOutcome.mjs
@@ -54,7 +54,9 @@ export function getWarOutcome(data) {
     // Victory signal 3: all 3 enemy homeworlds captured (successful attacks)
     const factionsDefeated = new Set(
         events
-            .filter((e) => e.type === EVENT_TYPE.ATTACK && e.status === EVENT_STATUS.SUCCESS)
+            .filter(
+                (e) => e.type === EVENT_TYPE.ATTACK && e.status === EVENT_STATUS.SUCCESS,
+            )
             .map((e) => e.enemy),
     );
     const allHomeworldsCaptured = factionsDefeated.size === 3;
@@ -66,7 +68,8 @@ export function getWarOutcome(data) {
         .filter((e) => e.type === EVENT_TYPE.DEFEND && e.region === 0)
         .sort((a, b) => a.end_time - b.end_time);
     const defeatSignal =
-        r0Defends.length > 0 && r0Defends[r0Defends.length - 1].status === EVENT_STATUS.FAIL;
+        r0Defends.length > 0 &&
+        r0Defends[r0Defends.length - 1].status === EVENT_STATUS.FAIL;
 
     // Decision
     if (victorySignal && !defeatSignal) {

--- a/src/utils/time.mjs
+++ b/src/utils/time.mjs
@@ -60,7 +60,7 @@ export function elapsedSeconds(past) {
     return Math.floor(elapsed / 1000);
 }
 
-export function elapsedDateTime(past) {
+export function elapsedMilliseconds(past) {
     const now = new Date();
     const elapsed = now - past;
     return elapsed;


### PR DESCRIPTION
## Summary
- Prettier reformatting across 8 files (no logic changes)
- Renamed `elapsedDateTime` → `elapsedMilliseconds` and `campaignData2` → `retriedCampaignData` for clarity
- Exported 4 WarTimeline helper functions for testability
- Added `timing` object to `/api/h1/update` response
- Added component tests for `computeFrontier` and `warTimeline`

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:unit:run` — 245 tests pass (20 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)