### PR TITLE
chore: disable link prefetching, clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ docker build -f ./Dockerfile.app -t ghcr.io/elfensky/helldiversbot:local .
 --no-cache --progress=plain
 
 - Use `docker build -t ghcr.io/elfensky/helldiversbot:staging .` to build the image locally for local hardware
-    <!-- - Use `docker build --platform linux/amd64 -t ghcr.io/elfensky/helldiversbot:staging .` -->
+      <!-- - Use `docker build --platform linux/amd64 -t ghcr.io/elfensky/helldiversbot:staging .` -->
 - Use `docker buildx build --platform linux/amd64 -t ghcr.io/elfensky/helldiversbot:staging .` to build the image for standard x86_64 hardware
 - Use `docker compose up` to run the container locally.
 
@@ -157,4 +157,12 @@ Purpose: This command is used to push your current Prisma schema to the database
 Use Case: It’s particularly useful during the development phase when you want to quickly sync your database schema with your Prisma schema without worrying about migration history.
 Caution: It can overwrite data if your schema changes affect existing tables or columns, so it’s best for early-stage development or prototyping.
 
-cx scan create --project-name "helldivers.bot" --branch "develop" --scan-types "sast, sca, iac-security, container-security" --container-images "helldiversbot:local" --containers-local-resolution -s .
+## Security
+
+### SAST, SCA, IAC
+
+cx scan create --project-name "helldivers.bot" --branch "develop" --scan-types "sast, sca, iac-security" -s . --debug
+
+### Containers
+
+cx scan create --project-name "helldivers.bot" --branch "develop" --scan-types "container-security" --containers-local-resolution --container-images "ghcr.io/elfensky/helldiversbot:local" -s . --debug

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -65,6 +65,7 @@ function Architecture() {
             </p>
             <Link
                 href="/architecture"
+                prefetch={false}
                 className="mt-2 inline-block text-[var(--color-primary)] hover:underline"
             >
                 View data flow diagram &rarr;

--- a/src/app/not-found.jsx
+++ b/src/app/not-found.jsx
@@ -13,7 +13,7 @@ export default function NotFound() {
                 This area has been classified by Super Earth High Command. It either never
                 existed, or has been redacted for your safety.
             </p>
-            <Link href="/" className="text-[var(--color-primary)] hover:underline">
+            <Link href="/" prefetch={false} className="text-[var(--color-primary)] hover:underline">
                 Return to Managed Democracy →
             </Link>
         </div>

--- a/src/components/layout/BottomNav/BottomNav.jsx
+++ b/src/components/layout/BottomNav/BottomNav.jsx
@@ -20,6 +20,7 @@ export default function BottomNav() {
                     <Link
                         key={href}
                         href={href}
+                        prefetch={false}
                         className={`bottom-nav-tab ${isActive ? 'active' : ''}`}
                     >
                         <span

--- a/src/components/layout/Footer/Footer.jsx
+++ b/src/components/layout/Footer/Footer.jsx
@@ -45,22 +45,22 @@ export default function Footer() {
                     <div className="footer-section-label">Features</div>
                     <ul className="footer-links">
                         <li>
-                            <Link href="/" className="footer-link">
+                            <Link href="/" prefetch={false} className="footer-link">
                                 Campaign
                             </Link>
                         </li>
                         <li>
-                            <Link href="/archives" className="footer-link">
+                            <Link href="/archives" prefetch={false} className="footer-link">
                                 Archives
                             </Link>
                         </li>
                         <li>
-                            <Link href="/discord" className="footer-link">
+                            <Link href="/discord" prefetch={false} className="footer-link">
                                 Discord Bot
                             </Link>
                         </li>
                         <li>
-                            <Link href="/api" className="footer-link">
+                            <Link href="/api" prefetch={false} className="footer-link">
                                 API
                             </Link>
                         </li>

--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -20,6 +20,7 @@ function Logo() {
     return (
         <Link
             href="/"
+            prefetch={false}
             data-umami-event={'header-home'}
             aria-label="Go to homepage"
             className="z-50 flex flex-row items-center justify-center gap-2 text-[clamp(1.1rem,0.9rem+1vw,1.5rem)] font-bold"

--- a/src/components/layout/Navigation/HeaderNav.jsx
+++ b/src/components/layout/Navigation/HeaderNav.jsx
@@ -20,6 +20,7 @@ export default function HeaderNav() {
                     <Link
                         key={href}
                         href={href}
+                        prefetch={false}
                         className={`header-nav-link ${isActive ? 'header-nav-link--active' : ''}`}
                     >
                         {live && <span className="bottom-nav-live">●</span>}

--- a/src/components/layout/Navigation/Navigation.jsx
+++ b/src/components/layout/Navigation/Navigation.jsx
@@ -16,6 +16,7 @@ export default async function Navigation() {
             <HeaderNav />
             <Link
                 href="https://status.helldivers.bot"
+                prefetch={false}
                 data-umami-event="header-status"
                 title="Status"
                 aria-label="Status"
@@ -39,6 +40,7 @@ export default async function Navigation() {
             </Link>
             <Link
                 href="https://github.com/elfensky/helldivers1api"
+                prefetch={false}
                 data-umami-event="header-github"
                 aria-label="GitHub"
                 className="hidden min-[250px]:block"
@@ -79,7 +81,7 @@ async function User({ session }) {
 
     return (
         <div className="flex items-center gap-4">
-            <Link href="/dashboard" data-umami-event="header-dashboard">
+            <Link href="/dashboard" prefetch={false} data-umami-event="header-dashboard">
                 <Image
                     src={avatarUrl}
                     className="rounded-full"


### PR DESCRIPTION
## Summary
- Add `prefetch={false}` to all `<Link>` components in layout/nav (Header, Footer, BottomNav, HeaderNav, Navigation, about, not-found)
- Reorganize README Checkmarx security scan commands into separate SAST/SCA and container sections with `--debug` flag

## Test plan
- [ ] Verify no unexpected prefetch network requests in DevTools
- [ ] Confirm all navigation links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)