### PR TITLE
Timeline rail: proportional dots and ghost-border fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Prettier with tailwindcss plugin. No ESLint configured. Run `npm run format` onc
 
 ### Styling
 
-Tailwind-first: use utility classes and theme tokens (`bg-primary`, `border-ghost-border`, `text-text-muted`, etc.) before reaching for custom CSS. Only create a `.css` file when Tailwind cannot express the style (complex animations, pseudo-element content, multi-selector cascades). If a CSS custom property is used in more than one component, add it to the `@theme` block in `layout.css` so it's available as a utility.
+Tailwind-first: use utility classes and theme tokens (`bg-primary`, `border-ghost`, `text-text-muted`, etc.) before reaching for custom CSS. Only create a `.css` file when Tailwind cannot express the style (complex animations, pseudo-element content, multi-selector cascades). If a CSS custom property is used in more than one component, add it to the `@theme` block in `layout.css` so it's available as a utility.
 
 ### Design Tokens
 

--- a/src/app/brandkit/brandkit.css
+++ b/src/app/brandkit/brandkit.css
@@ -51,7 +51,7 @@
 
 .bk-rule {
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
     padding: 0.75rem 1rem;
     display: flex;
     flex-direction: column;
@@ -82,7 +82,7 @@
 }
 
 .bk-swatch {
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
 }
 
 .bk-swatch-color {
@@ -119,7 +119,7 @@
     flex: 1;
     min-width: 80px;
     padding: 0.5rem;
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
     text-align: center;
     font-size: 0.75rem;
 }
@@ -166,7 +166,7 @@
     margin-top: 1rem;
     padding: 0.75rem;
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
 }
 
 .bk-font-row > div {
@@ -260,7 +260,7 @@
     display: grid;
     grid-template-columns: 1fr 4px;
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
     transition: background 0.2s ease;
 }
 

