### PR TITLE
feat: desktop & wide responsive layout (#168)

### DIFF
--- a/docs/superpowers/specs/2026-03-30-phase-7-desktop-wide-responsive-design.md
+++ b/docs/superpowers/specs/2026-03-30-phase-7-desktop-wide-responsive-design.md
@@ -44,17 +44,17 @@ DOM order is mobile-friendly (map before sidebar). CSS `grid-template-areas` han
 ```css
 /* Mobile (default) */
 grid-template-areas:
-  "alerts"
-  "updated"
-  "map"
-  "sidebar";
+    'alerts'
+    'updated'
+    'map'
+    'sidebar';
 grid-template-columns: 1fr;
 
 /* Desktop (lg:) */
 grid-template-areas:
-  "alerts  alerts"
-  "updated updated"
-  "sidebar map";
+    'alerts  alerts'
+    'updated updated'
+    'sidebar map';
 grid-template-columns: 260px 1fr;
 ```
 
@@ -70,12 +70,12 @@ The sidebar has a fixed height matching the content area and scrolls independent
 
 ## Breakpoint Scaling
 
-| Breakpoint | Width | Sidebar | Layout | Max-Width |
-|---|---|---|---|---|
-| < lg (< 1024px) | — | N/A | Single column, vertical stack (unchanged) | None |
-| lg: (1024px) | 1024px+ | 260px fixed | Two-column: sidebar left, map right | Dynamic cap |
-| xl: (1280px) | 1280px+ | 300px fixed | Same, sidebar wider | Dynamic cap |
-| 3xl: (1920px) | 1920px+ | 360px fixed | Same, sidebar wider | Dynamic cap |
+| Breakpoint      | Width   | Sidebar     | Layout                                    | Max-Width   |
+| --------------- | ------- | ----------- | ----------------------------------------- | ----------- |
+| < lg (< 1024px) | —       | N/A         | Single column, vertical stack (unchanged) | None        |
+| lg: (1024px)    | 1024px+ | 260px fixed | Two-column: sidebar left, map right       | Dynamic cap |
+| xl: (1280px)    | 1280px+ | 300px fixed | Same, sidebar wider                       | Dynamic cap |
+| 3xl: (1920px)   | 1920px+ | 360px fixed | Same, sidebar wider                       | Dynamic cap |
 
 ### Mobile / Tablet (Unchanged)
 

--- a/docs/superpowers/specs/2026-03-30-phase-7-desktop-wide-responsive-design.md
+++ b/docs/superpowers/specs/2026-03-30-phase-7-desktop-wide-responsive-design.md
@@ -1,0 +1,148 @@
+# Phase 7: Desktop & Wide Responsive Layout
+
+**Issue:** #168
+**Date:** 2026-03-30
+**Status:** Design approved
+
+## Summary
+
+Progressive enhancement from the tablet layout (lg: 1024px) to desktop, wide, and ultrawide breakpoints. The dashboard becomes a two-column layout with a scrollable sidebar on the left and a pinned galaxy map on the right, fitting all content in a single viewport without page-level scrolling.
+
+## DOM Structure
+
+Flat grid-based layout. The root container is the grid — no intermediate `.dashboard-main` wrapper.
+
+```
+<div class="dashboard">        ← CSS Grid container
+  <Alerts />                   ← grid-area: alerts
+  <p>Updated</p>               ← grid-area: updated
+  <div class="dashboard-map">  ← grid-area: map (DOM order: before sidebar for mobile)
+    <Galaxy />
+  </div>
+  <div class="dashboard-sidebar"> ← grid-area: sidebar (scrollable container)
+    Campaigns (EventCards)
+    Stats (FactionTabs + StatGrid)
+    Event Timeline (moved here from outside)
+  </div>
+</div>
+```
+
+DOM order is mobile-friendly (map before sidebar). CSS `grid-template-areas` handles visual reordering at desktop — no `order` or `row-reverse` needed.
+
+## Layout Structure (lg: 1024px+)
+
+### Two-Column: Sidebar Left + Pinned Map Right
+
+- **Sidebar (left):** Fixed width per breakpoint, independently scrollable (`overflow-y: auto`), contains campaigns, stats, and timeline.
+- **Map (right):** Fills remaining width, position sticky so it stays pinned in the viewport while the sidebar scrolls. Map is vertically centered within its column.
+- **Alerts + timestamp:** Span full width above the two-column area.
+- **Inset padding:** Everything sits inside the existing `.gutters` spacing — not edge-to-edge. This provides breathing room between the header, content, and viewport edges.
+- **Content height:** `calc(100dvh - var(--header-height) - vertical-padding)` where `--header-height` is 80px at lg:+ and vertical padding matches gutter spacing.
+
+### Grid Template Areas
+
+```css
+/* Mobile (default) */
+grid-template-areas:
+  "alerts"
+  "updated"
+  "map"
+  "sidebar";
+grid-template-columns: 1fr;
+
+/* Desktop (lg:) */
+grid-template-areas:
+  "alerts  alerts"
+  "updated updated"
+  "sidebar map";
+grid-template-columns: 260px 1fr;
+```
+
+### Sidebar Content Order
+
+1. Campaigns (EventCards — faction frontline status)
+2. Stats (FactionTabs + StatGrid)
+3. Event Timeline (moved from below the dashboard into the sidebar)
+
+### Sidebar Scrolling
+
+The sidebar has a fixed height matching the content area and scrolls independently with `overflow-y: auto`. Scrollbar styling should be minimal (thin, muted) to match the dark theme. The map remains pinned regardless of sidebar scroll position.
+
+## Breakpoint Scaling
+
+| Breakpoint | Width | Sidebar | Layout | Max-Width |
+|---|---|---|---|---|
+| < lg (< 1024px) | — | N/A | Single column, vertical stack (unchanged) | None |
+| lg: (1024px) | 1024px+ | 260px fixed | Two-column: sidebar left, map right | Dynamic cap |
+| xl: (1280px) | 1280px+ | 300px fixed | Same, sidebar wider | Dynamic cap |
+| 3xl: (1920px) | 1920px+ | 360px fixed | Same, sidebar wider | Dynamic cap |
+
+### Mobile / Tablet (Unchanged)
+
+Below lg:, the layout remains a single vertical column: map on top (centered, max-width 480px at md:), data below. No changes to mobile or tablet breakpoints.
+
+### Sidebar Order Consistency
+
+The sidebar always appears on the left when the two-column layout is active. There is no breakpoint where it flips to the right. Below lg:, the two-column layout doesn't exist — it's a single column.
+
+## Dynamic Max-Width Cap
+
+The galaxy map is a circle whose diameter is constrained by the available viewport height. Once the map column reaches the height limit, making the container wider adds no value — the map can't grow beyond its vertical constraint.
+
+The dashboard container's `max-width` is calculated dynamically:
+
+```
+max-width: calc(100dvh - var(--header-height) - var(--vertical-padding) + var(--sidebar-width) + var(--horizontal-gaps))
+```
+
+This ensures the container stops growing exactly when the map can't benefit from more width. The container is horizontally centered (`margin: 0 auto`) so ultrawide monitors see the dashboard centered with space on both sides.
+
+### Variables
+
+- `--header-height`: 80px (header is always 80px at sm:+, and lg: implies sm:+)
+- `--vertical-padding`: total top + bottom gutter padding, scales with breakpoint
+- `--sidebar-width`: 260px / 300px / 360px depending on breakpoint
+- `--horizontal-gaps`: gap between sidebar and map column
+
+## Files to Modify
+
+### `DashboardClient.css`
+
+- Replace flex layout with CSS Grid using `grid-template-areas`
+- Remove `.dashboard-main` styles, add `.dashboard` grid styles
+- Mobile: single-column grid (alerts → updated → map → sidebar)
+- lg: two-column grid with `grid-template-areas: "alerts alerts" "updated updated" "sidebar map"`
+- Sidebar: fixed width, `overflow-y: auto`, height calc
+- Map column: `position: sticky`, `top` offset, vertically centered
+- Dynamic `max-width` on `.dashboard`, centered with `margin: 0 auto`
+- xl: and 3xl: media queries for sidebar width scaling
+- Sector grid: single column inside sidebar (already the case at lg:)
+
+### `DashboardClient.jsx`
+
+- Remove `.dashboard-main` wrapper div — make all sections direct children of root `.dashboard` grid
+- Assign grid-area class names or data attributes to: Alerts, timestamp, map, sidebar
+- Move Event Timeline into `.dashboard-sidebar`
+- DOM order: Alerts → timestamp → map → sidebar (mobile-friendly)
+- No changes to component props or data flow
+
+### No Changes To
+
+- Mobile/tablet layout behavior (below lg:) — grid just stacks single-column
+- Individual components: EventCard, StatGrid, FactionTabs, Alerts, Galaxy, Event, WarTimeline
+- Header, Footer, BottomNav, HeaderNav
+- tokens.css, layout.css (no new design tokens needed)
+
+## Deferred
+
+- **Alert hover → map highlight:** Hovering an alert card highlights the related sector on the map. Split to a separate issue in the polish phase — not part of this layout work.
+
+## Design Decisions
+
+1. **Sidebar left, not right:** Follows natural LTR reading flow — scan data first, then look at the visualization. Also consistent with common dashboard patterns (navigation/data panels on the left).
+2. **Inset with padding, not edge-to-edge:** Edge-to-edge feels unfinished. The gutter padding gives the layout breathing room and consistency with the rest of the site.
+3. **Dynamic max-width over static:** A static cap (e.g. 2560px) would waste space on some monitors and be too wide on others. The dynamic calc ties the width directly to the map's height constraint, which is the actual limiting factor.
+4. **Timeline in sidebar:** Fits the "no vertical scrolling" goal. The timeline is part of the data panel, not a separate full-width section. The sidebar scrolls to accommodate it.
+5. **Sticky map, not fixed:** `position: sticky` keeps the map in the document flow while pinning it visually. Simpler than `position: fixed` which requires manual offset management.
+6. **CSS Grid over Flexbox:** Grid with `grid-template-areas` makes the layout explicit and readable. No `order` or `row-reverse` hacks — grid areas handle sidebar-left/map-right placement directly regardless of DOM order.
+7. **Flat DOM:** Removed the `.dashboard-main` wrapper. All sections are direct grid children. The only nesting is the sidebar container, which is justified — it's a scrollable unit, not a layout wrapper.

--- a/src/app/page.css
+++ b/src/app/page.css
@@ -17,3 +17,14 @@ main > * {
     position: relative;
     z-index: 1;
 }
+
+/* At desktop, shrink main and hide footer — dashboard fills viewport, no page scroll */
+@media (min-width: 1024px) {
+    main {
+        min-height: auto;
+    }
+
+    footer {
+        display: none;
+    }
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -43,7 +43,7 @@ export default async function HomePage() {
 
     return (
         <>
-            <div className="gutters pt-4 pb-2">
+            <div className="gutters pt-4 pb-2 lg:hidden">
                 <h1 className="font-[family-name:var(--font-display)] text-sm text-[var(--color-primary)]">
                     Track Managed Democracy Across the Galaxy
                 </h1>

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -61,6 +61,7 @@
         max-width: calc(100dvh - 80px - 2rem + 260px + 1rem);
         margin-left: auto;
         margin-right: auto;
+        padding-inline: 1.5rem;
         height: calc(100dvh - 80px);
     }
 

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -1,3 +1,38 @@
+/* === Dashboard Grid Layout === */
+
+.dashboard {
+    display: grid;
+    grid-template-areas:
+        "alerts"
+        "updated"
+        "map"
+        "sidebar";
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding-bottom: 1rem;
+}
+
+.dashboard-alerts {
+    grid-area: alerts;
+}
+
+.dashboard-updated {
+    grid-area: updated;
+}
+
+.dashboard-map {
+    grid-area: map;
+}
+
+.dashboard-sidebar {
+    grid-area: sidebar;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* === Sector Grid (campaign cards) === */
+
 .sector-grid {
     display: grid;
     grid-template-columns: 1fr;
@@ -11,33 +46,74 @@
     }
 }
 
-@media (min-width: 768px) {
-    .dashboard-map {
-        max-width: 480px;
-        margin: 0 auto;
-    }
-}
+/* === Desktop: two-column grid (lg: 1024px) === */
 
 @media (min-width: 1024px) {
+    .dashboard {
+        grid-template-areas:
+            "alerts  alerts"
+            "updated updated"
+            "sidebar map";
+        grid-template-columns: 260px minmax(0, 1fr);
+        grid-template-rows: auto auto minmax(0, 1fr);
+        width: 100%;
+        max-width: calc(100dvh - 80px - 3rem + 260px + 1rem);
+        margin-left: auto;
+        margin-right: auto;
+        height: calc(100dvh - 80px);
+        padding-bottom: 0;
+    }
+
     .dashboard-map {
+        position: sticky;
+        top: calc(80px + 1.5rem);
+        align-self: start;
         max-width: none;
+        max-height: 100%;
+        min-height: 0;
+        overflow: hidden;
         margin: 0;
     }
-    .dashboard-main {
-        display: flex;
-        gap: 1rem;
-    }
-    .dashboard-map {
-        flex: 1;
-        min-width: 0;
-    }
+
     .dashboard-sidebar {
-        flex: 0 0 260px;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
+        overflow-y: auto;
+        min-height: 0;
     }
+
     .sector-grid {
         grid-template-columns: 1fr;
     }
+}
+
+/* === Wide desktop: wider sidebar (xl: 1280px) === */
+
+@media (min-width: 1280px) {
+    .dashboard {
+        grid-template-columns: 300px minmax(0, 1fr);
+        max-width: calc(100dvh - 80px - 3rem + 300px + 1rem);
+    }
+}
+
+/* === Ultrawide: widest sidebar (3xl: 1920px) === */
+
+@media (min-width: 1920px) {
+    .dashboard {
+        grid-template-columns: 360px minmax(0, 1fr);
+        max-width: calc(100dvh - 80px - 3rem + 360px + 1rem);
+    }
+}
+
+/* === Sidebar scrollbar === */
+
+.dashboard-sidebar::-webkit-scrollbar {
+    width: 4px;
+}
+
+.dashboard-sidebar::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.dashboard-sidebar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
 }

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -3,10 +3,10 @@
 .dashboard {
     display: grid;
     grid-template-areas:
-        "alerts"
-        "updated"
-        "map"
-        "sidebar";
+        'alerts'
+        'updated'
+        'map'
+        'sidebar';
     grid-template-columns: 1fr;
     gap: 1rem;
     padding-top: 1rem;
@@ -52,9 +52,9 @@
 @media (min-width: 1024px) {
     .dashboard {
         grid-template-areas:
-            "alerts  alerts"
-            "updated updated"
-            "sidebar map";
+            'alerts  alerts'
+            'updated updated'
+            'sidebar map';
         grid-template-columns: 260px minmax(0, 1fr);
         grid-template-rows: auto auto minmax(0, 1fr);
         width: 100%;

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -9,6 +9,7 @@
         "sidebar";
     grid-template-columns: 1fr;
     gap: 1rem;
+    padding-top: 1rem;
     padding-bottom: 1rem;
 }
 
@@ -57,11 +58,10 @@
         grid-template-columns: 260px minmax(0, 1fr);
         grid-template-rows: auto auto minmax(0, 1fr);
         width: 100%;
-        max-width: calc(100dvh - 80px - 3rem + 260px + 1rem);
+        max-width: calc(100dvh - 80px - 2rem + 260px + 1rem);
         margin-left: auto;
         margin-right: auto;
         height: calc(100dvh - 80px);
-        padding-bottom: 0;
     }
 
     .dashboard-map {
@@ -90,7 +90,7 @@
 @media (min-width: 1280px) {
     .dashboard {
         grid-template-columns: 300px minmax(0, 1fr);
-        max-width: calc(100dvh - 80px - 3rem + 300px + 1rem);
+        max-width: calc(100dvh - 80px - 2rem + 300px + 1rem);
     }
 }
 
@@ -99,7 +99,7 @@
 @media (min-width: 1920px) {
     .dashboard {
         grid-template-columns: 360px minmax(0, 1fr);
-        max-width: calc(100dvh - 80px - 3rem + 360px + 1rem);
+        max-width: calc(100dvh - 80px - 2rem + 360px + 1rem);
     }
 }
 

--- a/src/components/h1/Dashboard/DashboardClient.jsx
+++ b/src/components/h1/Dashboard/DashboardClient.jsx
@@ -19,112 +19,112 @@ export default function DashboardClient({ data, mapState }) {
     const timeAgo = formatTimeAgo(data.last_updated);
 
     return (
-        <div className="gutters flex flex-col gap-4 pb-4">
+        <div className="dashboard gutters">
             <h1 className="sr-only">Live Campaign</h1>
-            <Alerts data={data} />
+            <div className="dashboard-alerts">
+                <Alerts data={data} />
+            </div>
             {timeAgo && (
                 <p
-                    className="font-mono text-xs"
+                    className="dashboard-updated font-mono text-xs"
                     style={{ color: 'var(--color-text-muted)' }}
                     suppressHydrationWarning
                 >
                     {timeAgo}
                 </p>
             )}
-            <div className="dashboard-main">
-                <div className="dashboard-map">
-                    <Galaxy mapState={mapState} />
-                </div>
-                <div className="dashboard-sidebar">
-                    <ul className="sector-grid list-none p-0">
-                        {factionIndices.map((index) => {
-                            const campaignData = data.live?.find(
-                                (l) => l.enemy === index,
-                            );
-                            const frontier = computeFrontier(
-                                campaignData,
-                                mapState[index],
-                            );
-                            if (!frontier) return null;
-
-                            const isDefending = frontier.event === 'active';
-                            const label = isDefending ? 'DEFENDING' : 'CAPTURING';
-                            const activeEvent =
-                                isDefending ?
-                                    events?.find(
-                                        (e) =>
-                                            e.enemy === index &&
-                                            e.type === 'defend' &&
-                                            e.status === 'active',
-                                    )
-                                :   null;
-
-                            return (
-                                <li key={`frontier-${index}`}>
-                                    <EventCard
-                                        label={label}
-                                        region={frontier.region}
-                                        percent={frontier.percent}
-                                        points={frontier.points}
-                                        pointsMax={frontier.pointsMax}
-                                        factionIndex={index}
-                                        pace={
-                                            activeEvent ?
-                                                evaluateProgress(activeEvent)
-                                            :   null
-                                        }
-                                    />
-                                </li>
-                            );
-                        })}
-                        {factionIndices.map((index) => {
-                            const homeworld = mapState[index]?.[11];
-                            if (homeworld?.event !== 'active') return null;
-                            const attackEvent = events?.find(
-                                (e) =>
-                                    e.enemy === index &&
-                                    e.type === 'attack' &&
-                                    e.status === 'active',
-                            );
-
-                            return (
-                                <li key={`attack-${index}`}>
-                                    <EventCard
-                                        label="ATTACKING"
-                                        region={homeworld.region}
-                                        percent={homeworld.percent}
-                                        points={homeworld.points}
-                                        pointsMax={homeworld.points_max}
-                                        factionIndex={index}
-                                        pace={
-                                            attackEvent ?
-                                                evaluateProgress(attackEvent)
-                                            :   null
-                                        }
-                                    />
-                                </li>
-                            );
-                        })}
-                    </ul>
-                    <section className="flex flex-col gap-2">
-                        <h2>Stats</h2>
-                        <FactionTabs active={faction} onChange={setFaction} />
-                        <StatGrid live={data.live} faction={faction} />
-                    </section>
-                </div>
+            <div className="dashboard-map">
+                <Galaxy mapState={mapState} />
             </div>
-            {events?.length > 0 && (
-                <section className="flex flex-col gap-2">
-                    <h2>Event Timeline</h2>
-                    <ul className="flex list-none flex-col gap-2 p-0">
-                        {events.map((event) => (
-                            <li key={event.event_id}>
-                                <Event event={event} />
+            <div className="dashboard-sidebar">
+                <ul className="sector-grid list-none p-0">
+                    {factionIndices.map((index) => {
+                        const campaignData = data.live?.find(
+                            (l) => l.enemy === index,
+                        );
+                        const frontier = computeFrontier(
+                            campaignData,
+                            mapState[index],
+                        );
+                        if (!frontier) return null;
+
+                        const isDefending = frontier.event === 'active';
+                        const label = isDefending ? 'DEFENDING' : 'CAPTURING';
+                        const activeEvent =
+                            isDefending ?
+                                events?.find(
+                                    (e) =>
+                                        e.enemy === index &&
+                                        e.type === 'defend' &&
+                                        e.status === 'active',
+                                )
+                            :   null;
+
+                        return (
+                            <li key={`frontier-${index}`}>
+                                <EventCard
+                                    label={label}
+                                    region={frontier.region}
+                                    percent={frontier.percent}
+                                    points={frontier.points}
+                                    pointsMax={frontier.pointsMax}
+                                    factionIndex={index}
+                                    pace={
+                                        activeEvent ?
+                                            evaluateProgress(activeEvent)
+                                        :   null
+                                    }
+                                />
                             </li>
-                        ))}
-                    </ul>
+                        );
+                    })}
+                    {factionIndices.map((index) => {
+                        const homeworld = mapState[index]?.[11];
+                        if (homeworld?.event !== 'active') return null;
+                        const attackEvent = events?.find(
+                            (e) =>
+                                e.enemy === index &&
+                                e.type === 'attack' &&
+                                e.status === 'active',
+                        );
+
+                        return (
+                            <li key={`attack-${index}`}>
+                                <EventCard
+                                    label="ATTACKING"
+                                    region={homeworld.region}
+                                    percent={homeworld.percent}
+                                    points={homeworld.points}
+                                    pointsMax={homeworld.points_max}
+                                    factionIndex={index}
+                                    pace={
+                                        attackEvent ?
+                                            evaluateProgress(attackEvent)
+                                        :   null
+                                    }
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+                <section className="flex flex-col gap-2">
+                    <h2>Stats</h2>
+                    <FactionTabs active={faction} onChange={setFaction} />
+                    <StatGrid live={data.live} faction={faction} />
                 </section>
-            )}
+                {events?.length > 0 && (
+                    <section className="flex flex-col gap-2">
+                        <h2>Event Timeline</h2>
+                        <ul className="flex list-none flex-col gap-2 p-0">
+                            {events.map((event) => (
+                                <li key={event.event_id}>
+                                    <Event event={event} />
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/components/h1/Dashboard/DashboardClient.jsx
+++ b/src/components/h1/Dashboard/DashboardClient.jsx
@@ -18,6 +18,58 @@ export default function DashboardClient({ data, mapState }) {
     const events = data?.events?.sort((a, b) => b.start_time - a.start_time);
     const timeAgo = formatTimeAgo(data.last_updated);
 
+    function renderFrontierCard(index) {
+        const campaignData = data.live?.find((l) => l.enemy === index);
+        const frontier = computeFrontier(campaignData, mapState[index]);
+        if (!frontier) return null;
+
+        const isDefending = frontier.event === 'active';
+        const label = isDefending ? 'DEFENDING' : 'CAPTURING';
+        const activeEvent =
+            isDefending ?
+                events?.find(
+                    (e) =>
+                        e.enemy === index && e.type === 'defend' && e.status === 'active',
+                )
+            :   null;
+
+        return (
+            <li key={`frontier-${index}`}>
+                <EventCard
+                    label={label}
+                    region={frontier.region}
+                    percent={frontier.percent}
+                    points={frontier.points}
+                    pointsMax={frontier.pointsMax}
+                    factionIndex={index}
+                    pace={activeEvent ? evaluateProgress(activeEvent) : null}
+                />
+            </li>
+        );
+    }
+
+    function renderHomeworldCard(index) {
+        const homeworld = mapState[index]?.[11];
+        if (homeworld?.event !== 'active') return null;
+        const attackEvent = events?.find(
+            (e) => e.enemy === index && e.type === 'attack' && e.status === 'active',
+        );
+
+        return (
+            <li key={`attack-${index}`}>
+                <EventCard
+                    label="ATTACKING"
+                    region={homeworld.region}
+                    percent={homeworld.percent}
+                    points={homeworld.points}
+                    pointsMax={homeworld.points_max}
+                    factionIndex={index}
+                    pace={attackEvent ? evaluateProgress(attackEvent) : null}
+                />
+            </li>
+        );
+    }
+
     return (
         <div className="dashboard gutters">
             <h1 className="sr-only">Live Campaign</h1>
@@ -38,74 +90,8 @@ export default function DashboardClient({ data, mapState }) {
             </div>
             <div className="dashboard-sidebar">
                 <ul className="sector-grid list-none p-0">
-                    {factionIndices.map((index) => {
-                        const campaignData = data.live?.find(
-                            (l) => l.enemy === index,
-                        );
-                        const frontier = computeFrontier(
-                            campaignData,
-                            mapState[index],
-                        );
-                        if (!frontier) return null;
-
-                        const isDefending = frontier.event === 'active';
-                        const label = isDefending ? 'DEFENDING' : 'CAPTURING';
-                        const activeEvent =
-                            isDefending ?
-                                events?.find(
-                                    (e) =>
-                                        e.enemy === index &&
-                                        e.type === 'defend' &&
-                                        e.status === 'active',
-                                )
-                            :   null;
-
-                        return (
-                            <li key={`frontier-${index}`}>
-                                <EventCard
-                                    label={label}
-                                    region={frontier.region}
-                                    percent={frontier.percent}
-                                    points={frontier.points}
-                                    pointsMax={frontier.pointsMax}
-                                    factionIndex={index}
-                                    pace={
-                                        activeEvent ?
-                                            evaluateProgress(activeEvent)
-                                        :   null
-                                    }
-                                />
-                            </li>
-                        );
-                    })}
-                    {factionIndices.map((index) => {
-                        const homeworld = mapState[index]?.[11];
-                        if (homeworld?.event !== 'active') return null;
-                        const attackEvent = events?.find(
-                            (e) =>
-                                e.enemy === index &&
-                                e.type === 'attack' &&
-                                e.status === 'active',
-                        );
-
-                        return (
-                            <li key={`attack-${index}`}>
-                                <EventCard
-                                    label="ATTACKING"
-                                    region={homeworld.region}
-                                    percent={homeworld.percent}
-                                    points={homeworld.points}
-                                    pointsMax={homeworld.points_max}
-                                    factionIndex={index}
-                                    pace={
-                                        attackEvent ?
-                                            evaluateProgress(attackEvent)
-                                        :   null
-                                    }
-                                />
-                            </li>
-                        );
-                    })}
+                    {factionIndices.map(renderFrontierCard)}
+                    {factionIndices.map(renderHomeworldCard)}
                 </ul>
                 <section className="flex flex-col gap-2">
                     <h2>Stats</h2>

--- a/src/components/h1/Galaxy/Galaxy.jsx
+++ b/src/components/h1/Galaxy/Galaxy.jsx
@@ -7,10 +7,7 @@ export default function Galaxy({ mapState }) {
     const svgRef = useRef(null);
 
     return (
-        <section
-            id="galaxy"
-            className="mb-4 flex flex-col items-center gap-4"
-        >
+        <section id="galaxy" className="mb-4 flex flex-col items-center gap-4">
             <Map svgRef={svgRef} map={mapState} />
             <Tooltip svgRef={svgRef} map={mapState} />
         </section>

--- a/src/components/h1/Galaxy/Galaxy.jsx
+++ b/src/components/h1/Galaxy/Galaxy.jsx
@@ -9,7 +9,7 @@ export default function Galaxy({ mapState }) {
     return (
         <section
             id="galaxy"
-            className="mx-4 mb-4 flex flex-grow-[4] flex-col items-center gap-4 sm:mx-0"
+            className="mb-4 flex flex-col items-center gap-4"
         >
             <Map svgRef={svgRef} map={mapState} />
             <Tooltip svgRef={svgRef} map={mapState} />


### PR DESCRIPTION
## Summary

- Flatten dashboard DOM to CSS Grid with `grid-template-areas` — single-column on mobile, two-column (sidebar left, pinned map right) at lg:+
- Dynamic `max-width` tied to viewport height prevents wasted space on ultrawide monitors
- Sidebar scrolls independently with campaigns, stats, and event timeline; map stays pinned
- Breakpoint scaling: 260px sidebar (lg:), 300px (xl:), 360px (3xl:)
- Hero text and footer hidden at desktop for zero page-level scroll
- Removed stale 480px map cap at md: that caused a jarring size regression

## Test plan

- [ ] Verify mobile (375px): single column, hero visible, bottom nav, map full width
- [ ] Verify tablet (768px): single column, map fills grid column (no 480px cap)
- [ ] Verify lg: (1024px): sidebar 260px left, map pinned right, no page scroll
- [ ] Verify xl: (1280px): sidebar 300px, centered with breathing room
- [ ] Verify 3xl: (1920px+): sidebar 360px, dynamic max-width centers dashboard
- [ ] Verify sidebar scrolls independently at desktop
- [ ] Verify other pages (archives, about) are unaffected

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)