### PR TITLE
docs: explain why Production always builds migrate image

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -41,6 +41,9 @@ jobs:
                   build-args: |
                       NODE_ENV=production
 
+    # Always build migrate in Production — unlike staging, no skip logic here.
+    # Each tag needs a versioned image, releases are infrequent (~$3/yr CI cost),
+    # and a missing migration image causes broken deploys. Not worth optimizing.
     build-migrate:
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add YAML comment explaining the deliberate choice. Unlike staging (high-frequency, skip logic), Production releases are infrequent and a missing migration image breaks deploys.