### PR TITLE
Release v0.24.1

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -2,7 +2,7 @@
 POSTGRES_URL="postgresql://username:password@host:port/databasename?schema=public"
 # Local: POSTGRES_URL="postgresql://elfensky:supersecretpassword123@127.0.0.1:5432/helldivers1api?schema=public"
 # Docker: POSTGRES_URL="postgresql://elfensky:supersecretpassword123@host.docker.internal:5432/helldivers1api?schema=public"
-SKIP_MIGRATIONS="false" # Set to "true" when using separate migrate container (docker-compose)
+POSTGRES_SSL="true" # Set to "false" when connecting to a database without SSL
 
 # UPDATE // API key for the update endpoint
 UPDATE_KEY="fcb19795-474f-4ff1-aa21-5d36b81167ba" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Check formatting
-              run: npx prettier --check .
-
             - name: Run unit tests
               run: npm run test:unit
 

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -3,7 +3,6 @@ on:
     workflow_dispatch: # allows requesting workflow manually from the website
     push:
         branches:
-            - main
             - develop
 permissions:
     contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.24.1 (2026-04-04)
+
+### Fixes
+
+- Decouple Postgres SSL from `NODE_ENV` — new `POSTGRES_SSL` env var controls SSL independently of build mode
+- Add `platform: linux/amd64` to `docker-compose.yml` for ARM Mac compatibility
+- Fix README Docker build tags (`:local` → `:staging`)
+
+### Chores
+
+- Remove unused `SKIP_MIGRATIONS` env var (never read by application)
+- Remove Prettier formatting check from CI
+
 ## 0.24.0 (2026-04-04)
 
 ### Phase 8: Real-Time Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@
 - Decouple Postgres SSL from `NODE_ENV` — new `POSTGRES_SSL` env var controls SSL independently of build mode
 - Add `platform: linux/amd64` to `docker-compose.yml` for ARM Mac compatibility
 - Fix README Docker build tags (`:local` → `:staging`)
+- Move `themeColor` from `metadata` to `viewport` export (Next.js 16 requirement)
 
 ### Chores
 
 - Remove unused `SKIP_MIGRATIONS` env var (never read by application)
 - Remove Prettier formatting check from CI
+- Normalize `docker-compose.yml` indentation, update host port
 
 ## 0.24.0 (2026-04-04)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All external data validated with Zod schemas (`src/validators/`) before database
 
 ### Formatting
 
-Prettier with tailwindcss plugin. No ESLint configured. **Always run `npx prettier --write .` before committing** — not during development. CI enforces `prettier --check` and will fail unformatted code.
+Prettier with tailwindcss plugin. No ESLint configured. **Always run `npx prettier --write .` before committing** — not during development.
 
 ### Styling
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ When using the docker container, the database you are connecting to needs to alr
 
 #### Build locally
 
-docker build -f ./Dockerfile.migrate -t ghcr.io/elfensky/helldiversbot-migrate:local .
-docker build -f ./Dockerfile.app -t ghcr.io/elfensky/helldiversbot:local .
---no-cache --progress=plain
+```sh
+docker build -f ./Dockerfile.migrate -t ghcr.io/elfensky/helldiversbot-migrate:staging .
+docker build -f ./Dockerfile.app -t ghcr.io/elfensky/helldiversbot:staging .
+```
 
-- Use `docker build -t ghcr.io/elfensky/helldiversbot:staging .` to build the image locally for local hardware
-- Use `docker buildx build --platform linux/amd64 -t ghcr.io/elfensky/helldiversbot:staging .` to build the image for standard x86_64 hardware
-- Use `docker compose up` to run the container locally.
+- Add `--no-cache --progress=plain` for clean rebuilds
+- Use `docker buildx build --platform linux/amd64 -f ./Dockerfile.app -t ghcr.io/elfensky/helldiversbot:staging .` to cross-compile for x86_64
+- Use `docker compose up` to run the containers locally
 
 #### Deploy to ghcr.io
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,39 @@
 services:
-  migrate:
-    container_name: helldiversbot-migrate
-    image: ghcr.io/elfensky/helldiversbot-migrate:staging
-    env_file:
-      - .env.development
-    # Runs migrations and exits
+    migrate:
+        container_name: helldiversbot-migrate
+        platform: linux/amd64
+        image: ghcr.io/elfensky/helldiversbot-migrate:staging
+        env_file:
+            - .env.development
+        # Runs migrations and exits
 
-  helldiversbot:
-    container_name: helldiversbot
-    # this isn't neccesary, the dockerfile entrypoint takes care of that
-    # init: true # replaces manually installing and using tini in the docker file.
-    restart: unless-stopped
-    image: ghcr.io/elfensky/helldiversbot:staging
-    ports:
-      - "127.0.0.1:58102:3000" #security update, from '58102:3000'
-    env_file:
-      - .env.development
-    environment:
-      - SKIP_MIGRATIONS=true
-    depends_on:
-      migrate:
-        condition: service_completed_successfully
+    helldiversbot:
+        container_name: helldiversbot
+        # this isn't neccesary, the dockerfile entrypoint takes care of that
+        # init: true # replaces manually installing and using tini in the docker file.
+        restart: unless-stopped
+        platform: linux/amd64
+        image: ghcr.io/elfensky/helldiversbot:staging
+        ports:
+            - '127.0.0.1:58102:3000' #security update, from '58102:3000'
+        env_file:
+            - .env.development
+        depends_on:
+            migrate:
+                condition: service_completed_successfully
 
