### PR TITLE
feat: comprehensive Umami analytics expansion with ad-blocker bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **App version in footer** — shows package version, short commit SHA, and commit message in footer and dev console (auto-generated at build time by `next.config.mjs`)
 - **Catch-up toasts for active events** — show an "in progress" toast on page load when defend/attack events are already active (#LiveToasts)
 - **Push notification improvements** — add `badge` (favicon PNG), per-event `tag` grouping, and `renotify` for status changes; fix icon fallback from SVG to raster; precache badge in service worker shell assets
+- **Umami analytics expansion** — comprehensive Level 2 feature engagement tracking with ad-blocker bypass via same-origin proxy (`/api/umami`), `useTrack` hook for dynamic interactions, `umami.identify()` for authenticated users, and `category-action` event naming convention across ~40 tracked elements
 - **GlitchTip error tracking** — migrate from BugSink to GlitchTip with client tunnel (`/api/glitchtip`) to bypass ad blockers, CSP violation reporting via `report-uri`, and `environment` tagging to split dev/prod issues
 - **Error boundaries** — route-level (`error.jsx` at root + archives) and component-level (`ComponentErrorBoundary` wrapping Galaxy Map, Regions, Stats, Timeline) for graceful degradation
 - **Custom API docs** — replace SwaggerUI with lightweight server-rendered API documentation page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,19 @@ if (error) {
 - Use `errorResponse(code, start, error)` and `successResponse(code, start, data)` from `src/utils/responses.mjs`
 - Measure execution time with `roundedPerformanceTime(start)` from `src/utils/time.mjs`
 
+### Analytics Tracking
+
+Every interactive element (links, buttons, nav items) must have Umami tracking. Use `category-action` naming:
+
+- **`data-umami-event="category-action"`** for simple clicks (nav links, buttons, toggles). Preferred — the tracker script handles it automatically.
+- **`useTrack()` hook** for dynamic interactions where event name or data depends on state (e.g., `track('faction-tab-switch', { faction: id })`).
+- **`window.umami?.track()`** inside `useEffect` callbacks where hooks can't be called.
+- **`sendUmamiEvent()`** for server-side API route tracking (called inside `after()` to avoid blocking responses).
+
+Categories: `nav`, `auth`, `footer`, `docs`, `diagram`, `faction`, `archive`, `notification`, `push`, `sw`, `toast`, `dashboard`, `api`.
+
+When adding a new interactive element, always add a `data-umami-event` attribute. When adding a new API route that serves external consumers, add a server-side `umamiTrackEvent` call.
+
 ### Validation
 
 All external data validated with Zod schemas (`src/validators/`) before database operations.
@@ -125,6 +138,7 @@ All visual properties use CSS custom properties from `src/styles/tokens.css`, in
 - **On-demand season fetching:** `/archives` page derives SeasonSelector from current season number (not DB query). Missing seasons fetched from official API on first request via `fetchAndSeedSeason()` (`src/db/queries/fetchAndSeedSeason.mjs`).
 - **SSE live updates:** Worker polls API → DB write → `pg NOTIFY campaign_update` → SSE manager (`src/shared/utils/sse/sseManager.mjs`) broadcasts full campaign state via `/api/h1/stream` → `useLiveData` hook (`src/shared/hooks/useLiveData.mjs`) replaces React state. Postgres LISTEN/NOTIFY bridges worker thread and Next.js process (Prisma doesn't support LISTEN/NOTIFY — uses dedicated `pg.Client`).
 - **Notifications:** `detectChanges()` (`src/shared/utils/game/detectChanges.mjs`) detects event transitions (started/won/lost) on both client (Sonner toasts + Web Notifications) and server (push via `web-push`). `LiveToasts` also shows catch-up toasts for active events on page load. The Sonner `<Toaster>` is co-located inside `LiveToasts` (not root layout) to share the same module singleton — rendering it from a server component creates a separate `ToastState`. Single "Enable notifications" button enables both web and push. Push subscriptions stored in `push_subscription` table.
+- **Analytics:** Umami v3 (self-hosted, cookieless). Three tracking layers: (1) `data-umami-event` HTML attributes for click tracking — the tracker script captures these automatically; (2) `useTrack` hook (`src/shared/hooks/useTrack.mjs`) or `window.umami?.track()` for dynamic JS interactions; (3) `sendUmamiEvent()` (`src/shared/utils/umami.mjs`) for server-side API route tracking. Client-side tracker posts through same-origin proxy (`/api/umami` route, `/api/send` rewrite) to bypass ad blockers. Authenticated users identified via `umami.identify()` in `UserSection.jsx`. Production-only — no tracking in dev/test.
 - **PWA:** Service worker (`public/sw.js`) caches app shell, handles push events. Last SSE payload cached in localStorage for offline fallback.
 
 ## Architecture — Frontend Layout

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -65,6 +65,10 @@ const nextConfig = {
                 source: '/stats.js',
                 destination: 'https://umami.drunik.be/script.js',
             },
+            {
+                source: '/api/send',
+                destination: '/api/umami',
+            },
         ];
     },
     async headers() {

--- a/src/__tests__/unit/routes/umami-proxy.test.mjs
+++ b/src/__tests__/unit/routes/umami-proxy.test.mjs
@@ -1,0 +1,69 @@
+import { vi } from 'vitest';
+
+// Stub env before importing the route
+vi.stubEnv('UMAMI_SITE_URL', 'analytics.example.com');
+
+const { POST } = await import('@/app/api/umami/route');
+
+describe('POST /api/umami', () => {
+    let originalFetch;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        global.fetch = vi.fn(() =>
+            Promise.resolve(new Response('ok', { status: 200 })),
+        );
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    test('forwards body and headers to Umami', async () => {
+        const body = JSON.stringify({ type: 'event', payload: { url: '/' } });
+        const request = new Request('http://localhost:3000/api/umami', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'User-Agent': 'TestBrowser/1.0',
+                'X-Forwarded-For': '1.2.3.4',
+            },
+            body,
+        });
+
+        const response = await POST(request);
+
+        expect(global.fetch).toHaveBeenCalledOnce();
+        const [url, options] = global.fetch.mock.calls[0];
+        expect(url).toBe('https://analytics.example.com/api/send');
+        expect(options.method).toBe('POST');
+        expect(options.headers['Content-Type']).toBe('application/json');
+        expect(options.headers['User-Agent']).toBe('TestBrowser/1.0');
+        expect(options.headers['X-Forwarded-For']).toBe('1.2.3.4');
+        expect(options.body).toBe(body);
+        expect(response.status).toBe(200);
+    });
+
+    test('returns 405 for non-POST methods', async () => {
+        const request = new Request('http://localhost:3000/api/umami', {
+            method: 'GET',
+        });
+
+        const { GET } = await import('@/app/api/umami/route');
+        const response = await GET(request);
+        expect(response.status).toBe(405);
+    });
+
+    test('returns 502 when Umami is unreachable', async () => {
+        global.fetch = vi.fn(() => Promise.reject(new Error('Connection refused')));
+
+        const request = new Request('http://localhost:3000/api/umami', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        });
+
+        const response = await POST(request);
+        expect(response.status).toBe(502);
+    });
+});

