### PR TITLE
feat: nonce-based CSP via proxy.js

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -3,7 +3,7 @@ name: Build Production
 on:
     push:
         tags:
-            - "v*.*.*" # Triggers on version tags like v1.0.0
+            - 'v*.*.*' # Triggers on version tags like v1.0.0
 
 permissions:
     contents: write

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -106,7 +106,7 @@ jobs:
               with:
                   account: user
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  image-names: "helldiversbot"
+                  image-names: 'helldiversbot'
                   tag-selection: untagged
                   cut-off: 30min
                   dry-run: false

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,27 +41,10 @@ const nextConfig = {
         ];
     },
     async headers() {
-        const isDev = process.env.NODE_ENV === 'development';
-        const csp = [
-            "default-src 'self'",
-            `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://umami.lavrenov.io https://static.cloudflareinsights.com`,
-            "style-src 'self' 'unsafe-inline'",
-            "img-src 'self' data: https://authjs.dev https://cdn.discordapp.com https://avatars.githubusercontent.com https://www.gravatar.com",
-            "font-src 'self'",
-            "connect-src 'self' https://umami.lavrenov.io https://bugsink.lavrenov.cloud https://cloudflareinsights.com",
-            "form-action 'self'",
-            "frame-ancestors 'none'",
-            "base-uri 'self'",
-        ].join('; ');
-
         return [
             {
                 source: '/(.*)',
                 headers: [
-                    {
-                        key: 'Content-Security-Policy',
-                        value: csp,
-                    },
                     {
                         key: 'X-Frame-Options',
                         value: 'DENY',

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,400 +1,446 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-        "title": "Helldivers 1 API",
-        "version": "0.11.0",
-        "description": "A simple API"
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Helldivers 1 API",
+    "version": "0.11.0",
+    "description": "A simple API"
+  },
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "number",
+            "description": "Time taken to process the request (ms)"
+          },
+          "code": {
+            "type": "number",
+            "description": "HTTP status code"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable status message"
+          },
+          "error": {
+            "nullable": true,
+            "description": "Error details or null"
+          }
+        },
+        "required": [
+          "time",
+          "code",
+          "message"
+        ]
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "number",
+            "description": "Time taken to process the request (ms)"
+          },
+          "code": {
+            "type": "number",
+            "description": "HTTP status code"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable status message"
+          },
+          "data": {
+            "nullable": true,
+            "description": "Response data"
+          }
+        },
+        "required": [
+          "time",
+          "code",
+          "message"
+        ]
+      },
+      "RebroadcastFormData": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "get_campaign_status",
+              "get_snapshots"
+            ],
+            "description": "The action to perform."
+          },
+          "season": {
+            "type": "integer",
+            "minimum": 1,
+            "exclusiveMinimum": true,
+            "description": "Required if action is get_snapshots."
+          }
+        },
+        "required": [
+          "action"
+        ]
+      }
     },
