### PR TITLE
fix: pin npm@11 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
                   node-version-file: '.node-version'
                   cache: 'npm'
 
+            - name: Pin npm version
+              run: npm install -g npm@11
+
             - name: Install dependencies
               run: npm ci
 
@@ -59,6 +62,9 @@ jobs:
               with:
                   node-version-file: '.node-version'
                   cache: 'npm'
+
+            - name: Pin npm version
+              run: npm install -g npm@11
 
             - name: Install dependencies
               run: npm ci


### PR DESCRIPTION
## Summary
- Pin npm@11 in CI workflow (`npm install -g npm@11`) to match local dev and Dockerfiles
- CI was failing because Node 22's bundled npm 10.x resolves `overrides` differently than npm 11, causing `npm ci` to reject the lockfile
- Also disabled CodeQL "Default setup" via API — it conflicted with the existing `codeql.yml` advanced workflow

## Test plan
- [ ] CI workflow passes on this PR (both SonarCloud and Test & Build jobs)
- [ ] CodeQL workflow passes after default setup was disabled
- [ ] Local: 561/561 unit tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)