--- a/src/__tests__/unit/shared/components/Auth.test.jsx
+++ b/src/__tests__/unit/shared/components/Auth.test.jsx
@@ -21,10 +21,10 @@ describe('SignIn', () => {
         expect(link).toHaveAttribute('href', '/sign-in');
     });
 
-    test('link has data-umami-event="header-signin"', () => {
+    test('link has data-umami-event="auth-signin"', () => {
         render(<SignIn />);
         const link = screen.getByRole('link', { name: 'Sign In' });
-        expect(link).toHaveAttribute('data-umami-event', 'header-signin');
+        expect(link).toHaveAttribute('data-umami-event', 'auth-signin');
     });
 });
 
@@ -34,9 +34,9 @@ describe('SignOut', () => {
         expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
     });
 
-    test('button has data-umami-event="header-signout"', () => {
+    test('button has data-umami-event="auth-signout"', () => {
         render(<SignOut />);
         const button = screen.getByRole('button', { name: 'Sign Out' });
-        expect(button).toHaveAttribute('data-umami-event', 'header-signout');
+        expect(button).toHaveAttribute('data-umami-event', 'auth-signout');
     });
 });

--- a/src/__tests__/unit/shared/hooks/useTrack.test.mjs
+++ b/src/__tests__/unit/shared/hooks/useTrack.test.mjs
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTrack } from '@/shared/hooks/useTrack.mjs';
+
+describe('useTrack', () => {
+    afterEach(() => {
+        delete window.umami;
+    });
+
+    test('calls window.umami.track when available', () => {
+        window.umami = { track: vi.fn() };
+        const { result } = renderHook(() => useTrack());
+
+        result.current('test-event', { key: 'value' });
+
+        expect(window.umami.track).toHaveBeenCalledWith('test-event', { key: 'value' });
+    });
+
+    test('no-ops silently when window.umami is not available', () => {
+        const { result } = renderHook(() => useTrack());
+
+        // Should not throw
+        expect(() => result.current('test-event')).not.toThrow();
+    });
+
+    test('no-ops silently when called without data', () => {
+        window.umami = { track: vi.fn() };
+        const { result } = renderHook(() => useTrack());
+
+        result.current('test-event');
+
+        expect(window.umami.track).toHaveBeenCalledWith('test-event', undefined);
+    });
+});