-    "components": {
-        "schemas": {
-            "ErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "time": {
-                        "type": "number",
-                        "description": "Time taken to process the request (ms)"
-                    },
-                    "code": {
-                        "type": "number",
-                        "description": "HTTP status code"
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Human-readable status message"
-                    },
-                    "error": {
-                        "nullable": true,
-                        "description": "Error details or null"
-                    }
-                },
-                "required": ["time", "code", "message"]
+    "parameters": {}
+  },
+  "paths": {
+    "/api/h1/campaign": {
+      "get": {
+        "summary": "Get campaign data for a specific season or the latest.",
+        "description": "Returns campaign data for a given season if the `season` query parameter is provided and valid. If no season is provided, returns the latest campaign data. If data is not found locally, attempts to fetch and update from a remote source.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The season number to fetch campaign data for.",
+              "example": "1"
             },
-            "SuccessResponse": {
-                "type": "object",
-                "properties": {
+            "required": false,
+            "description": "The season number to fetch campaign data for.",
+            "name": "season",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign data found and returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
                     "time": {
-                        "type": "number",
-                        "description": "Time taken to process the request (ms)"
+                      "type": "number",
+                      "description": "Time taken to process the request (ms)"
                     },
                     "code": {
-                        "type": "number",
-                        "description": "HTTP status code"
+                      "type": "number",
+                      "description": "HTTP status code"
                     },
                     "message": {
-                        "type": "string",
-                        "description": "Human-readable status message"
+                      "type": "string",
+                      "description": "Human-readable status message"
                     },
                     "data": {
-                        "nullable": true,
-                        "description": "Response data"
+                      "nullable": true,
+                      "description": "The campaign data object"
                     }
-                },
-                "required": ["time", "code", "message"]
-            },
-            "RebroadcastFormData": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["get_campaign_status", "get_snapshots"],
-                        "description": "The action to perform."
-                    },
-                    "season": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "exclusiveMinimum": true,
-                        "description": "Required if action is get_snapshots."
-                    }
-                },
-                "required": ["action"]
-            }
-        },
-        "parameters": {}
-    },
-    "paths": {
-        "/api/h1/campaign": {
-            "get": {
-                "summary": "Get campaign data for a specific season or the latest.",
-                "description": "Returns campaign data for a given season if the `season` query parameter is provided and valid. If no season is provided, returns the latest campaign data. If data is not found locally, attempts to fetch and update from a remote source.",
-                "parameters": [
-                    {
-                        "schema": {
-                            "type": "string",
-                            "description": "The season number to fetch campaign data for.",
-                            "example": "1"
-                        },
-                        "required": false,
-                        "description": "The season number to fetch campaign data for.",
-                        "name": "season",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Campaign data found and returned successfully.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number",
-                                            "description": "Time taken to process the request (ms)"
-                                        },
-                                        "code": {
-                                            "type": "number",
-                                            "description": "HTTP status code"
-                                        },
-                                        "message": {
-                                            "type": "string",
-                                            "description": "Human-readable status message"
-                                        },
-                                        "data": {
-                                            "nullable": true,
-                                            "description": "The campaign data object"
-                                        }
-                                    },
-                                    "required": ["time", "code", "message"]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid season parameter.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Campaign data not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    }
+                  },
+                  "required": [
+                    "time",
+                    "code",
+                    "message"
+                  ]
                 }
+              }
             }
-        },
-        "/api/h1/rebroadcast": {
-            "post": {
-                "summary": "Perform a campaign status or snapshot action",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RebroadcastFormData"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RebroadcastFormData"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "nullable": true
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request (content type, action, or arguments).",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "error_code": {
-                                            "type": "number"
-                                        },
-                                        "error_message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["time", "error_code", "error_message"]
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized. API key missing, malformed, or not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "error_code": {
-                                            "type": "number"
-                                        },
-                                        "error_message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["time", "error_code", "error_message"]
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden. API key found but disabled.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "error_code": {
-                                            "type": "number"
-                                        },
-                                        "error_message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["time", "error_code", "error_message"]
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "error_code": {
-                                            "type": "number"
-                                        },
-                                        "error_message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["time", "error_code", "error_message"]
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Method not allowed.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "error_code": {
-                                            "type": "number"
-                                        },
-                                        "error_message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["time", "error_code", "error_message"]
-                                }
-                            }
-                        }
-                    }
+          },
+          "400": {
+            "description": "Invalid season parameter.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
+              }
             }
-        },
-        "/api/h1/update": {
-            "get": {
-                "summary": "Trigger current campaign status and snapshot updates",
-                "description": "**Internal-use-only.** This endpoint is used by a node (web) worker to continuously trigger status and season updates for the current campaign. It is not intended for external user consumption. Requires a valid `key` query parameter matching the server's `UPDATE_KEY` environment variable.",
-                "tags": ["Internal"],
-                "parameters": [
-                    {
-                        "schema": {
-                            "type": "string",
-                            "description": "Internal API key for authorization."
-                        },
-                        "required": true,
-                        "description": "Internal API key for authorization.",
-                        "name": "key",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Update successful. Returns the updated status and season data.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "time": {
-                                            "type": "number"
-                                        },
-                                        "code": {
-                                            "type": "number"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        },
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "updated": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "status": {
-                                                            "nullable": true,
-                                                            "description": "The updated status data."
-                                                        },
-                                                        "season": {
-                                                            "nullable": true,
-                                                            "description": "The updated season data."
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "required": ["updated"]
-                                        }
-                                    },
-                                    "required": ["time", "code", "message", "data"]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request. Missing key parameter.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized. The provided key is missing or invalid.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed. Only GET is supported.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    }
+          },
+          "404": {
+            "description": "Campaign data not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
+              }
             }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