--- a/src/app/brandkit/page.jsx
+++ b/src/app/brandkit/page.jsx
@@ -90,9 +90,9 @@ function Palette() {
                     token="--color-outline-variant"
                 />
                 <Swatch
-                    color="var(--color-ghost-border)"
+                    color="var(--color-ghost)"
                     name="Ghost"
-                    token="--color-ghost-border"
+                    token="--color-ghost"
                 />
             </div>
 

--- a/src/app/layout.css
+++ b/src/app/layout.css
@@ -21,7 +21,7 @@
     --color-faction-bugs: #e8822a;
     --color-faction-cyborgs: #8b2d2d;
     --color-faction-illuminate: #7ec8e3;
-    --color-ghost-border: rgba(255, 255, 255, 0.15);
+    --color-ghost: rgba(255, 255, 255, 0.15);
 
     /* Typography */
     --font-display: 'Insignia', 'Space Grotesk', 'Impact', sans-serif;
@@ -135,7 +135,7 @@ section {
 }
 .card {
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
 }
 
 p {
@@ -144,7 +144,7 @@ p {
 
 #tooltip {
     background-color: rgba(0, 0, 0, 0.75);
-    border: 2px solid var(--color-ghost-border);
+    border: 2px solid var(--color-ghost);
 
     progress {
         /* Remove default appearance */

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -73,6 +73,8 @@
     }
 
     .dashboard-map {
+        position: sticky;
+        top: 80px;
         display: flex;
         align-items: flex-start;
         justify-content: end;

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -62,10 +62,14 @@
             'alerts  map'
             'sidebar map'
             'hint    hint';
-        grid-template-columns: minmax(260px, 1fr) minmax(0, calc((100dvh - 80px) * 806.93 / 868.81));
+        grid-template-columns: minmax(260px, 1fr) minmax(
+                0,
+                calc((100dvh - 80px) * 806.93 / 868.81)
+            );
         grid-template-rows: auto minmax(0, 1fr) auto;
         column-gap: 6rem;
         min-height: calc(100dvh - 80px);
+        position: relative;
     }
 
     .dashboard-map {
@@ -82,6 +86,8 @@
     }
 
     .dashboard-scroll-hint {
+        position: sticky;
+        bottom: 1.5rem;
         display: flex;
         justify-content: center;
         padding: 0.5rem;
@@ -90,6 +96,22 @@
         font-size: 0.75rem;
         opacity: 0.5;
     }
+
+    .hint-arrow {
+        display: inline-block;
+        font-size: 1rem;
+        margin-right: 0.25rem;
+        margin-top: -3px;
+        animation: hint-bob 5s ease-in-out infinite;
+    }
+
+    @keyframes hint-bob {
+        0%,
+        100% {
+            transform: translateY(-3px);
+        }
+        50% {
+            transform: translateY(3px);
+        }
+    }
 }
-
-

--- a/src/components/h1/Dashboard/DashboardClient.css
+++ b/src/components/h1/Dashboard/DashboardClient.css
@@ -59,20 +59,20 @@
 @media (min-width: 1024px) {
     .dashboard {
         grid-template-areas:
-            'alerts  alerts'
+            'alerts  map'
             'sidebar map'
             'hint    hint';
         grid-template-columns: minmax(260px, 1fr) minmax(0, calc((100dvh - 80px) * 806.93 / 868.81));
         grid-template-rows: auto minmax(0, 1fr) auto;
         column-gap: 6rem;
-        height: calc(100dvh - 80px);
+        min-height: calc(100dvh - 80px);
     }
 
     .dashboard-map {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: end;
-        max-height: 100%;
+        max-height: calc(100dvh - 80px - 2rem);
         min-height: 0;
         margin: 0;
     }

--- a/src/components/h1/Dashboard/DashboardClient.jsx
+++ b/src/components/h1/Dashboard/DashboardClient.jsx
@@ -120,7 +120,7 @@ export default function DashboardClient({ data, mapState }) {
                         ?.scrollIntoView({ behavior: 'smooth' })
                 }
             >
-                ↓ event log
+                <span className="hint-arrow">↓</span> event log
             </button>
         </div>
     );

--- a/src/components/h1/Event/Event.jsx
+++ b/src/components/h1/Event/Event.jsx
@@ -7,12 +7,12 @@ import { EVENT_TYPE } from '@/enums/events';
 const STATUS_STYLES = {
     success: {
         bg: 'bg-[rgba(0,20,0,0.4)]',
-        border: 'border-ghost-border',
+        border: 'border-ghost',
         accent: 'bg-success',
     },
     fail: {
         bg: 'bg-[rgba(40,0,0,0.5)]',
-        border: 'border-ghost-border',
+        border: 'border-ghost',
         accent: 'bg-danger',
     },
     active: {

--- a/src/components/h1/Event/Event.jsx
+++ b/src/components/h1/Event/Event.jsx
@@ -65,10 +65,12 @@ export default function Event({ event, compact = false }) {
                         />
                     )}
                 </div>
-                <div className="text-[0.6875rem] text-text-muted">{timeText}</div>
-                {!showCompact && progress && (
-                    <div className="text-[0.6875rem] text-primary">{progress}</div>
-                )}
+                <div className="flex items-baseline justify-between text-[0.6875rem]">
+                    <span className="text-text-muted">{timeText}</span>
+                    {!showCompact && progress && (
+                        <span className="text-primary">{progress}</span>
+                    )}
+                </div>
                 {!showCompact && (
                     <div className="h-1.5 w-full bg-danger">
                         <div

--- a/src/components/h1/FactionTabs/FactionTabs.css
+++ b/src/components/h1/FactionTabs/FactionTabs.css
@@ -2,7 +2,7 @@
     display: flex;
     width: 100%;
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
 }
 
 .faction-tab {

--- a/src/components/h1/Galaxy/EventCard.css
+++ b/src/components/h1/Galaxy/EventCard.css
@@ -3,7 +3,7 @@
     grid-template-columns: 1fr 4px;
     height: 100%;
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
 }
 
 .sector-card-event {

--- a/src/components/h1/StatGrid/StatGrid.css
+++ b/src/components/h1/StatGrid/StatGrid.css
@@ -22,7 +22,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr) 4px;
     background: var(--color-surface-1);
-    border: 1px solid var(--color-ghost-border);
+    border: 1px solid var(--color-ghost);
     overflow: hidden;
 }
 

--- a/src/components/h1/Timeline/Timeline.css
+++ b/src/components/h1/Timeline/Timeline.css
@@ -1,6 +1,6 @@
 .event {
     background-color: rgba(0, 0, 0, 0.75);
-    border: 2px solid var(--color-ghost-border);
+    border: 2px solid var(--color-ghost);
 }
 
 .event.success {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -98,46 +98,40 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        justify-content: space-between;
         width: 18px;
         flex-shrink: 0;
+        align-self: stretch;
     }
 
-    .rail-circle {
-        width: 12px;
-        height: 12px;
-        border: 2px solid rgba(255, 255, 255, 0.35);
+    .rail-separator {
+        width: 14px;
+        height: 2px;
+        background: var(--color-ghost);
+        flex-shrink: 0;
+        position: relative;
+        z-index: 1;
+    }
+
+    .rail-dot {
+        width: 8px;
+        height: 8px;
         border-radius: 50%;
-        background: var(--color-surface-0);
-        position: relative;
-        z-index: 1;
         flex-shrink: 0;
-        margin-top: 3px;
-    }
-
-    .rail-block {
-        width: 6px;
-        height: 14px;
-        flex-shrink: 0;
-        margin-top: 2px;
         position: relative;
         z-index: 1;
     }
 
-    .rail-block--success {
+    .rail-dot--success {
         background: var(--color-success);
     }
 
-    .rail-block--fail {
+    .rail-dot--fail {
         background: var(--color-danger);
     }
 
-    .rail-block--active {
+    .rail-dot--active {
         background: var(--color-primary);
-    }
-
-    .rail-connector {
-        flex: 1;
-        min-height: 1rem;
     }
 
     .timeline-day-header {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -56,9 +56,11 @@
     flex-direction: column;
 }
 
-/* === Desktop rail column — hidden on mobile === */
+/* === Rail elements — hidden on mobile === */
 
-.timeline-day-rail {
+.rail-circle,
+.rail-dots,
+.rail-separator {
     display: none;
 }
 
@@ -86,40 +88,45 @@
         background: rgba(255, 255, 255, 0.08);
     }
 
-    /* Each day: rail + content side by side */
+    /* Each day: 2-row grid — circle+header, then dots+cards */
     .timeline-day {
-        display: flex;
-        gap: 1rem;
-        align-items: flex-start;
+        display: grid;
+        grid-template-columns: 18px 1fr;
+        grid-template-rows: auto 1fr;
+        gap: 0 1rem;
     }
 
-    /* Show desktop rail */
-    .timeline-day-rail {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: space-between;
-        width: 18px;
-        flex-shrink: 0;
-        align-self: stretch;
-    }
-
+    /* Row 1, col 1: day marker circle */
     .rail-circle {
+        display: flex;
+        grid-row: 1;
+        grid-column: 1;
         width: 10px;
         height: 10px;
         border: 2px solid var(--color-ghost);
         border-radius: 50%;
         background: var(--color-surface-0);
-        flex-shrink: 0;
+        justify-self: center;
+        align-self: center;
         position: relative;
         z-index: 1;
     }
 
+    /* Row 2, col 1: dots container */
+    .rail-dots {
+        display: block;
+        grid-row: 2;
+        grid-column: 1;
+        position: relative;
+    }
+
     .rail-separator {
+        display: block;
         width: 14px;
         height: 2px;
         background: var(--color-ghost);
-        flex-shrink: 0;
+        margin: 0.5rem 0;
+        margin-left: calc(8px - 7px);
         position: relative;
         z-index: 1;
     }
@@ -128,8 +135,9 @@
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        flex-shrink: 0;
-        position: relative;
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
         z-index: 1;
     }
 
@@ -145,15 +153,19 @@
         background: var(--color-primary);
     }
 
+    /* Row 1, col 2: day header */
     .timeline-day-header {
+        grid-row: 1;
+        grid-column: 2;
         box-shadow: none;
         flex-direction: row;
         padding: 0 0 0.25rem 0;
     }
 
-    .timeline-day-content {
-        flex: 1;
-        min-width: 0;
+    /* Row 2, col 2: event card grid */
+    .timeline-day-grid {
+        grid-row: 2;
+        grid-column: 2;
     }
 
     /* Desktop: switch to grid layout for cards */

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -58,8 +58,7 @@
 
 /* === Rail elements — hidden on mobile === */
 
-.rail-circle,
-.rail-dots,
+.rail,
 .rail-separator {
     display: none;
 }
@@ -96,28 +95,36 @@
         gap: 0 1rem;
     }
 
-    /* Row 1, col 1: day marker circle */
-    .rail-circle {
-        display: flex;
-        grid-row: 1;
+    /* Rail: spans both rows in col 1 */
+    .rail {
+        display: block;
+        grid-row: 1 / -1;
         grid-column: 1;
+        position: relative;
+    }
+
+    .rail-circle {
         width: 10px;
         height: 10px;
         border: 2px solid var(--color-ghost);
         border-radius: 50%;
         background: var(--color-surface-0);
-        justify-self: center;
-        align-self: center;
-        position: relative;
+        position: absolute;
+        top: 4px;
+        left: 50%;
+        transform: translateX(-50%);
         z-index: 1;
     }
 
-    /* Row 2, col 1: dots container */
-    .rail-dots {
-        display: block;
-        grid-row: 2;
-        grid-column: 1;
-        position: relative;
+    .rail-circle::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 100%;
+        width: 6px;
+        height: 2px;
+        background: var(--color-ghost);
+        transform: translateY(-50%);
     }
 
     .rail-separator {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -71,7 +71,7 @@
     }
 
     .timeline-days {
-        gap: 2rem;
+        gap: 0.75rem;
         position: relative;
     }
 
@@ -102,6 +102,17 @@
         width: 18px;
         flex-shrink: 0;
         align-self: stretch;
+    }
+
+    .rail-circle {
+        width: 10px;
+        height: 10px;
+        border: 2px solid var(--color-ghost);
+        border-radius: 50%;
+        background: var(--color-surface-0);
+        flex-shrink: 0;
+        position: relative;
+        z-index: 1;
     }
 
     .rail-separator {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -73,7 +73,7 @@
     }
 
     .timeline-days {
-        gap: 0.75rem;
+        gap: 1.25rem;
         position: relative;
     }
 
@@ -125,10 +125,13 @@
         width: 14px;
         height: 2px;
         background: var(--color-ghost);
-        margin: 0.5rem 0;
         margin-left: calc(8px - 7px);
         position: relative;
         z-index: 1;
+    }
+
+    .rail-separator + .rail-separator {
+        margin-top: calc(-1.25rem + 4px);
     }
 
     .rail-dot {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -28,7 +28,6 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex-direction: row-reverse;
     box-shadow: inset -6px 0 0 0 var(--color-ghost);
     padding: 0.5rem calc(12px + 6px) 0.25rem 0;
 }

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -29,7 +29,7 @@
     align-items: center;
     gap: 0.5rem;
     box-shadow: inset -6px 0 0 0 var(--color-ghost);
-    padding: 0.5rem calc(12px + 6px) 0.25rem 0;
+    padding: 1rem calc(12px + 6px) 0.25rem 0;
 }
 
 .timeline-day-label {

--- a/src/components/h1/Timeline/TimelineSection.css
+++ b/src/components/h1/Timeline/TimelineSection.css
@@ -29,7 +29,7 @@
     align-items: center;
     gap: 0.5rem;
     flex-direction: row-reverse;
-    box-shadow: inset -6px 0 0 0 var(--color-ghost-border);
+    box-shadow: inset -6px 0 0 0 var(--color-ghost);
     padding: 0.5rem calc(12px + 6px) 0.25rem 0;
 }
 

--- a/src/components/h1/Timeline/TimelineSection.jsx
+++ b/src/components/h1/Timeline/TimelineSection.jsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import './TimelineSection.css';
 import Event from '@/components/h1/Event/Event';
 import { groupEventsByDay } from '@/utils/groupEventsByDay.mjs';
@@ -28,23 +29,17 @@ export default function TimelineSection({ events }) {
                             const gapBefore = prevMs != null && prevMs - thisMs > dayMs;
                             const gapAfter = nextMs != null && thisMs - nextMs > dayMs;
 
+                            const chronological = [...group.events].sort((a, b) => a.start_time - b.start_time);
+                            const times = chronological.map((e) => (e.start_time % 86400));
+                            const minT = Math.min(...times);
+                            const maxT = Math.max(...times);
+                            const range = maxT - minT;
+
                             return (
-                                <div key={group.date} className="timeline-day">
-                                    <div
-                                        className="timeline-day-rail"
-                                        aria-hidden="true"
-                                    >
-                                        {gapBefore && <div className="rail-separator" />}
-                                        <div className="rail-circle" />
-                                        {group.events.map((event) => (
-                                            <div
-                                                key={event.event_id}
-                                                className={`rail-dot rail-dot--${event.status}`}
-                                            />
-                                        ))}
-                                        {gapAfter && <div className="rail-separator" />}
-                                    </div>
-                                    <div className="timeline-day-content">
+                                <Fragment key={group.date}>
+                                    {gapBefore && <div className="rail-separator" aria-hidden="true" />}
+                                    <div className="timeline-day">
+                                        <div className="rail-circle" aria-hidden="true" />
                                         <div className="timeline-day-header">
                                             <span className="timeline-day-label">
                                                 {group.label}
@@ -54,6 +49,19 @@ export default function TimelineSection({ events }) {
                                                     {wins}W / {losses}L
                                                 </span>
                                             )}
+                                        </div>
+                                        <div className="rail-dots" aria-hidden="true">
+                                            {chronological.map((event) => {
+                                                const t = event.start_time % 86400;
+                                                const pct = range > 0 ? ((t - minT) / range) * 100 : 0;
+                                                return (
+                                                    <div
+                                                        key={event.event_id}
+                                                        className={`rail-dot rail-dot--${event.status}`}
+                                                        style={{ top: `calc(${pct}% - ${pct * 8 / 100}px)` }}
+                                                    />
+                                                );
+                                            })}
                                         </div>
                                         <div className="timeline-day-grid">
                                             {group.events.map((event) => (
@@ -65,7 +73,8 @@ export default function TimelineSection({ events }) {
                                             ))}
                                         </div>
                                     </div>
-                                </div>
+                                    {gapAfter && <div className="rail-separator" aria-hidden="true" />}
+                                </Fragment>
                             );
                         })}
                     </div>

--- a/src/components/h1/Timeline/TimelineSection.jsx
+++ b/src/components/h1/Timeline/TimelineSection.jsx
@@ -39,18 +39,8 @@ export default function TimelineSection({ events }) {
                                 <Fragment key={group.date}>
                                     {gapBefore && <div className="rail-separator" aria-hidden="true" />}
                                     <div className="timeline-day">
-                                        <div className="rail-circle" aria-hidden="true" />
-                                        <div className="timeline-day-header">
-                                            <span className="timeline-day-label">
-                                                {group.label}
-                                            </span>
-                                            {(wins > 0 || losses > 0) && (
-                                                <span className="timeline-day-summary">
-                                                    {wins}W / {losses}L
-                                                </span>
-                                            )}
-                                        </div>
-                                        <div className="rail-dots" aria-hidden="true">
+                                        <div className="rail" aria-hidden="true">
+                                            <div className="rail-circle" />
                                             {chronological.map((event) => {
                                                 const t = event.start_time % 86400;
                                                 const pct = range > 0 ? ((t - minT) / range) * 100 : 0;
@@ -62,6 +52,16 @@ export default function TimelineSection({ events }) {
                                                     />
                                                 );
                                             })}
+                                        </div>
+                                        <div className="timeline-day-header">
+                                            <span className="timeline-day-label">
+                                                {group.label}
+                                            </span>
+                                            {(wins > 0 || losses > 0) && (
+                                                <span className="timeline-day-summary">
+                                                    {wins}W / {losses}L
+                                                </span>
+                                            )}
                                         </div>
                                         <div className="timeline-day-grid">
                                             {group.events.map((event) => (

--- a/src/components/h1/Timeline/TimelineSection.jsx
+++ b/src/components/h1/Timeline/TimelineSection.jsx
@@ -13,7 +13,7 @@ export default function TimelineSection({ events }) {
                     <p className="timeline-empty">No events recorded yet.</p>
                 ) : (
                     <div className="timeline-days">
-                        {groups.map((group) => {
+                        {groups.map((group, i) => {
                             const wins = group.events.filter(
                                 (e) => e.status === 'success',
                             ).length;
@@ -21,20 +21,27 @@ export default function TimelineSection({ events }) {
                                 (e) => e.status === 'fail',
                             ).length;
 
+                            const dayMs = 86_400_000;
+                            const thisMs = new Date(group.date).getTime();
+                            const prevMs = groups[i - 1] && new Date(groups[i - 1].date).getTime();
+                            const nextMs = groups[i + 1] && new Date(groups[i + 1].date).getTime();
+                            const gapBefore = prevMs != null && prevMs - thisMs > dayMs;
+                            const gapAfter = nextMs != null && thisMs - nextMs > dayMs;
+
                             return (
                                 <div key={group.date} className="timeline-day">
                                     <div
                                         className="timeline-day-rail"
                                         aria-hidden="true"
                                     >
-                                        <div className="rail-circle" />
+                                        {gapBefore && <div className="rail-separator" />}
                                         {group.events.map((event) => (
                                             <div
                                                 key={event.event_id}
-                                                className={`rail-block rail-block--${event.status}`}
+                                                className={`rail-dot rail-dot--${event.status}`}
                                             />
                                         ))}
-                                        <div className="rail-connector" />
+                                        {gapAfter && <div className="rail-separator" />}
                                     </div>
                                     <div className="timeline-day-content">
                                         <div className="timeline-day-header">

--- a/src/components/h1/Timeline/TimelineSection.jsx
+++ b/src/components/h1/Timeline/TimelineSection.jsx
@@ -35,6 +35,7 @@ export default function TimelineSection({ events }) {
                                         aria-hidden="true"
                                     >
                                         {gapBefore && <div className="rail-separator" />}
+                                        <div className="rail-circle" />
                                         {group.events.map((event) => (
                                             <div
                                                 key={event.event_id}

--- a/src/components/h1/War/War.jsx
+++ b/src/components/h1/War/War.jsx
@@ -9,7 +9,7 @@ export function WarOutcome({ data }) {
 
     return (
         <div
-            className={`flex flex-1 items-center border-2 border-ghost-border bg-surface-1 px-4 py-2 font-display text-xl font-black uppercase ${outcome === 'victory' ? 'border-primary text-primary' : 'border-danger text-danger'}`}
+            className={`flex flex-1 items-center border-2 border-ghost bg-surface-1 px-4 py-2 font-display text-xl font-black uppercase ${outcome === 'victory' ? 'border-primary text-primary' : 'border-danger text-danger'}`}
         >
             <span className="font-bold">
                 {outcome === 'victory' ? 'Victory' : 'Defeat'}
@@ -45,7 +45,7 @@ function generateGlobalWarStats(statistics) {
     });
 
     return (
-        <article className="flex flex-col gap-1 border border-ghost-border bg-surface-1 p-4">
+        <article className="flex flex-col gap-1 border border-ghost bg-surface-1 p-4">
             <div className="flex items-center justify-start gap-2">
                 <img
                     src={`/icons/faction3.webp`}
@@ -66,7 +66,7 @@ function generateGlobalWarStats(statistics) {
 }
 function generateWarStats(statistic) {
     return (
-        <article key={statistic.enemy} className="flex flex-col gap-1 border border-ghost-border bg-surface-1 p-4">
+        <article key={statistic.enemy} className="flex flex-col gap-1 border border-ghost bg-surface-1 p-4">
             <div className="flex items-center justify-start gap-2">
                 <img
                     src={`/icons/faction${statistic.enemy}.webp`}

--- a/src/components/layout/BottomNav/BottomNav.css
+++ b/src/components/layout/BottomNav/BottomNav.css
@@ -7,7 +7,7 @@
     display: flex;
     height: 48px;
     background: var(--color-surface-1);
-    border-top: 1px solid var(--color-ghost-border);
+    border-top: 1px solid var(--color-ghost);
 }
 
 /* Unlayered CSS beats Tailwind's @layer utilities, so md:hidden won't work.

--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -62,7 +62,7 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     padding-bottom: var(--space-2);
-    border-bottom: 1px solid var(--color-ghost-border);
+    border-bottom: 1px solid var(--color-ghost);
     margin-bottom: var(--space-3);
 }
 
@@ -97,7 +97,7 @@
 
 /* Bottom separator bar */
 .footer-separator {
-    border-top: 1px solid var(--color-ghost-border);
+    border-top: 1px solid var(--color-ghost);
     margin-top: var(--space-8);
     padding-top: var(--space-4);
     padding-bottom: calc(48px + 1rem);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -26,7 +26,7 @@
     /* === OUTLINE === */
     --color-outline: #999077;
     --color-outline-variant: #4d4732;
-    --color-ghost-border: rgba(255, 255, 255, 0.15);
+    --color-ghost: rgba(255, 255, 255, 0.15);
 
     /* === FACTION (game-canonical — do not change) === */
     --color-faction-bugs: #e8822a;


### PR DESCRIPTION
## Summary

- Rename `--color-ghost-border` to `--color-ghost` to fix Tailwind v4 class scanner ambiguity (borders were rendering solid white)
- Left-align timeline day header text on mobile with increased top-padding
- Replace rectangular rail blocks with proportional time-based dots
- Dots positioned by time-of-day within each day's rail using absolute positioning
- Add ghost day circles aligned with header text, with horizontal tick mark
- Gap-aware separators between non-consecutive days (4px inner gap)
- Switch timeline day layout to CSS grid for circle-header alignment
- Inline pace text with due-time on active event cards
- Sticky galaxy map on desktop, scroll hint arrow

## Test plan

- [x] `npm run build` passes
- [x] DevTools: ghost borders render as `rgba(255, 255, 255, 0.15)` not solid white
- [x] DevTools: rail dots positioned proportionally by time
- [x] DevTools: day circles aligned with header label text (0px diff)
- [x] DevTools: separators only between multi-day gaps, 4px apart
- [x] DevTools: mobile hides all rail elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)