### PR TITLE
fix: self-heal missing migrate image in staging CI

### DIFF
--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -14,6 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             migrate: ${{ steps.filter.outputs.migrate }}
+            image_missing: ${{ steps.check.outputs.missing }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v6
@@ -30,9 +31,18 @@ jobs:
                         - 'package-lock.json'
                         - 'Dockerfile.migrate'
 
+            - name: Check if migrate image exists
+              id: check
+              run: |
+                  if docker manifest inspect ghcr.io/${{ github.repository_owner }}/helldiversbot-migrate:staging > /dev/null 2>&1; then
+                    echo "missing=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "missing=true" >> "$GITHUB_OUTPUT"
+                  fi
+
     build-migrate:
         needs: detect-migration
-        if: needs.detect-migration.outputs.migrate == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.detect-migration.outputs.migrate == 'true' || needs.detect-migration.outputs.image_missing == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -97,7 +107,7 @@ jobs:
               with:
                   account: user
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  image-names: 'helldiversbot helldiversbot-migrate'
+                  image-names: 'helldiversbot'
                   tag-selection: untagged
                   cut-off: 30min
                   dry-run: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.16.0",
+    "version": "0.20.0",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Summary
- Added `docker manifest inspect` check to staging CI — if the `helldiversbot-migrate:staging` image is missing from GHCR, `build-migrate` triggers automatically even without migration file changes
- Removed `helldiversbot-migrate` from the cleanup job's retention policy to prevent unintended tag pruning
- Bumped `package.json` version to `0.20.0` to match current version tags

## Context
The conditional `build-migrate` optimization (skip when no prisma/package changes) could leave the `:staging` tag missing if the cleanup action pruned it between builds. This caused `docker compose pull` failures on the production server.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm `docker manifest inspect ghcr.io/elfensky/helldiversbot-migrate:staging` returns a valid manifest
- [ ] Confirm `docker compose pull` succeeds on the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)