+      }
+    },
+    "/api/h1/rebroadcast": {
+      "post": {
+        "summary": "Perform a campaign status or snapshot action",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/RebroadcastFormData"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RebroadcastFormData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (content type, action, or arguments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "error_code": {
+                      "type": "number"
+                    },
+                    "error_message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "error_code",
+                    "error_message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. API key missing, malformed, or not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "error_code": {
+                      "type": "number"
+                    },
+                    "error_message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "error_code",
+                    "error_message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. API key found but disabled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "error_code": {
+                      "type": "number"
+                    },
+                    "error_message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "error_code",
+                    "error_message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "error_code": {
+                      "type": "number"
+                    },
+                    "error_message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "error_code",
+                    "error_message"
+                  ]
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "error_code": {
+                      "type": "number"
+                    },
+                    "error_message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "error_code",
+                    "error_message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/h1/update": {
+      "get": {
+        "summary": "Trigger current campaign status and snapshot updates",
+        "description": "**Internal-use-only.** This endpoint is used by a node (web) worker to continuously trigger status and season updates for the current campaign. It is not intended for external user consumption. Requires a valid `key` query parameter matching the server's `UPDATE_KEY` environment variable.",
+        "tags": [
+          "Internal"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal API key for authorization."
+            },
+            "required": true,
+            "description": "Internal API key for authorization.",
+            "name": "key",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. Returns the updated status and season data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "type": "number"
+                    },
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "updated": {
+                          "type": "object",
+                          "properties": {
+                            "status": {
+                              "nullable": true,
+                              "description": "The updated status data."
+                            },
+                            "season": {
+                              "nullable": true,
+                              "description": "The updated season data."
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "updated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "time",
+                    "code",
+                    "message",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Missing key parameter.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. The provided key is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed. Only GET is supported.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/src/__tests__/unit/components/Header.test.jsx
+++ b/src/__tests__/unit/components/Header.test.jsx
@@ -2,6 +2,13 @@
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+vi.mock('next/headers', () => ({
+    headers: vi.fn(() =>
+        Promise.resolve({
+            get: (key) => (key === 'x-nonce' ? 'test-nonce' : null),
+        }),
+    ),
+}));
 vi.mock('@/components/layout/Navigation/Navigation', () => ({
     default: () => <nav data-testid="navigation" />,
 }));

--- a/src/app/archives/page.jsx
+++ b/src/app/archives/page.jsx
@@ -104,7 +104,10 @@ export default async function WarHistoryPage({ searchParams }) {
     );
 }
 
-function JsonLd() {
+async function JsonLd() {
+    const { headers } = await import('next/headers');
+    const nonce = (await headers()).get('x-nonce') ?? undefined;
+
     // Static JSON-LD structured data for SEO — no user input, safe to inline
     const structuredData = [
         {
@@ -138,7 +141,9 @@ function JsonLd() {
 
     return (
         <script
+            nonce={nonce}
             type="application/ld+json"
+            suppressHydrationWarning
             // eslint-disable-next-line react/no-danger -- static structured data, no user input
             dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
         />

--- a/src/app/discord/page.jsx
+++ b/src/app/discord/page.jsx
@@ -6,11 +6,16 @@ export const metadata = {
     openGraph: { url: '/discord' },
 };
 
-export default function BotPage() {
+export default async function BotPage() {
+    const { headers } = await import('next/headers');
+    const nonce = (await headers()).get('x-nonce') ?? undefined;
+
     return (
         <div className="gutters flex min-h-[50vh] flex-col items-center justify-center gap-4">
             <script
+                nonce={nonce}
                 type="application/ld+json"
+                suppressHydrationWarning
                 // Safe: schema is a hardcoded constant, not user input
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
             />

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,6 +1,7 @@
 import './layout.css';
 //nextjs
 import Script from 'next/script';
+import { headers } from 'next/headers';
 import { Space_Grotesk, Inter } from 'next/font/google';
 //components
 import Header from '@/components/layout/Header/Header';
@@ -49,7 +50,8 @@ export const metadata = {
     },
 };
 
-export default function RootLayout({ children }) {
+export default async function RootLayout({ children }) {
+    const nonce = (await headers()).get('x-nonce') ?? undefined;
     const isProduction = process.env.NODE_ENV === 'production';
 
     return (
@@ -66,7 +68,9 @@ export default function RootLayout({ children }) {
             </head> */}
             <body id="body" className="flex min-h-screen min-w-full flex-col antialiased">
                 <script
+                    nonce={nonce}
                     type="application/ld+json"
+                    suppressHydrationWarning
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
                 />
 
@@ -94,6 +98,7 @@ export default function RootLayout({ children }) {
 
                 {isProduction ?
                     <Script
+                        nonce={nonce}
                         // src="https://umami.lavrenov.io/script.js"
                         src="/stats.js"
                         data-website-id="9a916711-2868-43d2-9932-964fc9528824"

--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -2,10 +2,13 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import Script from 'next/script';
+import { headers } from 'next/headers';
 //components
 import Navigation from '@/components/layout/Navigation/Navigation';
 
 export default async function Header() {
+    const nonce = (await headers()).get('x-nonce') ?? undefined;
+
     return (
         <header
             id="header"
@@ -15,7 +18,11 @@ export default async function Header() {
                 <Logo />
                 <Navigation />
             </div>
-            <Script src="/scripts/headerGPU.js" strategy="afterInteractive" />
+            <Script
+                nonce={nonce}
+                src="/scripts/headerGPU.js"
+                strategy="afterInteractive"
+            />
         </header>
     );
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+export function proxy(request) {
+    const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+    const isDev = process.env.NODE_ENV === 'development';
+
+    const csp = [
+        "default-src 'self'",
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://umami.lavrenov.io https://static.cloudflareinsights.com${isDev ? " 'unsafe-eval'" : ''}`,
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: https://authjs.dev https://cdn.discordapp.com https://avatars.githubusercontent.com https://www.gravatar.com",
+        "font-src 'self'",
+        "connect-src 'self' https://umami.lavrenov.io https://bugsink.lavrenov.cloud https://cloudflareinsights.com",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+    ].join('; ');
+
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set('x-nonce', nonce);
+    requestHeaders.set('Content-Security-Policy', csp);
+
+    const response = NextResponse.next({ request: { headers: requestHeaders } });
+    response.headers.set('Content-Security-Policy', csp);
+    return response;
+}
+
+export const config = {
+    matcher: [
+        {
+            source: '/((?!_next/static|_next/image|favicons|fonts|icons|images|svgs|workers|favicon.ico|sitemap.xml|robots.txt).*)',
+            missing: [
+                { type: 'header', key: 'next-router-prefetch' },
+                { type: 'header', key: 'purpose', value: 'prefetch' },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
## Summary

- Replace static `unsafe-inline` + `unsafe-eval` CSP with per-request nonce-based policy via Next.js 16 `proxy.js`
- Add `strict-dynamic` for cascading script trust, dev-only `unsafe-eval` for HMR
- Add nonce to all JSON-LD `<script>` tags and `<Script>` components across layout, archives, discord, and Header

## Test plan

- [x] `npm run build` passes (proxy recognized as `ƒ Proxy (Middleware)`)
- [x] `npm run test:unit` — 619/619 tests pass
- [x] Prettier formatted
- [ ] Verify in Chrome DevTools: CSP header contains `nonce-`, no `unsafe-inline`
- [ ] Verify no CSP console errors on `/`, `/archives`, `/discord`
- [ ] Verify Umami analytics and headerGPU scripts load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)