### PR TITLE
fix: add HSTS header to close Checkmarx finding

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,6 +73,10 @@ const nextConfig = {
                         key: 'Referrer-Policy',
                         value: 'strict-origin-when-cross-origin',
                     },
+                    {
+                        key: 'Strict-Transport-Security',
+                        value: 'max-age=94608000; includeSubDomains; preload',
+                    },
                 ],
             },
             {


### PR DESCRIPTION
## Summary
- Adds `Strict-Transport-Security: max-age=94608000; includeSubDomains; preload` to the global security headers in `next.config.mjs`
- Resolves the missing HSTS vulnerability flagged by Checkmarx
- 3-year max-age with preload eligibility

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:unit` — all 252 tests pass
- [ ] Verify header appears in production responses after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)