### PR TITLE
chore: standardize Docker user to built-in node

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -50,16 +50,13 @@ LABEL description="nextjs application that serves as an api rebroadcaster and fo
 # defaults to production, but can be overriden at build time
 ARG NODE_ENV=production 
 ENV NODE_ENV=$NODE_ENV
-# security & permissions
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-# configure the container to run as non-root user
-USER nextjs
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
+# Run as non-root user (node user is built into node:*-alpine images)
+USER node
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"


### PR DESCRIPTION
## Summary

- Replace custom `nextjs`/`nodejs` user (uid 1001) with built-in `node` user (uid 1000) in `Dockerfile.app`
- Removes 2 unnecessary `RUN addgroup`/`adduser` commands
- Both Dockerfiles now consistently use the `node` user

## Test plan

- [ ] `docker build -f Dockerfile.app .` succeeds
- [ ] App container runs correctly as `node` user

🤖 Generated with [Claude Code](https://claude.com/claude-code)