--- a/src/app/api/h1/campaign/route.js
+++ b/src/app/api/h1/campaign/route.js
@@ -21,7 +21,7 @@ export async function GET(request) {
         const data = {
             ms: roundedPerformanceTime(start),
         };
-        await umamiTrackEvent('API | Campaign', '/api/h1/campaign', 'campaign', data);
+        await umamiTrackEvent('API | Campaign', '/api/h1/campaign', 'api-campaign', data);
     });
     let data = null;
     let season = null;

--- a/src/app/api/h1/rebroadcast/route.js
+++ b/src/app/api/h1/rebroadcast/route.js
@@ -77,7 +77,7 @@ export async function POST(request) {
         await umamiTrackEvent(
             'API | Rebroadcast',
             '/api/h1/rebroadcast',
-            'rebroadcast',
+            'api-rebroadcast',
             data,
         );
     });

--- a/src/app/api/h1/stream/route.js
+++ b/src/app/api/h1/stream/route.js
@@ -1,5 +1,7 @@
 import sseManager from '@/shared/utils/sse/sseManager';
 import { methodNotAllowed } from '@/shared/utils/api/methodNotAllowed';
+import { after } from 'next/server';
+import { umamiTrackEvent } from '@/shared/utils/umami';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -15,6 +17,10 @@ function getClientIp(request) {
 export async function GET(request) {
     // Initialize SSE manager on first request
     await sseManager.init();
+
+    after(async () => {
+        await umamiTrackEvent('API | Stream', '/api/h1/stream', 'api-sse-connect');
+    });
 
     if (!sseManager.healthy) {
         return new Response('SSE service unavailable', { status: 503 });

--- a/src/app/api/umami/route.js
+++ b/src/app/api/umami/route.js
@@ -1,5 +1,16 @@
 import { methodNotAllowed } from '@/shared/utils/api/methodNotAllowed';
 
+/**
+ * Same-origin proxy for Umami analytics. The client-side tracker script
+ * POSTs to /api/send (rewritten to /api/umami in next.config.mjs), and
+ * this route forwards the request to the self-hosted Umami instance.
+ *
+ * This bypasses ad blockers because the browser only sees first-party
+ * requests — no external domain in script-src or connect-src.
+ *
+ * X-Forwarded-For is forwarded so Umami can use the real client IP
+ * for its cookieless session hash (IP + UA + hostname).
+ */
 export async function POST(request) {
     const body = await request.text();
     const umamiUrl = `https://${process.env.UMAMI_SITE_URL}/api/send`;

--- a/src/app/api/umami/route.js
+++ b/src/app/api/umami/route.js
@@ -1,0 +1,37 @@
+import { methodNotAllowed } from '@/shared/utils/api/methodNotAllowed';
+
+export async function POST(request) {
+    const body = await request.text();
+    const umamiUrl = `https://${process.env.UMAMI_SITE_URL}/api/send`;
+
+    const headers = {
+        'Content-Type': request.headers.get('content-type') || 'application/json',
+        'User-Agent': request.headers.get('user-agent') || '',
+    };
+
+    const forwarded = request.headers.get('x-forwarded-for');
+    if (forwarded) {
+        headers['X-Forwarded-For'] = forwarded;
+    }
+
+    try {
+        const upstream = await fetch(umamiUrl, {
+            method: 'POST',
+            headers,
+            body,
+        });
+
+        return new Response(await upstream.text(), {
+            status: upstream.status,
+            headers: { 'Content-Type': 'text/plain' },
+        });
+    } catch {
+        return new Response('Bad Gateway', { status: 502 });
+    }
+}
+
+export const GET = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const DELETE = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const OPTIONS = methodNotAllowed;

--- a/src/app/docs/components/DocsSidebar.jsx
+++ b/src/app/docs/components/DocsSidebar.jsx
@@ -8,18 +8,18 @@ const sections = [
     {
         label: 'General',
         items: [
-            { href: '/docs', label: 'Overview' },
-            { href: '/docs/about', label: 'About' },
-            { href: '/docs/faq', label: 'FAQ' },
+            { href: '/docs', label: 'Overview', track: 'docs-overview' },
+            { href: '/docs/about', label: 'About', track: 'docs-about' },
+            { href: '/docs/faq', label: 'FAQ', track: 'docs-faq' },
         ],
     },
     {
         label: 'Technical',
         items: [
-            { href: '/docs/architecture', label: 'Architecture' },
-            { href: '/docs/notifications', label: 'Notifications' },
-            { href: '/docs/api', label: 'API Reference' },
-            { href: '/docs/brandkit', label: 'Brand Kit' },
+            { href: '/docs/architecture', label: 'Architecture', track: 'docs-architecture' },
+            { href: '/docs/notifications', label: 'Notifications', track: 'docs-notifications' },
+            { href: '/docs/api', label: 'API Reference', track: 'docs-api' },
+            { href: '/docs/brandkit', label: 'Brand Kit', track: 'docs-brandkit' },
         ],
     },
 ];
@@ -43,6 +43,7 @@ export default function DocsSidebar() {
             {/* Mobile breadcrumb bar */}
             <button
                 onClick={() => setOpen(!open)}
+                data-umami-event="docs-sidebar-toggle"
                 className="flex w-full items-center gap-2 border-b border-outline-variant bg-surface-1 px-4 py-3 text-body lg:hidden"
             >
                 <span className="text-text-muted">Docs /</span>
@@ -101,6 +102,7 @@ function SidebarContent({ pathname, onNavigate }) {
                                 key={item.href}
                                 href={item.href}
                                 prefetch={false}
+                                data-umami-event={item.track}
                                 onClick={onNavigate}
                                 className={`block border-l-2 px-4 py-1.5 text-body ${
                                     isActive ?

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -231,7 +231,6 @@ export default async function RootLayout({ children }) {
                         src="/stats.js"
                         data-website-id="9a916711-2868-43d2-9932-964fc9528824"
                         strategy="afterInteractive"
-                        data-host-url="https://umami.drunik.be"
                     />
                 :   null}
             </body>

--- a/src/app/not-found.jsx
+++ b/src/app/not-found.jsx
@@ -11,7 +11,7 @@ export default function NotFound() {
                 This area has been classified by Super Earth High Command. It either never
                 existed, or has been redacted for your safety.
             </p>
-            <Link href="/" prefetch={false} className="text-primary hover:underline">
+            <Link href="/" prefetch={false} data-umami-event="nav-404-home" className="text-primary hover:underline">
                 Return to Managed Democracy →
             </Link>
         </div>

--- a/src/app/sign-in/page.jsx
+++ b/src/app/sign-in/page.jsx
@@ -10,6 +10,7 @@ export default function SignInPage() {
                 <button
                     className="flex w-64 cursor-pointer items-center justify-center gap-3 px-6 py-3 text-white transition-opacity hover:opacity-90 active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
                     style={{ backgroundColor: '#5865F2' }}
+                    data-umami-event="auth-signin-discord"
                     onClick={() => signIn('discord', { callbackURL: '/dashboard' })}
                 >
                     <svg width="20" height="15" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -20,6 +21,7 @@ export default function SignInPage() {
                 <button
                     className="flex w-64 cursor-pointer items-center justify-center gap-3 px-6 py-3 text-white transition-opacity hover:opacity-90 active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
                     style={{ backgroundColor: '#24292e' }}
+                    data-umami-event="auth-signin-github"
                     onClick={() => signIn('github', { callbackURL: '/dashboard' })}
                 >
                     <svg width="20" height="20" viewBox="0 0 98 96" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/features/dashboard/DashboardClient.jsx
+++ b/src/features/dashboard/DashboardClient.jsx
@@ -132,6 +132,7 @@ export default function DashboardClient() {
             </div>
             <button
                 className="dashboard-scroll-hint"
+                data-umami-event="dashboard-scroll-to-log"
                 onClick={() =>
                     document
                         .getElementById('event-log')

--- a/src/features/dashboard/FactionTabs.jsx
+++ b/src/features/dashboard/FactionTabs.jsx
@@ -1,5 +1,6 @@
 'use client';
 import './FactionTabs.css';
+import { useTrack } from '@/shared/hooks/useTrack.mjs';
 
 const TABS = [
     { id: 'global', label: 'Global', icon: '/icons/faction3.webp' },
@@ -9,13 +10,17 @@ const TABS = [
 ];
 
 export default function FactionTabs({ active, onChange }) {
+    const track = useTrack();
     return (
         <div className="faction-tabs">
             {TABS.map(({ id, label, icon }) => (
                 <button
                     key={id}
                     className={`faction-tab ${active === id ? 'active' : ''}`}
-                    onClick={() => onChange(id)}
+                    onClick={() => {
+                        onChange(id);
+                        track('faction-tab-switch', { faction: id });
+                    }}
                     aria-label={label}
                 >
                     <img src={icon} alt="" className="faction-tab-icon" />

--- a/src/features/dashboard/SeasonSelector.jsx
+++ b/src/features/dashboard/SeasonSelector.jsx
@@ -1,9 +1,11 @@
 'use client';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTrack } from '@/shared/hooks/useTrack.mjs';
 
 export default function SeasonSelector({ seasons, currentSeason }) {
     const router = useRouter();
+    const track = useTrack();
 
     // Sync URL with resolved season so the link is shareable.
     // Defers via requestIdleCallback (with setTimeout fallback) to avoid
@@ -36,7 +38,11 @@ export default function SeasonSelector({ seasons, currentSeason }) {
         <nav>
             <select
                 value={currentSeason}
-                onChange={(e) => router.push(`/archives?season=${e.target.value}`)}
+                onChange={(e) => {
+                    const season = e.target.value;
+                    router.push(`/archives?season=${season}`);
+                    track('archive-season-select', { season: Number(season) });
+                }}
                 className="rounded bg-white/10 px-3 py-2 text-body text-white accent-primary hover:bg-white/20"
             >
                 {seasons.map((s) => (

--- a/src/features/notifications/LiveToasts.jsx
+++ b/src/features/notifications/LiveToasts.jsx
@@ -83,6 +83,9 @@ export default function LiveToasts({ prevData, data, isLeader }) {
                 const color = FACTION_COLORS[event.enemy];
                 toast(label, { duration: 8000, style: TOAST_STYLE(color) });
             }
+            if (window.umami) {
+                window.umami.track('toast-catch-up', { count: activeEvents.length });
+            }
         }, 50);
 
         return () => clearTimeout(timer);

--- a/src/features/notifications/NotificationFlowDiagram.jsx
+++ b/src/features/notifications/NotificationFlowDiagram.jsx
@@ -418,6 +418,7 @@ export default function NotificationFlowDiagram() {
                     <button
                         key={view.key}
                         className={v === view.key ? 'active' : ''}
+                        data-umami-event={`diagram-notification-${view.key}`}
                         onClick={() => setActiveView(view.key)}
                     >
                         {view.label}

--- a/src/features/notifications/NotificationToggle.jsx
+++ b/src/features/notifications/NotificationToggle.jsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useTrack } from '@/shared/hooks/useTrack.mjs';
 
 function urlBase64ToUint8Array(base64String) {
     const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -49,6 +50,7 @@ async function unsubscribeFromPush() {
 export default function NotificationToggle() {
     const [state, setState] = useState('loading'); // loading | unsupported | denied | enabled | disabled
     const [busy, setBusy] = useState(false);
+    const track = useTrack();
 
     useEffect(() => {
         if (typeof Notification === 'undefined') {
@@ -96,8 +98,12 @@ export default function NotificationToggle() {
         setBusy(true);
         const permission = await Notification.requestPermission();
         if (permission === 'granted') {
+            track('notification-enable');
             await subscribeToPush();
+            track('push-subscribe');
             setState('enabled');
+        } else if (permission === 'denied') {
+            track('notification-permission-denied');
         }
         setBusy(false);
     }
@@ -105,6 +111,8 @@ export default function NotificationToggle() {
     async function disable() {
         setBusy(true);
         await unsubscribeFromPush();
+        track('notification-disable');
+        track('push-unsubscribe');
         setState('disabled');
         setBusy(false);
     }

--- a/src/features/notifications/NotificationToggle.jsx
+++ b/src/features/notifications/NotificationToggle.jsx
@@ -86,6 +86,7 @@ export default function NotificationToggle() {
             <Link
                 href="/docs/faq"
                 prefetch={false}
+                data-umami-event="notification-faq"
                 className="font-mono text-small text-[var(--color-text-muted)] opacity-50 hover:opacity-80"
                 title="How to enable notifications"
             >

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -6,11 +6,11 @@ export function proxy(request) {
 
     const csp = [
         "default-src 'self'",
-        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://umami.drunik.be https://static.cloudflareinsights.com${isDev ? " 'unsafe-eval'" : ''}`,
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://static.cloudflareinsights.com${isDev ? " 'unsafe-eval'" : ''}`,
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: https://authjs.dev https://cdn.discordapp.com https://avatars.githubusercontent.com https://www.gravatar.com",
         "font-src 'self'",
-        "connect-src 'self' https://umami.drunik.be https://cloudflareinsights.com",
+        "connect-src 'self' https://cloudflareinsights.com",
         "form-action 'self'",
         "frame-ancestors 'none'",
         "base-uri 'self'",

--- a/src/shared/components/Auth/Auth.jsx
+++ b/src/shared/components/Auth/Auth.jsx
@@ -11,7 +11,7 @@ export function SignIn({ className }) {
         <Link
             href="/sign-in"
             className={`header-nav-link ${className ?? ''}`}
-            data-umami-event="header-signin"
+            data-umami-event="auth-signin"
         >
             Sign In
         </Link>
@@ -24,7 +24,7 @@ export function SignOut() {
         <button
             type="button"
             className="header-nav-link cursor-pointer"
-            data-umami-event="header-signout"
+            data-umami-event="auth-signout"
             onClick={() => signOut()}
         >
             Sign Out

--- a/src/shared/components/BottomNav/BottomNav.jsx
+++ b/src/shared/components/BottomNav/BottomNav.jsx
@@ -7,14 +7,14 @@ import StatusDot from '@/shared/components/StatusDot';
 export default function BottomNav() {
     const pathname = usePathname();
     const tabs = [
-        { href: '/', label: 'Live', live: true },
-        { href: '/archives', label: 'Archives', icon: '◈' },
-        { href: '/docs', label: 'Docs', icon: '◇' },
+        { href: '/', label: 'Live', live: true, track: 'nav-live' },
+        { href: '/archives', label: 'Archives', icon: '◈', track: 'nav-archives' },
+        { href: '/docs', label: 'Docs', icon: '◇', track: 'nav-docs' },
     ];
 
     return (
         <nav className="bottom-nav">
-            {tabs.map(({ href, label, icon, live }) => {
+            {tabs.map(({ href, label, icon, live, track }) => {
                 const isActive =
                     href === '/' ? pathname === '/' : pathname.startsWith(href);
                 return (
@@ -22,6 +22,7 @@ export default function BottomNav() {
                         key={href}
                         href={href}
                         prefetch={false}
+                        data-umami-event={track}
                         className={`bottom-nav-tab ${isActive ? 'active' : ''}`}
                     >
                         <span className="bottom-nav-icon">

--- a/src/shared/components/DataFlowDiagram/DataFlowDiagram.jsx
+++ b/src/shared/components/DataFlowDiagram/DataFlowDiagram.jsx
@@ -255,6 +255,7 @@ export default function DataFlowDiagram() {
                     <button
                         key={view.key}
                         className={activeView === view.key ? 'active' : ''}
+                        data-umami-event={`diagram-dataflow-${view.key}`}
                         onClick={() => setActiveView(view.key)}
                     >
                         {view.label}

--- a/src/shared/components/Footer/Footer.jsx
+++ b/src/shared/components/Footer/Footer.jsx
@@ -22,6 +22,7 @@ export default function Footer() {
                             href="https://lavrenov.io"
                             target="_blank"
                             rel="noopener noreferrer"
+                            data-umami-event="footer-portfolio"
                         >
                             Andrei Lavrenov
                         </a>
@@ -30,6 +31,7 @@ export default function Footer() {
                         href="https://ko-fi.com/H2H610Q1K"
                         target="_blank"
                         rel="noopener noreferrer"
+                        data-umami-event="footer-kofi"
                     >
                         <Image
                             src="/images/kofi.webp"
@@ -45,17 +47,17 @@ export default function Footer() {
                     <div className="footer-section-label">Features</div>
                     <ul className="footer-links">
                         <li>
-                            <Link href="/" prefetch={false} className="footer-link">
+                            <Link href="/" prefetch={false} data-umami-event="footer-campaign" className="footer-link">
                                 Campaign
                             </Link>
                         </li>
                         <li>
-                            <Link href="/archives" prefetch={false} className="footer-link">
+                            <Link href="/archives" prefetch={false} data-umami-event="footer-archives" className="footer-link">
                                 Archives
                             </Link>
                         </li>
                         <li>
-                            <Link href="/docs" prefetch={false} className="footer-link">
+                            <Link href="/docs" prefetch={false} data-umami-event="footer-docs" className="footer-link">
                                 Docs
                             </Link>
                         </li>
@@ -71,6 +73,7 @@ export default function Footer() {
                                 className="footer-link"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                data-umami-event="footer-discord"
                             >
                                 Helldivers Discord
                             </a>
@@ -81,6 +84,7 @@ export default function Footer() {
                                 className="footer-link"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                data-umami-event="footer-github"
                             >
                                 Github
                             </a>
@@ -91,6 +95,7 @@ export default function Footer() {
                                 className="footer-link"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                data-umami-event="footer-twitter"
                             >
                                 Twitter
                             </a>
@@ -101,6 +106,7 @@ export default function Footer() {
                                 className="footer-link"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                data-umami-event="footer-bugs"
                             >
                                 Report Bugs
                             </a>

--- a/src/shared/components/Header/Header.jsx
+++ b/src/shared/components/Header/Header.jsx
@@ -32,7 +32,7 @@ function Logo() {
         <Link
             href="/"
             prefetch={false}
-            data-umami-event={'header-home'}
+            data-umami-event="nav-home"
             aria-label="Go to homepage"
             className="z-50 flex flex-row items-center justify-center gap-2 text-h2 font-bold"
         >

--- a/src/shared/components/Navigation/HeaderNav.jsx
+++ b/src/shared/components/Navigation/HeaderNav.jsx
@@ -4,9 +4,9 @@ import { usePathname } from 'next/navigation';
 import StatusDot from '@/shared/components/StatusDot';
 
 const tabs = [
-    { href: '/', label: 'Live', live: true },
-    { href: '/archives', label: 'Archives' },
-    { href: '/docs', label: 'Docs' },
+    { href: '/', label: 'Live', live: true, track: 'nav-live' },
+    { href: '/archives', label: 'Archives', track: 'nav-archives' },
+    { href: '/docs', label: 'Docs', track: 'nav-docs' },
 ];
 
 export default function HeaderNav() {
@@ -14,7 +14,7 @@ export default function HeaderNav() {
 
     return (
         <div className="hidden items-center gap-3 md:flex">
-            {tabs.map(({ href, label, live }) => {
+            {tabs.map(({ href, label, live, track }) => {
                 const isActive =
                     href === '/' ? pathname === '/' : pathname.startsWith(href);
                 return (
@@ -22,6 +22,7 @@ export default function HeaderNav() {
                         key={href}
                         href={href}
                         prefetch={false}
+                        data-umami-event={track}
                         className={`header-nav-link ${isActive ? 'header-nav-link--active' : ''}`}
                     >
                         {live && <StatusDot />}

--- a/src/shared/components/Navigation/Navigation.jsx
+++ b/src/shared/components/Navigation/Navigation.jsx
@@ -12,7 +12,7 @@ export default function Navigation() {
                 <Link
                     href="https://status.helldivers.bot"
                     prefetch={false}
-                    data-umami-event="header-status"
+                    data-umami-event="nav-status"
                     title="Status"
                     aria-label="Status"
                     className="flex items-center opacity-70 transition-[opacity,transform] hover:opacity-100 active:scale-95"
@@ -37,7 +37,7 @@ export default function Navigation() {
                 <Link
                     href="https://github.com/elfensky/helldivers1api"
                     prefetch={false}
-                    data-umami-event="header-github"
+                    data-umami-event="nav-github"
                     aria-label="GitHub"
                     className="flex items-center opacity-70 transition-[opacity,transform] hover:opacity-100 active:scale-95"
                 >

--- a/src/shared/components/Navigation/UserSection.jsx
+++ b/src/shared/components/Navigation/UserSection.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
@@ -13,6 +13,7 @@ export default function UserSection() {
     const isProfileActive = pathname.startsWith('/profile');
     const { data: session, isPending } = useSession();
     const [avatarUrl, setAvatarUrl] = useState(session?.user?.image ?? null);
+    const identifiedRef = useRef(false);
 
     useEffect(() => {
         if (session?.user && !session.user.image) {
@@ -21,6 +22,16 @@ export default function UserSection() {
             setAvatarUrl(session.user.image);
         }
     }, [session?.user?.image, session?.user?.email]);
+
+    useEffect(() => {
+        if (session?.user?.id && !identifiedRef.current && window.umami) {
+            identifiedRef.current = true;
+            const provider = session.user.image?.includes('discord') ? 'discord'
+                : session.user.image?.includes('github') ? 'github'
+                : 'unknown';
+            window.umami.identify(session.user.id, { provider });
+        }
+    }, [session?.user?.id, session?.user?.image]);
 
     if (isPending) {
         return <div className="user-section-skeleton" />;

--- a/src/shared/components/Navigation/UserSection.jsx
+++ b/src/shared/components/Navigation/UserSection.jsx
@@ -43,7 +43,7 @@ export default function UserSection() {
             <Link
                 href="/profile"
                 prefetch={false}
-                data-umami-event="header-profile"
+                data-umami-event="nav-profile"
                 className="flex items-center opacity-70 transition-[opacity,transform] hover:opacity-100 active:scale-95"
             >
                 <Image

--- a/src/shared/components/ServiceWorkerRegister.jsx
+++ b/src/shared/components/ServiceWorkerRegister.jsx
@@ -19,6 +19,9 @@ export default function ServiceWorkerRegister() {
             const waiting = registrationRef.current?.waiting;
             if (!waiting || updateTriggeredRef.current) return;
             updateTriggeredRef.current = true;
+            if (window.umami) {
+                window.umami.track('sw-update-reload');
+            }
             waiting.postMessage({ type: 'SKIP_WAITING' });
         }
 

--- a/src/shared/hooks/useTrack.mjs
+++ b/src/shared/hooks/useTrack.mjs
@@ -2,6 +2,20 @@
 
 import { useCallback } from 'react';
 
+/**
+ * Client-side Umami tracking hook. Returns a stable callback that
+ * calls `window.umami.track()` if the tracker script is loaded.
+ * Silently no-ops when blocked by ad blockers or in dev mode.
+ *
+ * For tracking inside useEffect callbacks (where hooks can't be called),
+ * use `window.umami?.track()` directly instead.
+ *
+ * @returns {(eventName: string, data?: object) => void}
+ *
+ * @example
+ * const track = useTrack();
+ * <button onClick={() => track('faction-tab-switch', { faction: 'bugs' })}>
+ */
 export function useTrack() {
     return useCallback((eventName, data) => {
         if (typeof window !== 'undefined' && window.umami) {

--- a/src/shared/hooks/useTrack.mjs
+++ b/src/shared/hooks/useTrack.mjs
@@ -1,0 +1,11 @@
+'use client';
+
+import { useCallback } from 'react';
+
+export function useTrack() {
+    return useCallback((eventName, data) => {
+        if (typeof window !== 'undefined' && window.umami) {
+            window.umami.track(eventName, data);
+        }
+    }, []);
+}

--- a/src/shared/utils/umami.mjs
+++ b/src/shared/utils/umami.mjs
@@ -1,3 +1,12 @@
+/**
+ * Server-side Umami event sender. Posts directly to the Umami instance
+ * (server-to-server, not subject to ad blockers). Production-only.
+ *
+ * Client-side tracking uses the Umami tracker script (loaded in layout.jsx)
+ * which posts through the same-origin proxy at /api/umami.
+ *
+ * @param {object} payload - Event payload (merged with defaults: website, hostname, screen, language)
+ */
 async function sendUmamiEvent(payload) {
     if (process.env.NODE_ENV !== 'production') return;
 
@@ -25,14 +34,32 @@ async function sendUmamiEvent(payload) {
         });
 }
 
+/**
+ * Track a server-side page view. Production-only; no-ops in dev/test.
+ * @param {string} title - Page title
+ * @param {string} url   - Page URL path
+ */
 export async function umamiTrackPage(title, url) {
     await sendUmamiEvent({ title, url });
 }
 
+/**
+ * Track a named server-side event with optional custom data.
+ * Production-only; no-ops in dev/test. Called from API routes via
+ * Next.js `after()` so analytics never blocks the response.
+ *
+ * Event names use `category-action` format: `api-campaign`, `api-rebroadcast`, `api-sse-connect`.
+ *
+ * @param {string} title  - Page title for Umami context
+ * @param {string} url    - Route path (e.g. '/api/h1/campaign')
+ * @param {string} name   - Event name in category-action format
+ * @param {object} [data] - Optional custom properties (e.g. { ms, season })
+ */
 export async function umamiTrackEvent(title, url, name, data = {}) {
     await sendUmamiEvent({ title, url, name, data });
 }
 
+/** Maps NODE_ENV to the site hostname for Umami's session hashing. */
 function getHostname() {
     switch (process.env.NODE_ENV) {
         case 'development':


### PR DESCRIPTION
## Summary

- **Same-origin analytics proxy** — `/api/umami` route + `/api/send` rewrite eliminates ad-blocker detection by routing all Umami traffic through the app's own domain. Removed `umami.drunik.be` from CSP entirely.
- **~40 tracked interactions** — every nav link, button, OAuth flow, docs sidebar, diagram toggle, footer link, and dashboard interaction now has `data-umami-event` or `umami.track()` coverage using `category-action` naming convention.
- **Authenticated user identification** — `umami.identify(userId, { provider })` in `UserSection.jsx` tags logged-in sessions for journey analysis. Anonymous visitors stay anonymous.
- **`useTrack` hook** — thin `useCallback` wrapper around `window.umami.track()` with safety guards for ad blockers / dev mode.
- **Documentation** — JSDoc on all analytics utilities, CLAUDE.md tracking conventions, wiki architecture docs, CHANGELOG entry.

## Test plan

- [x] 708 unit tests passing
- [x] Production build clean
- [ ] Manual: DevTools Network tab confirms tracker POSTs go to same-origin `/api/send`, not `umami.drunik.be`
- [ ] Manual: Click BottomNav/HeaderNav links → verify `nav-*` events in Umami dashboard
- [ ] Manual: Switch faction tab → verify `faction-tab-switch` with `{ faction }` data
- [ ] Manual: Sign in → verify `umami.identify()` call in Network tab
- [ ] Manual: Enable/disable notifications → verify `notification-*` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)