### PR TITLE
fix: harden changelog extraction in release workflow

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -85,12 +85,17 @@ jobs:
                   TAG_NAME: ${{ github.ref_name }}
               run: |
                   VERSION="${TAG_NAME#v}"
-                  # Extract the section for this version from CHANGELOG.md
-                  NOTES=$(awk "/^## ${VERSION}[[:space:]]/,/^## [0-9]/" CHANGELOG.md | sed '$ d')
-                  # Remove the version header line itself
-                  NOTES=$(echo "$NOTES" | tail -n +2)
-                  # Write to file to preserve multiline
-                  echo "$NOTES" > /tmp/release-notes.md
+                  # State-machine awk: find "## <version>" header, collect until next "## " header or EOF
+                  awk -v ver="$VERSION" '
+                    /^## / { if (found) exit; if (index($0, "## " ver) == 1) { found=1; next } }
+                    found { print }
+                  ' CHANGELOG.md > /tmp/release-notes.md
+
+                  # Fail if changelog section is missing or empty
+                  if [ ! -s /tmp/release-notes.md ] || [ -z "$(tr -d '[:space:]' < /tmp/release-notes.md)" ]; then
+                    echo "::warning::No changelog entry found for ${VERSION} — using tag name as release body"
+                    echo "Release ${TAG_NAME}" > /tmp/release-notes.md
+                  fi
 
             - name: Create GitHub Release
               env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.22.1 (2026-04-03)
+
+### Release Workflow Fix
+
+- Switch Production Docker auth from expired PAT to `GITHUB_TOKEN`
+- Remove release-please (conflicted with manual tagging)
+- Add GitHub Release job with changelog extraction to Production workflow
+- Fix changelog extraction: use state-machine awk, add empty-body validation
+
 ## 0.22.0 (2026-04-02)
 
 ### Phase 9: Dashboard & Timeline Polish


### PR DESCRIPTION
## Summary

- Replace fragile range-operator awk with state-machine approach
- Add empty-body validation — warns and falls back instead of publishing blank release
- Add v0.22.1 changelog entry for the earlier release workflow fix
- Fixes: `## 0.22.1` without date, last section in file, missing version section

## Context (from AI debate)

Three AI participants unanimously agreed the awk extraction had 3 bugs. This implements the consensus fix.

## Test plan

- [ ] Re-tag v0.22.1 after merge → verify GitHub Release has correct changelog body
- [ ] `awk` extracts 0.22.0, 0.21.0, 0.22.1 sections correctly (tested locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)