-    # security
-    # security_opt:
-    #     - no-new-privileges:true # Prevents privilege escalation
-    #     - apparmor:docker-default # Mandatory Access Control
-    #     - seccomp=default # System call filtering
-    # cap_drop:
-    #     - ALL
+        # security
+        # security_opt:
+        #     - no-new-privileges:true # Prevents privilege escalation
+        #     - apparmor:docker-default # Mandatory Access Control
+        #     - seccomp=default # System call filtering
+        # cap_drop:
+        #     - ALL
 
-    # monitoring
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/healthcheck"]
-      interval: 60s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+        # monitoring
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/healthcheck']
+            interval: 60s
+            timeout: 10s
+            retries: 3
+            start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,39 @@
 services:
-    migrate:
-        container_name: helldiversbot-migrate
-        platform: linux/amd64
-        image: ghcr.io/elfensky/helldiversbot-migrate:staging
-        env_file:
-            - .env.development
-        # Runs migrations and exits
+  migrate:
+    container_name: helldiversbot-migrate
+    platform: linux/amd64
+    image: ghcr.io/elfensky/helldiversbot-migrate:staging
+    env_file:
+      - .env.development
+    # Runs migrations and exits
 
-    helldiversbot:
-        container_name: helldiversbot
-        # this isn't neccesary, the dockerfile entrypoint takes care of that
-        # init: true # replaces manually installing and using tini in the docker file.
-        restart: unless-stopped
-        platform: linux/amd64
-        image: ghcr.io/elfensky/helldiversbot:staging
-        ports:
-            - '127.0.0.1:58102:3000' #security update, from '58102:3000'
-        env_file:
-            - .env.development
-        depends_on:
-            migrate:
-                condition: service_completed_successfully
+  helldiversbot:
+    container_name: helldiversbot
+    # this isn't neccesary, the dockerfile entrypoint takes care of that
+    # init: true # replaces manually installing and using tini in the docker file.
+    restart: unless-stopped
+    platform: linux/amd64
+    image: ghcr.io/elfensky/helldiversbot:staging
+    ports:
+      - "127.0.0.1:50001:3000" #security update, from '58102:3000'
+    env_file:
+      - .env.development
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
 
-        # security
-        # security_opt:
-        #     - no-new-privileges:true # Prevents privilege escalation
-        #     - apparmor:docker-default # Mandatory Access Control
-        #     - seccomp=default # System call filtering
-        # cap_drop:
-        #     - ALL
+    # security
+    # security_opt:
+    #     - no-new-privileges:true # Prevents privilege escalation
+    #     - apparmor:docker-default # Mandatory Access Control
+    #     - seccomp=default # System call filtering
+    # cap_drop:
+    #     - ALL
 
-        # monitoring
-        healthcheck:
-            test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/healthcheck']
-            interval: 60s
-            timeout: 10s
-            retries: 3
-            start_period: 10s
+    # monitoring
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/healthcheck"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -35,13 +35,16 @@ const inter = Inter({
 //     }
 // }
 
+export const viewport = {
+    themeColor: '#282828',
+};
+
 export const metadata = {
     metadataBase: new URL('https://helldivers.bot'),
     title: 'Helldivers Bot - Live war dashboard for the original Helldivers',
     description:
         'Live Helldivers 1 war dashboard showing campaign progress, faction stats, active events, and an interactive galaxy map.',
     manifest: '/site.webmanifest',
-    themeColor: '#282828',
     appleWebApp: {
         capable: true,
         statusBarStyle: 'black-translucent',

--- a/src/shared/utils/sse/sseManager.mjs
+++ b/src/shared/utils/sse/sseManager.mjs
@@ -46,9 +46,9 @@ class SSEManager {
         this.listener = new pg.Client({
             connectionString: process.env.POSTGRES_URL,
             ssl:
-                process.env.NODE_ENV === 'production' ?
-                    { rejectUnauthorized: true }
-                :   false,
+                process.env.POSTGRES_SSL === 'false' ?
+                    false
+                :   { rejectUnauthorized: true },
         });
 
         await this.listener.connect();

--- a/src/update/notifyClient.mjs
+++ b/src/update/notifyClient.mjs
@@ -8,7 +8,7 @@ async function getClient() {
 
     client = new pg.Client({
         connectionString: process.env.POSTGRES_URL,
-        ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: true } : false,
+        ssl: process.env.POSTGRES_SSL === 'false' ? false : { rejectUnauthorized: true },
     });
 
     const { error } = await tryCatch(client.connect());


### PR DESCRIPTION
## Summary
- Decouple Postgres SSL from `NODE_ENV` — new `POSTGRES_SSL` env var controls SSL independently of build mode
- Add `platform: linux/amd64` to `docker-compose.yml` for ARM Mac compatibility
- Fix README Docker build tags (`:local` → `:staging`)
- Move `themeColor` from `metadata` to `viewport` export (Next.js 16 requirement)
- Remove unused `SKIP_MIGRATIONS` env var
- Remove Prettier formatting check from CI
- Normalize docker-compose indentation, update host port

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (631 tests)
- [ ] `docker compose pull` succeeds on ARM Mac
- [ ] Docker container connects to non-SSL Postgres with `POSTGRES_SSL=false`
- [ ] No `themeColor` warnings in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)