### PR TITLE
feat: migrate wiki docs to in-app /docs pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,16 +173,16 @@ For every phase or feature, use the `/superpowers:brainstorming` skill to explor
 
 ## Reference Docs
 
-> **Wiki local clone:** `../helldivers.bot.wiki` — edit locally, commit & push to update GitHub wiki.
-
-| Topic                              | Location                                                                                                                   |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Docker, CI/CD, init flow, env vars | [Wiki: Infrastructure](https://github.com/elfensky/helldivers.bot/wiki/Infrastructure)                                     |
-| Database schema & relationships    | [Wiki: Database-Schema](https://github.com/elfensky/helldivers.bot/wiki/Database-Schema)                                   |
-| Data pipeline & worker lifecycle   | [Wiki: Data-Flow](https://github.com/elfensky/helldivers.bot/wiki/Data-Flow)                                               |
-| API endpoints & authentication     | [Wiki: API-Reference](https://github.com/elfensky/helldivers.bot/wiki/API-Reference)                                       |
-| Utilities & Zod validators         | [Wiki: Utilities-Reference](https://github.com/elfensky/helldivers.bot/wiki/Utilities-Reference)                           |
-| Testing infrastructure             | [Wiki: Testing](https://github.com/elfensky/helldivers.bot/wiki/Testing)                                                   |
-| Real-time & notifications          | `/docs/notifications` (Mermaid diagram) + [Wiki: Real-Time](https://github.com/elfensky/helldivers.bot/wiki/Real-Time)     |
-| Data flow architecture             | `/docs/architecture` (Mermaid diagram) + [Wiki: Data-Flow](https://github.com/elfensky/helldivers.bot/wiki/Data-Flow)      |
-| Frontend design system & tokens    | `/docs/brandkit` (visual) + `src/app/layout.css`                                                                           |
+| Topic                              | Location                                         |
+| ---------------------------------- | ------------------------------------------------ |
+| Docker, CI/CD, init flow, env vars | `/docs/infrastructure`                           |
+| Database schema & relationships    | `/docs/database`                                 |
+| Data pipeline & worker lifecycle   | `/docs/data-flow`                                |
+| API endpoints & authentication     | `/docs/api`                                      |
+| Utilities & Zod validators         | `/docs/utilities`                                |
+| Testing infrastructure             | `/docs/testing`                                  |
+| Real-time & notifications          | `/docs/notifications`                            |
+| Data flow architecture             | `/docs/architecture` (Mermaid diagram)           |
+| Authentication & roles             | `/docs/authentication`                           |
+| Frontend design system & tokens    | `/docs/brandkit` (visual) + `src/app/layout.css` |
+| Official HD1 API reference         | `/docs/hd1-api`                                  |

--- a/src/app/docs/api/page.jsx
+++ b/src/app/docs/api/page.jsx
@@ -2,7 +2,7 @@ import { generateOpenApiSpec } from '@/shared/utils/api/openapi.registry';
 import EndpointCard from './EndpointCard';
 
 export const metadata = {
-    title: 'API Reference | Helldivers Bot',
+    title: 'Rebroadcast API | Helldivers Bot',
     description:
         'API documentation for the Helldivers Bot API — endpoints, request/response schemas, and authentication.',
     alternates: { canonical: '/docs/api' },
@@ -16,7 +16,7 @@ export default function ApiReferencePage() {
 
     return (
         <>
-            <h1 className="font-display text-primary">API Reference</h1>
+            <h1 className="font-display text-primary">Rebroadcast API</h1>
             <p className="mt-2 mb-6 leading-[1.7] text-text-muted">
                 Endpoint reference for the Helldivers Bot API. All responses follow a
                 standard envelope with{' '}
@@ -26,6 +26,80 @@ export default function ApiReferencePage() {
                 <code className="font-mono text-small text-text">data</code> /{' '}
                 <code className="font-mono text-small text-text">error</code> fields.
             </p>
+
+            <div className="mb-8 border border-ghost bg-surface-1 p-4">
+                <h2 className="mb-3 font-display text-h3 text-primary">
+                    Response Envelopes
+                </h2>
+                <div className="mb-4">
+                    <h3 className="mb-1 font-mono text-body text-text">
+                        Standard Envelope
+                    </h3>
+                    <p className="mb-2 text-body leading-[1.7] text-text-muted">
+                        Used by{' '}
+                        <code className="font-mono text-small text-text">
+                            /api/healthcheck
+                        </code>
+                        ,{' '}
+                        <code className="font-mono text-small text-text">
+                            /api/h1/campaign
+                        </code>
+                        ,{' '}
+                        <code className="font-mono text-small text-text">
+                            /api/h1/update
+                        </code>
+                        . The <code className="font-mono text-small text-text">time</code>{' '}
+                        field is elapsed milliseconds (floating-point). The{' '}
+                        <code className="font-mono text-small text-text">message</code>{' '}
+                        field is derived from the HTTP status code.
+                    </p>
+                    <pre className="overflow-x-auto bg-surface-2 p-3 font-mono text-small text-text">
+                        {`// Success
+{ "time": 42.5, "code": 200, "message": "OK", "data": { ... } }
+
+// Error
+{ "time": 42.5, "code": 400, "message": "Bad Request", "error": "details" }`}
+                    </pre>
+                </div>
+                <div className="mb-4">
+                    <h3 className="mb-1 font-mono text-body text-text">
+                        Rebroadcast Envelope
+                    </h3>
+                    <p className="mb-2 text-body leading-[1.7] text-text-muted">
+                        Used by{' '}
+                        <code className="font-mono text-small text-text">
+                            /api/h1/rebroadcast
+                        </code>{' '}
+                        error paths only. Mirrors the official HD1 API error format so
+                        proxy clients don&apos;t need to detect the error source.
+                        Successful rebroadcast responses return raw JSON directly.
+                    </p>
+                    <pre className="overflow-x-auto bg-surface-2 p-3 font-mono text-small text-text">
+                        {`{ "time": 1711234567, "error_code": 0, "error_message": "Invalid Content Type" }`}
+                    </pre>
+                </div>
+                <div>
+                    <h3 className="mb-1 font-mono text-body text-text">Authentication</h3>
+                    <p className="text-body leading-[1.7] text-text-muted">
+                        <code className="font-mono text-small text-text">
+                            /api/h1/rebroadcast
+                        </code>{' '}
+                        requires an API key via{' '}
+                        <code className="font-mono text-small text-text">
+                            Authorization: Bearer &lt;key&gt;
+                        </code>
+                        . Keys are managed from the user dashboard.{' '}
+                        <code className="font-mono text-small text-text">
+                            /api/h1/update
+                        </code>{' '}
+                        is internal (worker-only, Bearer token must match{' '}
+                        <code className="font-mono text-small text-text">UPDATE_KEY</code>
+                        ). All other endpoints are public.
+                    </p>
+                </div>
+            </div>
+
+            <h2 className="mb-3 font-display text-h3 text-primary">Endpoints</h2>
             <div className="flex flex-col gap-3">
                 {paths.map(([path, methods]) => (
                     <EndpointCard

--- a/src/app/docs/authentication/page.mdx
+++ b/src/app/docs/authentication/page.mdx
@@ -1,0 +1,268 @@
+export const metadata = {
+    title: 'Authentication | Helldivers Bot',
+    description: 'BetterAuth OAuth setup, sessions, roles, and API key authentication for helldivers.bot.',
+    alternates: { canonical: '/docs/authentication' },
+    openGraph: { url: '/docs/authentication' },
+};
+
+# Authentication
+
+**Library:** [BetterAuth](https://www.better-auth.com/) v1.5.6
+**Strategy:** OAuth-only (Discord + GitHub), database-backed sessions via Prisma adapter
+
+---
+
+## 1. Architecture
+
+Authentication is split across three files:
+
+### Server Configuration
+
+`src/auth.js`
+
+```js
+import { betterAuth } from 'better-auth';
+import { prismaAdapter } from 'better-auth/adapters/prisma';
+
+export const auth = betterAuth({
+    secret: process.env.BETTER_AUTH_SECRET,
+    baseURL: process.env.BETTER_AUTH_URL,
+    database: prismaAdapter(db, { provider: 'postgresql' }),
+    socialProviders: {
+        discord: { clientId: ..., clientSecret: ... },
+        github:  { clientId: ..., clientSecret: ... },
+    },
+    user: {
+        additionalFields: {
+            role: { type: 'string', defaultValue: 'user', input: false },
+        },
+    },
+});
+```
+
+Key points:
+- Prisma adapter connects to PostgreSQL (same `db` singleton used across the app)
+- `role` field added to `User` model as a custom BetterAuth field (not user-settable via input)
+- No email/password or magic link authentication configured
+
+### Client Utilities
+
+`src/auth-client.js`
+
+| Export       | Type     | Purpose                                              |
+| ------------ | -------- | ---------------------------------------------------- |
+| `authClient` | Object   | BetterAuth client instance from `createAuthClient()` |
+| `signIn`     | Function | `signIn(provider, options?)` — triggers OAuth flow. Default `callbackURL: '/profile'` |
+| `signOut`    | Function | Signs out and redirects to `/`                       |
+| `useSession` | Hook     | React hook for accessing session in client components |
+
+### Route Handler
+
+`src/app/api/auth/[...all]/route.js`
+
+```js
+import { toNextJsHandler } from 'better-auth/next-js';
+export const { GET, POST } = toNextJsHandler(auth);
+```
+
+Delegates all `/api/auth/*` requests to BetterAuth. Handles OAuth callbacks, session management, and sign-out.
+
+---
+
+## 2. Session Handling
+
+### Server-Side (Server Components & Server Actions)
+
+```js
+import { auth } from '@/auth';
+import { headers } from 'next/headers';
+
+const session = await auth.api.getSession({ headers: await headers() });
+// Returns: { user: { id, name, email, image, role, banned, ... }, session: { id, token, expiresAt, ... } }
+// Or: null (not authenticated)
+```
+
+Sessions are stored in the `Session` table with an opaque `token` field and `expiresAt` timestamp. BetterAuth manages session cookies automatically.
+
+### Client-Side (Client Components)
+
+```js
+'use client';
+import { useSession } from '@/auth-client';
+
+function MyComponent() {
+    const { data: session, isPending } = useSession();
+    // session?.user.name, session?.user.role, etc.
+}
+```
+
+### Session Revocation
+
+```js
+await auth.api.revokeSession({ headers: await headers() });
+```
+
+Used in the profile layout to revoke sessions for banned users.
+
+---
+
+## 3. Auth Guard Patterns
+
+### Layout Guard (Protected Routes)
+
+`src/app/profile/layout.jsx`
+
+```js
+const session = await auth.api.getSession({ headers: await headers() });
+
+if (!session || !session.user) {
+    redirect('/sign-in');
+}
+
+if (session.user.banned) {
+    await auth.api.revokeSession({ headers: await headers() });
+    redirect('/');
+}
+```
+
+All `/profile/*` routes are protected by this layout. Unauthenticated users are redirected to `/sign-in`. Banned users have their session revoked and are redirected to `/`.
+
+### Admin Guard (Server Actions)
+
+`src/db/queries/admin.mjs`
+
+```js
+async function requireAdmin() {
+    const session = await auth.api.getSession({ headers: await headers() });
+    if (!session || !session.user) return { error: 'Not authenticated' };
+    if (session.user.role !== 'admin') return { error: 'Forbidden' };
+    return { user: session.user };
+}
+```
+
+Used by all admin server actions (`getAllUsers`, `updateUserRole`, `toggleUserBan`, etc.). Returns `{ user }` on success or `{ error }` on failure.
+
+### Ownership Guard (Server Actions)
+
+`src/db/queries/account.mjs`, `src/db/queries/api.mjs`
+
+```js
+const session = await auth.api.getSession({ headers: await headers() });
+if (!session || !session.user) return { errors: { auth: 'Not authenticated' } };
+if (session.user.id !== userId) return { errors: { auth: 'Not authorized' } };
+```
+
+Ensures users can only act on their own resources (API keys, account data).
+
+---
+
+## 4. Sign-In / Sign-Out Flow
+
+### Sign-In
+
+`src/app/sign-in/page.jsx` — client component with Discord and GitHub OAuth buttons.
+
+**Flow:**
+1. User clicks "Sign in with Discord" or "Sign in with GitHub"
+2. `signIn('discord')` from `@/auth-client` calls `authClient.signIn.social({ provider: 'discord', callbackURL: '/profile' })`
+3. BetterAuth redirects to the provider's OAuth consent page
+4. On approval, provider redirects to `/api/auth/callback/discord`
+5. BetterAuth creates/links the `Account`, creates a `Session`, sets the session cookie
+6. User is redirected to the `callbackURL` (defaults to `/profile`)
+
+### Sign-Out
+
+`src/shared/components/Auth/Auth.jsx` — `<SignIn>` and `<SignOut>` button components.
+
+**Flow:**
+1. User clicks "Sign out" in the header
+2. `signOut()` from `@/auth-client` calls `authClient.signOut()` with `onSuccess` redirect to `/`
+3. BetterAuth revokes the session and clears the cookie
+
+### Navigation Integration
+
+`src/shared/components/Navigation/Navigation.jsx` is a server component that checks the session at request time. When authenticated, it renders the user's avatar and a `<SignOut>` button. When unauthenticated, it renders a `<SignIn>` button.
+
+---
+
+## 5. Role System
+
+| Role    | Access                                      |
+| ------- | ------------------------------------------- |
+| `user`  | Profile, API keys, reviews, account actions |
+| `admin` | Everything above + admin panel at `/profile/admin` |
+
+Roles are stored in `User.role` (string, default `"user"`). Admins can change roles via `updateUserRole()` but cannot demote themselves. The admin page (`/profile/admin`) checks `session.user.role === 'admin'` and redirects non-admins.
+
+---
+
+## 6. API Key Authentication
+
+API keys provide a separate authentication mechanism for the `/api/h1/rebroadcast` endpoint. They are independent of BetterAuth sessions.
+
+`src/db/queries/validateApiKey.mjs`
+
+**Flow:**
+1. Client sends `Authorization: Bearer <key>` header
+2. `validateApiKey()` extracts the key, computes `SHA-256(key)`
+3. Looks up the hash in the `ApiKey` table
+4. Returns `{ userId, keyId }` on success, or error state (`'missing'`, `'invalid'`, `'disabled'`)
+
+**Management:** Users can create (max 5), enable/disable, and delete API keys from their profile dashboard. The plaintext key is shown once at creation and never stored.
+
+See [API Reference](/docs/api) section 4 for the rebroadcast endpoint's full authentication flow.
+
+---
+
+## 7. Environment Variables
+
+Auth is **optional** — if `BETTER_AUTH_SECRET` is absent, all auth features are disabled (no sign-in UI, `/profile` redirects to home, auth API returns 503). If `BETTER_AUTH_SECRET` is present, all other auth vars are required (partial config throws at startup).
+
+| Variable               | Required        | Description                                  |
+| ---------------------- | --------------- | -------------------------------------------- |
+| `BETTER_AUTH_SECRET`   | No (all-or-none)| Session encryption secret (128+ chars). Controls whether auth is enabled. |
+| `BETTER_AUTH_URL`      | If auth enabled | Base URL (e.g., `http://localhost:3000`)      |
+| `AUTH_DISCORD_ID`      | If auth enabled | Discord OAuth app client ID                  |
+| `AUTH_DISCORD_SECRET`  | If auth enabled | Discord OAuth app client secret              |
+| `AUTH_GITHUB_ID`       | If auth enabled | GitHub OAuth app client ID                   |
+| `AUTH_GITHUB_SECRET`   | If auth enabled | GitHub OAuth app client secret               |
+
+**When auth is disabled:**
+- `src/auth.js` exports `auth = null` (BetterAuth is never initialized)
+- `/api/auth/*` returns 503 `{ error: "Auth is not configured on this instance" }`
+- `/profile/*` routes redirect to `/`
+- `UserSection` is not rendered in the navigation (server component guard)
+- Query files (`admin.mjs`, `account.mjs`, `api.mjs`) return early with `{ error: 'Auth not configured' }`
+
+See [Infrastructure](/docs/infrastructure) section 5 for the complete environment variable reference.
+
+---
+
+## 8. Migration Notes
+
+The project migrated from NextAuth.js v5 (beta) to BetterAuth in v0.25.0 (2026-04-04). Key changes:
+
+| Aspect              | NextAuth.js v5                           | BetterAuth                                         |
+| ------------------- | ---------------------------------------- | -------------------------------------------------- |
+| Route handler path  | `/api/auth/[...nextauth]`                | `/api/auth/[...all]`                               |
+| Server session      | `auth()` (direct call)                   | `auth.api.getSession({ headers: await headers() })` |
+| Client auth         | Server actions                           | Client-side via `authClient.signIn.social()`       |
+| Env: secret         | `AUTH_SECRET`                            | `BETTER_AUTH_SECRET`                               |
+| Env: trust host     | `AUTH_TRUST_HOST` (required)             | Not needed                                         |
+| Env: base URL       | Not needed                               | `BETTER_AUTH_URL`                                  |
+| Account fields      | `provider` / `providerAccountId`         | `providerId` / `accountId`                         |
+| Session token field  | `sessionToken`                           | `token`                                            |
+| Session expiry field | `expires`                                | `expiresAt`                                        |
+| Verification model  | `VerificationToken` (no PK)              | `Verification` (has `id` PK)                       |
+| WebAuthn            | `Authenticator` model                    | Removed                                            |
+| Email auth          | Nodemailer (commented out)               | Removed entirely                                   |
+
+**Breaking:** The migration dropped and recreated all auth tables. Existing users, sessions, and API keys were lost.
+
+---
+
+## Cross-References
+
+- [Database Schema](/docs/database) section 5 — auth model field definitions and constraints
+- [API Reference](/docs/api) section 9 — auth route endpoints
+- [Infrastructure](/docs/infrastructure) section 5 — environment variables

--- a/src/app/docs/components/DocsSidebar.jsx
+++ b/src/app/docs/components/DocsSidebar.jsx
@@ -4,27 +4,64 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 
+const topLevelItems = [{ href: '/docs', label: 'Overview', track: 'docs-overview' }];
+
 const sections = [
     {
         label: 'General',
         items: [
-            { href: '/docs', label: 'Overview', track: 'docs-overview' },
             { href: '/docs/about', label: 'About', track: 'docs-about' },
             { href: '/docs/faq', label: 'FAQ', track: 'docs-faq' },
         ],
     },
     {
-        label: 'Technical',
+        label: 'Architecture',
         items: [
-            { href: '/docs/architecture', label: 'Architecture', track: 'docs-architecture' },
-            { href: '/docs/notifications', label: 'Notifications', track: 'docs-notifications' },
-            { href: '/docs/api', label: 'API Reference', track: 'docs-api' },
+            {
+                href: '/docs/architecture',
+                label: 'Data Pipeline',
+                track: 'docs-architecture',
+            },
+            { href: '/docs/data-flow', label: 'Update Flow', track: 'docs-data-flow' },
+            { href: '/docs/database', label: 'Database Schema', track: 'docs-database' },
+            {
+                href: '/docs/notifications',
+                label: 'Notifications',
+                track: 'docs-notifications',
+            },
+            {
+                href: '/docs/authentication',
+                label: 'Authentication',
+                track: 'docs-authentication',
+            },
+        ],
+    },
+    {
+        label: 'Reference',
+        items: [
+            { href: '/docs/api', label: 'Rebroadcast', track: 'docs-api' },
+            { href: '/docs/utilities', label: 'Utilities', track: 'docs-utilities' },
+            { href: '/docs/hd1-api', label: 'Official', track: 'docs-hd1-api' },
             { href: '/docs/brandkit', label: 'Brand Kit', track: 'docs-brandkit' },
+        ],
+    },
+    {
+        label: 'Development',
+        items: [
+            {
+                href: '/docs/infrastructure',
+                label: 'Infrastructure',
+                track: 'docs-infrastructure',
+            },
+            { href: '/docs/testing', label: 'Testing', track: 'docs-testing' },
         ],
     },
 ];
 
 function getCurrentPage(pathname) {
+    for (const item of topLevelItems) {
+        if (item.href === pathname) return item.label;
+    }
     for (const section of sections) {
         for (const item of section.items) {
             if (item.href === pathname) return item.label;
@@ -63,16 +100,10 @@ export default function DocsSidebar() {
                 </nav>
             )}
 
-            {/* Desktop sidebar — glass panel fills column, nav content is sticky */}
-            <div
-                className="hidden border-r-2 border-primary lg:block"
-                style={{
-                    backdropFilter: 'blur(8.8px)',
-                    boxShadow: '0 4px 30px rgba(0, 0, 0, 0.1)',
-                }}
-            >
+            {/* Desktop sidebar — surface cards per section */}
+            <div className="hidden lg:block">
                 <nav
-                    className="p-gutters--left py-5"
+                    className="p-gutters--left flex flex-col gap-3 py-5"
                     style={{
                         position: 'sticky',
                         top: '80px',
@@ -90,9 +121,30 @@ export default function DocsSidebar() {
 function SidebarContent({ pathname, onNavigate }) {
     return (
         <>
+            <div className="border border-ghost bg-surface-1 p-3">
+                {topLevelItems.map((item) => {
+                    const isActive = item.href === pathname;
+                    return (
+                        <Link
+                            key={item.href}
+                            href={item.href}
+                            prefetch={false}
+                            data-umami-event={item.track}
+                            onClick={onNavigate}
+                            className={`block px-3 py-1.5 text-body ${
+                                isActive ?
+                                    'bg-surface-2 text-primary'
+                                :   'text-text hover:bg-surface-2'
+                            }`}
+                        >
+                            {item.label}
+                        </Link>
+                    );
+                })}
+            </div>
             {sections.map((section) => (
-                <div key={section.label} className="mb-5">
-                    <div className="px-4 pb-2 font-mono text-small tracking-[1.5px] text-text-muted uppercase">
+                <div key={section.label} className="border border-ghost bg-surface-1 p-3">
+                    <div className="px-3 pb-2 font-mono text-small tracking-[1.5px] text-text-muted uppercase">
                         {section.label}
                     </div>
                     {section.items.map((item) => {
@@ -104,10 +156,10 @@ function SidebarContent({ pathname, onNavigate }) {
                                 prefetch={false}
                                 data-umami-event={item.track}
                                 onClick={onNavigate}
-                                className={`block border-l-2 px-4 py-1.5 text-body ${
+                                className={`block px-3 py-1.5 text-body ${
                                     isActive ?
-                                        'border-primary bg-surface-2 text-primary'
-                                    :   'border-transparent text-text hover:bg-surface-2'
+                                        'bg-surface-2 text-primary'
+                                    :   'text-text hover:bg-surface-2'
                                 }`}
                             >
                                 {item.label}

--- a/src/app/docs/data-flow/page.mdx
+++ b/src/app/docs/data-flow/page.mdx
@@ -1,0 +1,679 @@
+export const metadata = {
+    title: 'Data Flow | Helldivers Bot',
+    description: 'Worker pipeline, two-table strategy, snapshot throttling, and data fetching architecture for helldivers.bot.',
+    alternates: { canonical: '/docs/data-flow' },
+    openGraph: { url: '/docs/data-flow' },
+};
+
+# Data Flow
+
+Technical reference for how the helldivers.bot application fetches, validates, and persists data from the official Helldivers 1 API.
+
+---
+
+## 1. Overview
+
+The full data pipeline from external API to stored records:
+
+```mermaid
+graph TD
+    subgraph Sources["DATA SOURCES"]
+        API_STATUS["get_campaign_status<br/><small>Live war state + stats</small>"]
+        API_SNAP["get_snapshots<br/><small>Historical time-series</small>"]
+        SEED["prisma/seed/seasons/*.json<br/><small>Bootstrap on first deploy</small>"]
+    end
+
+    subgraph Processing["PROCESSING"]
+        FETCH["fetch.mjs<br/><small>Axios POST, SSL bypass</small>"]
+        ZOD["Zod safeParse validation"]
+    end
+
+    subgraph Raw["RAW CACHE"]
+        RB_STATUS["rebroadcast_status<br/><small>1 row/season — raw JSON</small>"]
+        RB_SNAP["rebroadcast_snapshot<br/><small>1 row/season — raw JSON</small>"]
+    end
+
+    subgraph Normalized["NORMALIZED TABLES"]
+        SEASON_U["h1_season<br/><small>unconfirmed, last_updated = null</small>"]
+        EVENT["h1_event"]
+        EVENT_SNAP["h1_event_snapshot<br/><small>10-min throttle</small>"]
+        INTRO["h1_introduction_order"]
+        POINTS["h1_points_max"]
+        LIVE["h1_live<br/><small>Per-faction live state</small>"]
+        LIVE_SNAP["h1_live_snapshot<br/><small>15-min throttle</small>"]
+        SNAPSHOT["h1_snapshot<br/><small>Season pipeline only</small>"]
+        SEASON_C["h1_season<br/><small>confirmed, last_updated set</small>"]
+    end
+
+    API_STATUS --> FETCH
+    API_SNAP --> FETCH
+    SEED --> ZOD
+    FETCH --> ZOD
+    ZOD --> RB_STATUS
+    ZOD --> RB_SNAP
+    ZOD --> SEASON_U
+    SEASON_U --> EVENT --> EVENT_SNAP
+    SEASON_U --> INTRO
+    SEASON_U --> POINTS
+    SEASON_U --> LIVE --> LIVE_SNAP
+    SEASON_U --> SNAPSHOT
+    EVENT_SNAP --> SEASON_C
+    LIVE_SNAP --> SEASON_C
+    SNAPSHOT --> SEASON_C
+    INTRO --> SEASON_C
+    POINTS --> SEASON_C
+
+    style Sources fill:#1e293b,stroke:#3b82f6,color:#60a5fa
+    style Processing fill:#1a1a2e,stroke:#a855f7,color:#c084fc
+    style Raw fill:#1c1917,stroke:#f59e0b,color:#fbbf24
+    style Normalized fill:#0f1a0f,stroke:#22c55e,color:#4ade80
+```
+
+<details>
+<summary>Text version of the pipeline</summary>
+
+```
+Official API (api.helldiversgame.com)
+    |
+    v
+src/update/fetch.mjs          — HTTP layer (Axios POST, SSL bypass)
+    |
+    v
+src/validators/               — Zod safeParse validation
+    |
+    v
+rebroadcast_status            — Raw JSON, one row per season
+rebroadcast_snapshot          — Raw JSON, one row per season
+    |
+    v
+h1_season (unconfirmed)       — Season record, last_updated = null
+    |
+    v  [sequential]
+h1_event                      — Unified defend/attack events
+h1_event_snapshot             — Event progress snapshots (10-min throttle)
+h1_introduction_order         — Derived from campaign_status
+h1_points_max                 — Derived from campaign_status
+h1_live                       — Per-faction live state with map overlay
+h1_live_snapshot              — Live statistic snapshots (15-min throttle)
+h1_snapshot                   — Historical snapshots (season pipeline only)
+    |
+    v
+h1_season (confirmed)         — last_updated set only after all child writes succeed
+```
+
+</details>
+
+There are two distinct pipelines that share this shape:
+
+- **Status pipeline** (`updateStatus()`) — runs on every worker tick, updates the current campaign state. Writes `h1_event`, `h1_event_snapshot`, `h1_introduction_order`, `h1_points_max`, `h1_live`, and `h1_live_snapshot`.
+- **Season pipeline** (`updateSeason(season)`) — runs on-demand when historical season data is needed. Writes `h1_event`, `h1_introduction_order`, `h1_points_max`, and `h1_snapshot`.
+
+---
+
+## 2. Worker Thread Lifecycle
+
+Sources: `public/workers/cron.js`, `src/utils/initialize.worker.mjs`
+
+### Startup
+
+`initializeWorker()` is called from `src/instrumentation.js` during application bootstrap. It guards against non-Node.js runtimes before doing anything:
+
+```js
+if (process.env.NEXT_RUNTIME === 'nodejs') { ... }
+```
+
+This prevents the worker from being spawned in edge runtimes or during static builds.
+
+The worker script path is resolved differently depending on environment:
+
+| Environment              | Resolved path                                           |
+| ------------------------ | ------------------------------------------------------- |
+| `development`            | `path.resolve(process.cwd(), 'public/workers/cron.js')` |
+| `production` / `staging` | `path.resolve('/app/public/workers/cron.js')`           |
+
+After spawning, the parent sends a single initialization message to the worker:
+
+```js
+worker.postMessage({ key: key, interval: interval, port: port });
+```
+
+### Worker message loop
+
+The worker listens for exactly one message from the parent. On receipt, it immediately starts the polling loop:
+
+```js
+parentPort.on('message', async (msg) => {
+    const { key, interval, port } = msg;
+    async function doWork() { ... }
+    doWork();
+});
+```
+
+`doWork()` constructs the internal update URL and fetches it:
+
+```js
+const url = `http://localhost:${port}/api/h1/update?key=${key}`;
+const response = await fetch(url);
+```
+
+After each attempt — success or failure — the worker reports back to the parent:
+
+- Success: `{ data: responseJson, time: new Date().toString() }`
+- Error: `{ error: err.toString(), time: new Date().toString() }`
+
+Errors do not stop the worker. The loop continues unconditionally.
+
+### Sequential scheduling with `setTimeout`
+
+The worker uses `setTimeout(doWork, interval * 1000)` at the end of `doWork()`, not `setInterval`. This is intentional: the next poll only starts after the current one fully resolves. If an update takes longer than the configured interval, requests will not overlap and database operations will not race.
+
+### Parent-side message handling
+
+The parent logs errors from worker messages and thread-level errors:
+
+```js
+worker.on('message', (data) => {
+    if (data.error) console.error('Worker error:', data.error, 'at', data.time);
+});
+worker.on('error', (err) => console.error('Worker thread error:', err));
+worker.on('exit', (code) => {
+    console.log(`Worker stopped with exit code ${code}`);
+    worker = null;
+});
+```
+
+### Graceful shutdown
+
+On `SIGINT` or `SIGTERM`, the parent terminates the worker before exiting:
+
+```js
+process.on('SIGINT', async () => {
+    if (worker) await worker.terminate();
+    process.exit();
+});
+```
+
+---
+
+## 3. Status Update Pipeline
+
+Source: `src/update/status.mjs` — `updateStatus()`
+
+This function is invoked by `GET /api/h1/update?key=...` on every worker tick. It fetches the current campaign state and persists it to both table families.
+
+### Step-by-step
+
+**Step 0 — Timing**
+
+```js
+const start = performance.now();
+```
+
+Execution time is measured from the very start and returned in the response as `ms`.
+
+**Step 1 — Fetch**
+
+```js
+const { data: fetchedData, error: fetchedError } = await tryCatch(fetchStatus());
+```
+
+`fetchStatus()` POSTs `action=get_campaign_status` to the official API. It delegates to `fetchInvalidHttps()`, which throws on network failure or empty response. `tryCatch()` catches any thrown error and returns it in `error`. If `fetchedError` is set, `updateStatus()` throws immediately with a descriptive message and a `cause` pointing to the source location.
+
+**Step 2 — Zod validation**
+
+```js
+const check = isValidStatus(fetchedData);
+if (!check.success) throw new Error(...);
+```
+
+`isValidStatus` runs a Zod `safeParse` against the response. It validates the shape of `campaign_status[]`, `defend_event`, `attack_events[]`, and `statistics[]`. Validation failure throws before any database write occurs.
+
+**Step 3 — Extract season**
+
+```js
+const season = getSeasonFromStatus(fetchedData);
+```
+
+`getSeasonFromStatus` reads the season number from `campaign_status`, `defend_event`, and `statistics`. It logs a warning if multiple different season values are present across those fields. Attack events are deliberately excluded here because they can belong to a prior season while the rest of the payload belongs to the current one.
+
+**Step 4 — Write raw JSON (rebroadcast)**
+
+```js
+await tryCatch(queryUpsertRebroadcastStatus(season, fetchedData));
+```
+
+The complete, unmodified API response is stored in `rebroadcast_status`, keyed by `season`. This is an upsert — the row for that season is created or replaced.
+
+**Step 5 — Create unconfirmed season record**
+
+```js
+await tryCatch(queryUpsertSeason(season, false));
+```
+
+A row for this season is created in `h1_season` with `last_updated` left as `null`. The `false` parameter signals that this is the initial, unconfirmed creation. See the Confirm Pattern section below.
+
+**Step 6 — Upsert events**
+
+```js
+// Defend event (guard for null — API omits when no defend active)
+if (fetchedData.defend_event) {
+    await tryCatch(queryUpsertEvent(season, 'defend', fetchedData.defend_event));
+}
+
+// Attack events
+for (const event of fetchedData.attack_events) {
+    await tryCatch(queryUpsertEvent(season, 'attack', { ...event, region: 11 }));
+}
+```
+
+Both defend and attack events are written through the unified `queryUpsertEvent(season, type, event)` function to the `h1_event` table. Key differences:
+
+- `defend_event` is a single nullable object in the API response. It is guarded with an `if` check — the API omits this field when no defend event is active.
+- `attack_events` is an array. Each event is spread with `region: 11` added, because attack events always target the enemy homeworld (region 11) and the API does not include the region field.
+
+Events are written sequentially, not in parallel. Each error throws immediately.
+
+**Step 6.5 — Event snapshot capture (10-min throttle)**
+
+After upserting events, the pipeline captures time-series snapshots of event progress for active or terminal events:
+
+```js
+// For each defend/attack event where status is 'active', 'success', or 'fail':
+const { data: shouldSnapshot } = await tryCatch(
+    shouldTakeEventSnapshot(type, event.event_id, fetchedData.time),
+);
+if (shouldSnapshot) {
+    await tryCatch(queryCreateEventSnapshot(season, type, event, fetchedData.time));
+    recordEventSnapshotTime(type, event.event_id, fetchedData.time);
+}
+```
+
+For each active or terminal event (defend and attack), the pipeline calls `shouldTakeEventSnapshot()` to check whether 10 minutes have elapsed since the last snapshot for that specific event. If yes, it writes a row to `h1_event_snapshot` and updates the in-memory timer. Terminal events (`success`/`fail`) are also snapshotted to capture the final state.
+
+Snapshot errors are logged but do not throw — they are non-fatal to the pipeline. The update continues even if a snapshot write fails.
+
+**Step 7 — Derive introduction_order and points_max**
+
+```js
+const introOrder = fetchedData.campaign_status.map((c) => c.introduction_order);
+const pointsMax = fetchedData.campaign_status.map((c) => c.points_max);
+
+await tryCatch(queryUpsertIntroductionOrder(season, introOrder));
+await tryCatch(queryUpsertPointsMax(season, pointsMax));
+```
+
+These two values are derived from the `campaign_status` array by mapping each faction's entry. They are stored in their own tables (`h1_introduction_order` and `h1_points_max`) because they are season-level metadata, not per-tick data. Written sequentially; errors throw.
+
+**Step 8 — Upsert h1_live (per-faction live state)**
+
+```js
+for (let enemy = 0; enemy < 3; enemy++) {
+    const campaign = fetchedData.campaign_status[enemy];
+    const stats = fetchedData.statistics[enemy];
+    const factionMap = computeFactionMap(
+        enemy,
+        campaign,
+        defendEvent,
+        attackEvents,
+        season,
+    );
+    await tryCatch(queryUpsertLive(season, enemy, campaign, stats, factionMap));
+}
+```
+
+The pipeline loops over the three enemy factions (0, 1, 2). For each faction, it:
+
+1. Extracts the campaign entry and statistics entry from the API arrays.
+2. Computes a `factionMap` via `computeFactionMap()` — a deep-cloned map template from `src/enums/map` with live campaign data overlaid (points, percent, status) and event markers (`'defend'`/`'attack'`) applied to affected regions.
+3. Upserts a row in `h1_live` containing the campaign data, statistics, and computed map.
+
+The `computeFactionMap()` helper:
+
+- Deep-clones the base map template for the given enemy.
+- Sets `status` on all regions from the campaign.
+- Sets `points`, `points_max`, and `percent` on region 11 (homeworld).
+- Marks the region with `event: 'defend'` if a defend event targets that faction.
+- Marks region 11 with `event: 'attack'` if any active attack event targets that faction.
+
+**Step 8.5 — Live snapshot capture (15-min throttle)**
+
+```js
+const { data: shouldSnapshot } = await tryCatch(
+    shouldTakeLiveSnapshot(season, fetchedData.time),
+);
+if (shouldSnapshot) {
+    await tryCatch(
+        queryCreateLiveSnapshots(season, fetchedData.time, fetchedData.statistics),
+    );
+    recordLiveSnapshotTime(fetchedData.time);
+}
+```
+
+After all three factions are written, the pipeline checks `shouldTakeLiveSnapshot()` to determine if 15 minutes have elapsed since the last live snapshot. If yes, it writes all three factions' statistics to `h1_live_snapshot` in a single call and updates the in-memory timer.
+
+Like event snapshots, live snapshot errors are logged but do not throw — they are non-fatal.
+
+**Step 9 — Confirm season**
+
+```js
+await tryCatch(queryUpsertSeason(season, true));
+```
+
+`last_updated` is set only now, after all child writes have succeeded. See the Confirm Pattern section below.
+
+**Return value**
+
+```js
+return { ms, season, confirmSeason };
+```
+
+`ms` is the raw execution time in milliseconds (via `performanceTime(start)`, not rounded). `confirmSeason` is the updated `h1_season` record.
+
+### Confirm pattern
+
+`queryUpsertSeason` is called twice in every pipeline run:
+
+| Call                               | Parameter | Effect                                                             |
+| ---------------------------------- | --------- | ------------------------------------------------------------------ |
+| `queryUpsertSeason(season, false)` | `false`   | Creates or touches the season row; leaves `last_updated` as `null` |
+| `queryUpsertSeason(season, true)`  | `true`    | Sets `last_updated` to the current timestamp                       |
+
+The invariant this enforces: a season row with `last_updated !== null` has a complete, consistent set of child records. Any season row where `last_updated` is `null` was either just created and is mid-pipeline, or a previous pipeline run failed partway through. Consumers of the `h1_*` tables can filter on `last_updated IS NOT NULL` to read only confirmed seasons.
+
+### Error handling
+
+Every async operation is wrapped in `tryCatch()`, which returns `{ data, error }` instead of throwing. Errors surface as explicit `if (someError) throw new Error(...)` checks after each step, with a `cause` field that identifies the exact source file and operation. This makes stack traces actionable without relying on implicit propagation.
+
+The exception is snapshot writes (Steps 6.5 and 8.5), which log errors with `console.error` instead of throwing. Snapshot failures are non-fatal — the pipeline completes and confirms the season even if individual snapshots fail to write.
+
+---
+
+## 4. Season Snapshot Pipeline
+
+Source: `src/update/season.mjs` — `updateSeason(season)`
+
+This function fetches the full historical snapshot data for a given season number. It is structurally similar to the status pipeline but operates on different data and does not write live state or throttled snapshots.
+
+### Step-by-step
+
+**Step 0 — Guard and timing**
+
+```js
+if (!season) throw new Error('season is missing');
+const start = performance.now();
+```
+
+Season is required. If absent, the function throws before attempting any I/O.
+
+**Step 1 — Fetch**
+
+```js
+const { data: fetchedData, error: fetchedError } = await tryCatch(fetchSeason(season));
+```
+
+`fetchSeason` validates the season parameter with `isValidNumber.safeParse`, then POSTs `action=get_snapshots` with `season=N`. Unlike `fetchStatus`, `fetchSeason` delegates directly to `fetchInvalidHttps` which re-throws on error — a failed season fetch is always a hard failure.
+
+**Step 2 — Zod validation**
+
+```js
+const check = isValidSeason(fetchedData);
+```
+
+Validates the snapshot response shape. On failure, the individual Zod issues are logged before throwing.
+
+**Step 3 — Cross-check season**
+
+```js
+const season2 = getSeasonFromSnapshot(fetchedData);
+if (season !== season2) throw new Error('Invalid season');
+```
+
+The season number embedded in the response payload is compared against the requested season. A mismatch throws immediately, preventing data from being stored under the wrong season key.
+
+**Step 4 — Write raw JSON (rebroadcast)**
+
+```js
+await tryCatch(queryUpsertRebroadcastSeason(season, fetchedData));
+```
+
+The complete response is stored in `rebroadcast_snapshot`, keyed by `season`.
+
+**Step 5.1 — Create unconfirmed season record**
+
+```js
+await tryCatch(queryUpsertSeason(season, false));
+```
+
+Same confirm pattern as the status pipeline.
+
+**Steps 5.2-5.4 — Parallel normalized writes**
+
+```js
+await Promise.all([
+    tryCatch(queryUpsertIntroductionOrder(season, fetchedData.introduction_order)),
+    tryCatch(queryUpsertPointsMax(season, fetchedData.points_max)),
+    tryCatch(queryUpsertSnapshots(season, fetchedData.snapshots)),
+]);
+```
+
+Three tables are written concurrently: `h1_introduction_order`, `h1_points_max`, and `h1_snapshot`. Each result is checked individually after `Promise.all` resolves; any error throws immediately.
+
+**Step 5.5 — Upsert defend events**
+
+```js
+for (const event of fetchedData.defend_events) {
+    await tryCatch(queryUpsertEvent(season, 'defend', event));
+}
+```
+
+Defend events are iterated and each is written to `h1_event` via the unified `queryUpsertEvent` function. In the season pipeline, `defend_events` is an array (plural) because snapshot data contains full historical event lists rather than a single current event.
+
+**Step 5.6 — Upsert attack events**
+
+```js
+for (const event of fetchedData.attack_events) {
+    await tryCatch(queryUpsertEvent(season, 'attack', { ...event, region: 11 }));
+}
+```
+
+Attack events are also iterated individually. Each event is spread with `region: 11` added, same as in the status pipeline.
+
+**Step 6 — Confirm season**
+
+```js
+await tryCatch(queryUpsertSeason(season, true));
+```
+
+**Return value**
+
+```js
+return { ms, season, confirmSeason };
+```
+
+### On-demand invocation
+
+`updateSeason()` is not called on a schedule. It is called reactively by API handlers when they cannot find the requested season in the local database:
+
+- `GET /api/h1/campaign?season=N` — queries local `h1_*` tables first; calls `updateSeason(season)` if the season is missing.
+- `POST /api/h1/rebroadcast` with `action=get_snapshots` — queries `rebroadcast_snapshot` first; calls `updateSeason(season)` if the row is absent.
+
+After `updateSeason()` returns, the handler re-queries the database and returns the result. This means a cold request for an unknown season incurs one extra round-trip to the official API before responding.
+
+### Frontend on-demand fetching
+
+The `/war` history page also fetches seasons on-demand via `fetchAndSeedSeason()` (`src/db/queries/fetchAndSeedSeason.mjs`). When a user selects a season not yet in the database:
+
+1. `getCampaign(season)` returns `null`
+2. `fetchAndSeedSeason(season)` calls `fetchSeason(season)` (official API) and upserts into `h1_season`, `h1_event`, `h1_snapshot`, `h1_introduction_order`, `h1_points_max`
+3. `getCampaign(season)` is re-queried and now returns the seeded data
+
+The season selector on `/war` is derived from the current season number (`Array.from({length: activeSeason - 1}, ...)`), not from a database query. This ensures all past seasons are always selectable regardless of what exists in the DB.
+
+---
+
+## 5. Two-Table Strategy
+
+Every pipeline run writes the same data twice: once as raw JSON, once as normalized relational rows.
+
+### Rebroadcast tables
+
+| Table                  | Populated by                   | Key               |
+| ---------------------- | ------------------------------ | ------------------ |
+| `rebroadcast_status`   | `queryUpsertRebroadcastStatus` | `season` (unique) |
+| `rebroadcast_snapshot` | `queryUpsertRebroadcastSeason` | `season` (unique) |
+
+These tables store the complete, unmodified API response as a JSON blob. There is one row per season. They exist to serve the `/api/h1/rebroadcast` endpoint, which mirrors the official API format exactly — clients that were already consuming the official API can point at this endpoint and receive the same payload structure without any transformation.
+
+### H1 tables
+
+| Table                   | Relationship                              | Written by           |
+| ----------------------- | ----------------------------------------- | -------------------- |
+| `h1_season`             | Root; one row per season                  | Both pipelines       |
+| `h1_event`              | Many per season (defend + attack unified) | Both pipelines       |
+| `h1_event_snapshot`     | Many per event (10-min intervals)         | Status pipeline only |
+| `h1_live`               | Three per season (one per faction)        | Status pipeline only |
+| `h1_live_snapshot`      | Many per season (15-min intervals)        | Status pipeline only |
+| `h1_snapshot`           | Many per season                           | Season pipeline only |
+| `h1_introduction_order` | One per season                            | Both pipelines       |
+| `h1_points_max`         | One per season                            | Both pipelines       |
+
+These tables store normalized, relational data keyed on `season`. They accumulate historical records across every update cycle, enabling structured queries, aggregations, and time-series analysis. They are used by the `/api/h1/campaign` endpoint and the frontend.
+
+### Why both exist
+
+The two representations serve different consumers with incompatible requirements:
+
+- The rebroadcast endpoint must return the exact payload structure the official API produces. Reconstructing that structure from normalized rows on every request would be fragile and expensive.
+- The campaign endpoint and frontend need to filter, join, and aggregate across seasons and time. Querying a JSON blob for that is impractical.
+
+Storing both avoids the trade-off: the raw blob is always available for faithful reproduction, and the normalized rows are always available for structured access. The storage overhead is the duplicated JSON, which is acceptable given the relatively small payload sizes of the Helldivers 1 API.
+
+---
+
+## 6. Snapshot Throttle System
+
+Source: `src/update/snapshotTimers.mjs`
+
+The status pipeline runs on every worker tick (typically every few seconds), but writing a snapshot row on every tick would generate excessive data. The snapshot throttle system limits how often snapshots are written using in-memory timestamp tracking with a database cold-start fallback.
+
+### Architecture
+
+The module maintains three pieces of in-memory state:
+
+```js
+let currentSeason = null;
+let lastLiveSnapshotTime = null; // single timestamp
+const lastEventSnapshotTimes = new Map(); // key: `${type}:${event_id}`, value: time
+```
+
+All timestamps are API-provided Unix times (the `time` field from the status response), not wall-clock times. This ensures throttle intervals are based on game-time progression, not server clock.
+
+### Intervals
+
+| Snapshot type  | Interval | Constant                                  |
+| -------------- | -------- | ----------------------------------------- |
+| Live snapshot  | 15 min   | `LIVE_SNAPSHOT_INTERVAL = 900` (seconds)  |
+| Event snapshot | 10 min   | `EVENT_SNAPSHOT_INTERVAL = 600` (seconds) |
+
+### Live snapshot throttle
+
+**`shouldTakeLiveSnapshot(season, apiTime)`** — Returns `true` if a live snapshot should be written.
+
+On cold start (when `lastLiveSnapshotTime` is `null`), it queries the database for the most recent `h1_live_snapshot` row for the current season and seeds the in-memory timestamp from it. If no row exists, it defaults to `0`, which guarantees the first check passes.
+
+On subsequent calls, it compares `apiTime - lastLiveSnapshotTime` against the 900-second interval purely in memory, with no database query.
+
+**`recordLiveSnapshotTime(time)`** — Called after a successful snapshot write to update the in-memory timestamp. This must be called only after the database write succeeds to avoid the timer advancing past a failed write.
+
+### Event snapshot throttle
+
+**`shouldTakeEventSnapshot(type, eventId, apiTime)`** — Returns `true` if a snapshot should be written for the given event.
+
+Works identically to the live snapshot throttle, but tracks each event independently using a `Map` keyed by `${type}:${event_id}` (e.g., `defend:42` or `attack:17`). On cold start for a given event, it queries `h1_event_snapshot` for that specific type and event_id.
+
+**`recordEventSnapshotTime(type, eventId, time)`** — Updates the in-memory timestamp for a specific event after a successful write.
+
+### Season change detection
+
+**`resetIfSeasonChanged(season)`** — Called at the top of `shouldTakeLiveSnapshot()`. If the season number has changed since the last call, it clears all in-memory timestamps:
+
+```js
+if (currentSeason !== null && currentSeason !== season) {
+    lastLiveSnapshotTime = null;
+    lastEventSnapshotTimes.clear();
+}
+currentSeason = season;
+```
+
+This ensures that when a new season starts, the throttle system re-seeds from the database (which will find no rows for the new season) and immediately begins capturing snapshots.
+
+**`resetSnapshotTimers()`** — A manual reset function that clears all in-memory state. Available for external callers but not currently used by the pipelines (season changes are detected automatically).
+
+### Cold-start behavior
+
+Because the worker thread restarts on every deployment (and the Next.js process may restart for other reasons), in-memory state is regularly lost. The cold-start fallback ensures the system recovers gracefully:
+
+1. First tick after restart: `lastLiveSnapshotTime` is `null`, triggering a DB query.
+2. DB returns the most recent snapshot time (or nothing if no snapshots exist yet).
+3. The throttle check runs against the DB-seeded value.
+4. All subsequent ticks use the in-memory value, avoiding repeated DB queries.
+
+This design means the worst case on restart is one extra database read per snapshot type, not a gap or duplication in snapshot data.
+
+---
+
+## 7. Fetching Layer
+
+Source: `src/update/fetch.mjs`
+
+### `getApiURL()`
+
+Returns the base URL for all environments:
+
+| `NODE_ENV`    | URL                                   |
+| ------------- | ------------------------------------- |
+| `development` | `https://api.helldiversgame.com/1.0/` |
+| `staging`     | `https://api.helldiversgame.com/1.0/` |
+| `production`  | `https://api.helldiversgame.com/1.0/` |
+
+All three environments target the same production API. A commented-out QA URL (`api-qa.helldiversgame.com`) exists in the source but is not active.
+
+### `fetchInvalidHttps(url, formData)`
+
+The core HTTP function used by both public fetchers. It creates an `https.Agent` with SSL certificate validation disabled:
+
+```js
+const agent = new https.Agent({ rejectUnauthorized: false });
+```
+
+This is required because the official Helldivers 1 API has certificate issues that would otherwise cause every request to fail. The agent is passed to Axios on every call.
+
+The function uses `axios.post`. It throws in two cases:
+
+- The response has no `data` field.
+- Axios itself throws (network failure, non-2xx status, etc.) — the Axios error is wrapped with the HTTP status and message included.
+
+### `fetchStatus()`
+
+```js
+export async function fetchStatus() { ... }
+```
+
+Posts `action=get_campaign_status`. Delegates directly to `fetchInvalidHttps` and returns the result. On error, the exception propagates to the caller (`updateStatus`) which handles it via `tryCatch`.
+
+### `fetchSeason(season)`
+
+```js
+export async function fetchSeason(season) { ... }
+```
+
+Validates `season` with `isValidNumber.safeParse` before constructing the request. Posts `action=get_snapshots` with `season=N`. On validation failure, throws immediately before making any network request. On network error, the exception propagates from `fetchInvalidHttps`.
+
+---
+
+## Cross-references
+
+- See [Database Schema](/docs/database) for table structures and column definitions.
+- See [Notifications](/docs/notifications) for the live data polling, toast notifications, and push notification systems that consume the update pipeline's output. The frontend polls `GET /api/h1/live` every 10 seconds via the `useLiveData` hook.
+- See [API Reference](/docs/api) for the `/api/h1/update` endpoint that triggers the status pipeline on each worker tick, and `/api/h1/live` for the polling endpoint that serves live data to clients.
+- See [Utilities](/docs/utilities) for `tryCatch`, `getSeasonFromStatus`, `getSeasonFromSnapshot`, and the Zod validation schemas.

--- a/src/app/docs/database/page.mdx
+++ b/src/app/docs/database/page.mdx
@@ -1,0 +1,721 @@
+export const metadata = {
+    title: 'Database Schema | Helldivers Bot',
+    description: 'Prisma 7 schema reference — models, relationships, indexes, and constraints for helldivers.bot.',
+    alternates: { canonical: '/docs/database' },
+    openGraph: { url: '/docs/database' },
+};
+
+# Database Schema
+
+This document is the canonical reference for the PostgreSQL schema managed by Prisma. It covers every model, field, constraint, and index. Cross-references to data flow and API behaviour are noted inline.
+
+---
+
+## 1. Schema Configuration
+
+Prisma 7 separates schema definition from connection configuration. The schema file (`prisma/schema.prisma`) defines the provider and generator. The connection URL lives in `prisma.config.mjs`.
+
+### Schema file
+
+```prisma
+datasource db {
+    provider = "postgresql"
+}
+
+generator client {
+    provider = "prisma-client"
+    output   = "../src/generated/prisma"
+}
+```
+
+| Setting       | Value                     | Notes                                                            |
+| ------------- | ------------------------- | ---------------------------------------------------------------- |
+| Provider      | `postgresql`              | Connection URL configured externally in `prisma.config.mjs`      |
+| Generator     | `prisma-client`           | Prisma 7 standard generator (replaces legacy `prisma-client-js`) |
+| Client output | `../src/generated/prisma` | Import path: `@/generated/prisma/client`                         |
+
+### Connection configuration (`prisma.config.mjs`)
+
+```js
+import 'dotenv/config';
+import { defineConfig, env } from 'prisma/config';
+
+export default defineConfig({
+    schema: 'prisma/schema.prisma',
+    migrations: { path: 'prisma/migrations' },
+    datasource: { url: env('POSTGRES_URL') },
+});
+```
+
+This file is read by the Prisma CLI for migrations and introspection. The `dotenv/config` import loads `.env` for local CLI usage; in Docker, `POSTGRES_URL` is injected as a real environment variable.
+
+### Runtime client (`src/db/db.js`)
+
+Prisma 7 requires a JavaScript driver adapter instead of the Rust query engine. The project uses `@prisma/adapter-pg` (which bundles `pg` internally):
+
+```js
+import { PrismaClient } from '@/generated/prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+const prismaClientSingleton = () => {
+    const adapter = new PrismaPg({ connectionString: process.env.POSTGRES_URL });
+    return new PrismaClient({ adapter });
+};
+```
+
+The singleton pattern caches the client on `globalThis.prismaGlobal` to survive Next.js hot reloads in development.
+
+---
+
+## 2. Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    h1_season ||--o| h1_introduction_order : "OneSeasonToOneIntroductionOrder"
+    h1_season ||--o| h1_points_max : "OneSeasonToOnePointsMax"
+    h1_season ||--o{ h1_snapshot : "OneSeasonToManySnapshots"
+    h1_season ||--o{ h1_event : "OneSeasonToManyEvents"
+    h1_season ||--o{ h1_live : "OneSeasonToManyLive"
+    h1_season ||--o{ h1_live_snapshot : "OneSeasonToManyLiveSnapshots"
+    h1_season ||--o{ h1_event_snapshot : "OneSeasonToManyEventSnapshots"
+    h1_event ||--o{ h1_event_snapshot : "OneEventToManySnapshots"
+
+    h1_season {
+        String   id           PK
+        DateTime last_updated "nullable"
+        Int      season       UK
+    }
+
+    h1_introduction_order {
+        String id    PK
+        Int    season FK "unique"
+        Int[]  order
+    }
+
+    h1_points_max {
+        String id     PK
+        Int    season FK "unique"
+        Int[]  points
+    }
+
+    h1_snapshot {
+        String id     PK
+        Int    season FK
+        Int    time
+        Json   data
+    }
+
+    h1_event {
+        String id       PK
+        Int    season   FK
+        String type
+        Int    event_id
+        Int    region
+        String status
+    }
+
+    h1_event_snapshot {
+        String id       PK
+        Int    season   FK
+        String type
+        Int    event_id FK
+        Int    time
+        Int    points
+        Int    points_max
+    }
+
+    h1_live {
+        String id     PK
+        Int    season FK
+        Int    enemy
+        Int    points
+        String status
+        Json   map    "nullable"
+    }
+
+    h1_live_snapshot {
+        String id     PK
+        Int    season FK
+        Int    time
+        Int    enemy
+        BigInt deaths
+        BigInt kills
+    }
+
+    rebroadcast_status {
+        String   id           PK
+        Int      season       UK
+        DateTime last_updated
+        Json     json
+    }
+
+    rebroadcast_snapshot {
+        String   id           PK
+        Int      season       UK
+        DateTime last_updated
+        Json     json
+    }
+
+    User ||--o{ Account : "accounts"
+    User ||--o{ Session : "sessions"
+    User ||--o| Settings : "settings"
+    User ||--o{ Review : "reviews"
+    User ||--o{ ApiKey : "apiKeys"
+
+    User {
+        String   id            PK
+        String   username      UK
+        String   email         UK
+        Boolean  emailVerified
+        String   role
+        Boolean  banned
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    Account {
+        String   id         PK
+        String   userId     FK
+        String   accountId
+        String   providerId
+        DateTime accessTokenExpiresAt
+        DateTime refreshTokenExpiresAt
+    }
+
+    Session {
+        String   id        PK
+        String   token     UK
+        String   userId    FK
+        DateTime expiresAt
+        String   ipAddress
+        String   userAgent
+    }
+
+    Verification {
+        String   id         PK
+        String   identifier
+        String   value
+        DateTime expiresAt
+    }
+
+    Settings {
+        String userId PK-FK
+        Json   settings
+    }
+
+    Review {
+        String  id        PK
+        String  authorId  FK
+        Boolean published
+    }
+
+    ApiKey {
+        String  id      PK
+        String  hash    UK
+        String  userId  FK
+        Boolean enabled
+    }
+
+    App {
+        String id             PK
+        String version
+        Int    active_season
+    }
+```
+
+> `rebroadcast_status` and `rebroadcast_snapshot` link to game seasons via the `season` integer field but carry **no Prisma-level foreign key** to `h1_season`. They are intentionally independent: they can be written before an `h1_season` row exists, and they store raw API responses regardless of normalisation state.
+
+---
+
+## 3. Game Data Models
+
+### h1_season
+
+The root anchor for all game data. Every normalised game table points back to this row via `season` (the integer game season number, not the surrogate `id`).
+
+| Field          | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                                                                                           |
+| -------------- | ----------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `String`    | `TEXT`          | `@id @default(uuid(7))` — surrogate PK, UUIDv7                                                                                                                                |
+| `last_updated` | `DateTime?` | `TIMESTAMPTZ`   | Nullable. `null` means the season row was pre-seeded but has not yet received a successful data update. Set to the current timestamp at the end of a successful update cycle. |
+| `season`       | `Int`       | `INTEGER`       | `@unique` — the game season number. Used as the FK target by all child tables.                                                                                                |
+
+**Indexes:**
+
+| Index                     | Fields       |
+| ------------------------- | ------------ |
+| `@@index([season])`       | season       |
+| `@@index([last_updated])` | last_updated |
+
+**Relations (outbound):**
+
+| Relation name                     | Target model            | Cardinality           |
+| --------------------------------- | ----------------------- | --------------------- |
+| `OneSeasonToOneIntroductionOrder` | `h1_introduction_order` | one-to-one (optional) |
+| `OneSeasonToOnePointsMax`         | `h1_points_max`         | one-to-one (optional) |
+| `OneSeasonToManySnapshots`        | `h1_snapshot`           | one-to-many           |
+| `OneSeasonToManyEvents`           | `h1_event`              | one-to-many           |
+| `OneSeasonToManyLive`             | `h1_live`               | one-to-many           |
+| `OneSeasonToManyLiveSnapshots`    | `h1_live_snapshot`      | one-to-many           |
+| `OneSeasonToManyEventSnapshots`   | `h1_event_snapshot`     | one-to-many           |
+
+**Design note:** Child tables reference `season` (Int) rather than the surrogate `id` (UUID). This keeps foreign keys human-readable, avoids UUID joins in queries that filter by season number, and matches the season integer used in the official API response.
+
+---
+
+### h1_introduction_order
+
+One row per season. Stores the ordered list of planets (by their integer identifiers) for that season.
+
+| Field    | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                                        |
+| -------- | ----------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `id`     | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                                                    |
+| `season` | `Int`       | `INTEGER`       | `@unique` FK → `h1_season.season`. The `@unique` constraint is what enforces the one-to-one relationship with `h1_season`. |
+| `order`  | `Int[]`     | `INTEGER[]`     | Native PostgreSQL integer array. The ordered sequence of `introduction_order` values for all planets in this season.       |
+
+**Indexes:**
+
+| Index               | Fields |
+| ------------------- | ------ |
+| `@@index([season])` | season |
+
+---
+
+### h1_points_max
+
+One row per season. Stores the maximum liberation points for each planet in the season.
+
+| Field    | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                  |
+| -------- | ----------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `id`     | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                              |
+| `season` | `Int`       | `INTEGER`       | `@unique` FK → `h1_season.season`. Enforces one-to-one with `h1_season`.                             |
+| `points` | `Int[]`     | `INTEGER[]`     | Native PostgreSQL integer array. Each index position corresponds to a planet's `introduction_order`. |
+
+**Indexes:**
+
+| Index               | Fields |
+| ------------------- | ------ |
+| `@@index([season])` | season |
+
+---
+
+### h1_snapshot
+
+Historical time-series data. Each row is a point-in-time snapshot of campaign state for a season, keyed by the original Unix timestamp from the API.
+
+| Field    | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                       |
+| -------- | ----------- | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `id`     | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                                   |
+| `season` | `Int`       | `INTEGER`       | FK → `h1_season.season`                                                                                   |
+| `time`   | `Int`       | `INTEGER`       | Unix timestamp as returned by the official API. Used as the natural deduplication key alongside `season`. |
+| `data`   | `Json`      | `JSONB`         | Parsed and structured snapshot data.                                                                      |
+
+**Constraints:**
+
+| Type       | Fields           | Notes                                                           |
+| ---------- | ---------------- | --------------------------------------------------------------- |
+| `@@unique` | `[season, time]` | Prevents duplicate snapshots for the same timestamp in a season |
+| `@@index`  | `[season]`       | Supports fetching all snapshots for a season                    |
+
+---
+
+### h1_event
+
+A unified table that holds both attack and defend events in a single model. The `type` column discriminates between the two event kinds, eliminating the need for UNION queries across separate tables.
+
+| Field              | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                                       |
+| ------------------ | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                                                   |
+| `season`           | `Int`       | `INTEGER`       | FK → `h1_season.season`                                                                                                   |
+| `type`             | `String`    | `TEXT`          | `"attack"` or `"defend"` — discriminator column                                                                           |
+| `event_id`         | `Int`       | `INTEGER`       | Official API event identifier                                                                                             |
+| `start_time`       | `Int`       | `INTEGER`       | Unix timestamp                                                                                                            |
+| `end_time`         | `Int`       | `INTEGER`       | Unix timestamp                                                                                                            |
+| `region`           | `Int`       | `INTEGER`       | Actual region integer for defend events. Sentinel value `11` for attack events (attack events have no region in the API). |
+| `enemy`            | `Int`       | `INTEGER`       | Enemy faction identifier                                                                                                  |
+| `points_max`       | `Int`       | `INTEGER`       |                                                                                                                           |
+| `points`           | `Int`       | `INTEGER`       |                                                                                                                           |
+| `status`           | `String`    | `TEXT`          | `"active"`, `"success"`, or `"fail"`                                                                                      |
+| `players_at_start` | `Int?`      | `INTEGER`       | Nullable. Player count when the event started. May be unavailable for older events.                                       |
+
+**Constraints and indexes:**
+
+| Type       | Fields             | Notes                                                              |
+| ---------- | ------------------ | ------------------------------------------------------------------ |
+| `@@unique` | `[type, event_id]` | Compound unique — event IDs are unique within a type               |
+| `@@index`  | `[season, type]`   | Filter events by type within a season                              |
+| `@@index`  | `[season, status]` | Filter events by status within a season (e.g., active events only) |
+| `@@index`  | `[season, enemy]`  | Filter events by enemy faction within a season                     |
+
+**Relations:**
+
+| Relation name             | Target model        | Cardinality |
+| ------------------------- | ------------------- | ----------- |
+| `OneSeasonToManyEvents`   | `h1_season`         | many-to-one |
+| `OneEventToManySnapshots` | `h1_event_snapshot` | one-to-many |
+
+---
+
+### h1_event_snapshot
+
+Time-series point data for individual events. Each row captures the `points` and `points_max` of an event at a specific timestamp, enabling progress-over-time visualisations. Links to `h1_event` via the compound `(type, event_id)` key and to `h1_season` via `season`.
+
+| Field        | Prisma Type | PostgreSQL Type | Constraints / Notes                                                   |
+| ------------ | ----------- | --------------- | --------------------------------------------------------------------- |
+| `id`         | `String`    | `TEXT`          | `@id @default(uuid(7))`                                               |
+| `season`     | `Int`       | `INTEGER`       | Denormalised FK → `h1_season.season` for efficient per-season queries |
+| `type`       | `String`    | `TEXT`          | `"attack"` or `"defend"` — part of FK to `h1_event`                   |
+| `event_id`   | `Int`       | `INTEGER`       | Part of FK to `h1_event` via `(type, event_id)`                       |
+| `time`       | `Int`       | `INTEGER`       | Unix timestamp from API response                                      |
+| `points`     | `Int`       | `INTEGER`       | Event progress at this timestamp                                      |
+| `points_max` | `Int`       | `INTEGER`       | Maximum points for the event at this timestamp                        |
+
+**Constraints and indexes:**
+
+| Type       | Fields                   | Notes                                   |
+| ---------- | ------------------------ | --------------------------------------- |
+| `@@unique` | `[type, event_id, time]` | One snapshot per event per timestamp    |
+| `@@index`  | `[season, time]`         | Range queries by season and time window |
+| `@@index`  | `[event_id, time]`       | Fetch time-series for a specific event  |
+
+**Relations:**
+
+| Relation name                   | Target model | Cardinality |
+| ------------------------------- | ------------ | ----------- |
+| `OneEventToManySnapshots`       | `h1_event`   | many-to-one |
+| `OneSeasonToManyEventSnapshots` | `h1_season`  | many-to-one |
+
+---
+
+### h1_live
+
+Current live state for a faction within a season. Combines campaign status (points, status) with aggregate statistics (kills, missions, etc.) in a single denormalised row. One row per `(season, enemy)` pair.
+
+| Field                      | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                  |
+| -------------------------- | ----------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `id`                       | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                              |
+| `season`                   | `Int`       | `INTEGER`       | FK → `h1_season.season` (relation is optional in Prisma — `h1_season?` — but `season` is always set) |
+| `enemy`                    | `Int`       | `INTEGER`       | Enemy faction identifier: `0` = Bugs, `1` = Cyborgs, `2` = Illuminate                                |
+| `points`                   | `Int`       | `INTEGER`       | Current liberation points                                                                            |
+| `points_taken`             | `Int`       | `INTEGER`       | Points taken by the enemy                                                                            |
+| `points_max`               | `Int`       | `INTEGER`       | Maximum points for this faction                                                                      |
+| `status`                   | `String`    | `TEXT`          | Enum-like: `"active"`, `"defeated"`, `"hidden"`                                                      |
+| `introduction_order`       | `Int`       | `INTEGER`       | War-entry position (`0`, `1`, `2`, `255`)                                                            |
+| `season_duration`          | `Int`       | `INTEGER`       | Total duration of the season in seconds                                                              |
+| `players`                  | `Int`       | `INTEGER`       | Active players during measurement window                                                             |
+| `total_unique_players`     | `Int`       | `INTEGER`       | Unique players across the season                                                                     |
+| `missions`                 | `Int`       | `INTEGER`       | Total missions attempted                                                                             |
+| `successful_missions`      | `Int`       | `INTEGER`       |                                                                                                      |
+| `total_mission_difficulty` | `Int`       | `INTEGER`       | Sum of difficulty values across all missions                                                         |
+| `completed_planets`        | `Int`       | `INTEGER`       |                                                                                                      |
+| `defend_events`            | `Int`       | `INTEGER`       | Total defend events in the season                                                                    |
+| `successful_defend_events` | `Int`       | `INTEGER`       |                                                                                                      |
+| `attack_events`            | `Int`       | `INTEGER`       | Total attack events in the season                                                                    |
+| `successful_attack_events` | `Int`       | `INTEGER`       |                                                                                                      |
+| `deaths`                   | `BigInt`    | `BIGINT`        | Cumulative player deaths. BigInt used because this exceeds INT range at scale.                       |
+| `kills`                    | `BigInt`    | `BIGINT`        | Cumulative enemy kills                                                                               |
+| `accidentals`              | `BigInt`    | `BIGINT`        | Cumulative friendly-fire deaths                                                                      |
+| `shots`                    | `BigInt`    | `BIGINT`        | Cumulative shots fired                                                                               |
+| `hits`                     | `BigInt`    | `BIGINT`        | Cumulative shots that connected                                                                      |
+| `map`                      | `Json?`     | `JSONB`         | Optional. Computed map data for this faction's 11 regions plus homeworld.                            |
+
+**Constraints and indexes:**
+
+| Type       | Fields            | Notes                             |
+| ---------- | ----------------- | --------------------------------- |
+| `@@unique` | `[season, enemy]` | One live row per enemy per season |
+| `@@index`  | `[season]`        | All enemies in a season           |
+
+> **BigInt fields:** `deaths`, `kills`, `accidentals`, `shots`, and `hits` use `BigInt` (PostgreSQL `BIGINT`) rather than `Int`. Helldivers cumulative counts for an active season easily exceed the 32-bit integer maximum of ~2.1 billion. When reading these values in JavaScript, Prisma returns them as native `BigInt` primitives — serialisation to JSON requires explicit conversion (e.g., `.toString()` or a custom serialiser).
+
+---
+
+### h1_live_snapshot
+
+Time-series history of per-faction statistics. Each row captures the statistics fields for one enemy faction at a specific timestamp. Used for charting statistical trends over time within a season.
+
+| Field                      | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                                  |
+| -------------------------- | ----------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `id`                       | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                                              |
+| `season`                   | `Int`       | `INTEGER`       | FK → `h1_season.season` (relation is optional in Prisma — `h1_season?` — but `season` is always set) |
+| `time`                     | `Int`       | `INTEGER`       | Unix timestamp from API response                                                                     |
+| `enemy`                    | `Int`       | `INTEGER`       | Enemy faction identifier: `0` = Bugs, `1` = Cyborgs, `2` = Illuminate                                |
+| `season_duration`          | `Int`       | `INTEGER`       | Total duration of the season in seconds                                                              |
+| `players`                  | `Int`       | `INTEGER`       | Active players during measurement window                                                             |
+| `total_unique_players`     | `Int`       | `INTEGER`       | Unique players across the season                                                                     |
+| `missions`                 | `Int`       | `INTEGER`       | Total missions attempted                                                                             |
+| `successful_missions`      | `Int`       | `INTEGER`       |                                                                                                      |
+| `total_mission_difficulty` | `Int`       | `INTEGER`       | Sum of difficulty values across all missions                                                         |
+| `completed_planets`        | `Int`       | `INTEGER`       |                                                                                                      |
+| `defend_events`            | `Int`       | `INTEGER`       | Total defend events in the season                                                                    |
+| `successful_defend_events` | `Int`       | `INTEGER`       |                                                                                                      |
+| `attack_events`            | `Int`       | `INTEGER`       | Total attack events in the season                                                                    |
+| `successful_attack_events` | `Int`       | `INTEGER`       |                                                                                                      |
+| `deaths`                   | `BigInt`    | `BIGINT`        | Cumulative player deaths                                                                             |
+| `kills`                    | `BigInt`    | `BIGINT`        | Cumulative enemy kills                                                                               |
+| `accidentals`              | `BigInt`    | `BIGINT`        | Cumulative friendly-fire deaths                                                                      |
+| `shots`                    | `BigInt`    | `BIGINT`        | Cumulative shots fired                                                                               |
+| `hits`                     | `BigInt`    | `BIGINT`        | Cumulative shots that connected                                                                      |
+
+**Constraints and indexes:**
+
+| Type       | Fields                  | Notes                                           |
+| ---------- | ----------------------- | ----------------------------------------------- |
+| `@@unique` | `[season, enemy, time]` | One snapshot per enemy per timestamp per season |
+| `@@index`  | `[season, time]`        | Range queries by season and time window         |
+
+---
+
+## 4. Rebroadcast Models
+
+These two tables are the raw-cache layer. They store the unmodified JSON responses from the official Helldivers API and are written on every update cycle, before normalisation begins.
+
+### rebroadcast_status
+
+Stores the latest raw response for `get_campaign_status` keyed by season. One row per season, upserted on every successful fetch.
+
+| Field          | Prisma Type | PostgreSQL Type | Constraints / Notes                                         |
+| -------------- | ----------- | --------------- | ----------------------------------------------------------- |
+| `id`           | `String`    | `TEXT`          | `@id @default(uuid(7))`                                     |
+| `season`       | `Int`       | `INTEGER`       | `@unique` — one raw status record per season                |
+| `last_updated` | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())` — timestamp of the last successful upsert |
+| `json`         | `Json`      | `JSONB`         | Complete raw JSON response from the official API            |
+
+**No foreign key to `h1_season`.** This is intentional: the rebroadcast tables can receive data before the normalised `h1_season` row exists, and they must remain writable even if normalisation fails.
+
+---
+
+### rebroadcast_snapshot
+
+Stores the latest raw response for `get_snapshots` keyed by season. Same structure as `rebroadcast_status`.
+
+| Field          | Prisma Type | PostgreSQL Type | Constraints / Notes                              |
+| -------------- | ----------- | --------------- | ------------------------------------------------ |
+| `id`           | `String`    | `TEXT`          | `@id @default(uuid(7))`                          |
+| `season`       | `Int`       | `INTEGER`       | `@unique` — one raw snapshot record per season   |
+| `last_updated` | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                                |
+| `json`         | `Json`      | `JSONB`         | Complete raw JSON response from the official API |
+
+> Note that `rebroadcast_snapshot` stores only the **latest** snapshot response per season, not time-series history. The time-series is built by normalising individual snapshots into `h1_snapshot` rows.
+
+---
+
+## 5. Auth and User Models
+
+These models implement [BetterAuth](https://www.better-auth.com/) with the Prisma adapter, plus application-specific extensions. Authentication is OAuth-only (Discord and GitHub providers). See [Authentication](/docs/authentication) for architecture details.
+
+### User
+
+Central user record. Extended beyond the BetterAuth baseline with `username`, `role`, `banned`, and application-specific relations.
+
+| Field           | Prisma Type | PostgreSQL Type | Constraints / Notes                                                       |
+| --------------- | ----------- | --------------- | ------------------------------------------------------------------------- |
+| `id`            | `String`    | `TEXT`          | `@id @default(uuid(7))`                                                   |
+| `name`          | `String?`   | `TEXT`          | Display name, optional                                                    |
+| `username`      | `String?`   | `TEXT`          | `@unique` — intended to hold the user's Discord username                  |
+| `email`         | `String?`   | `TEXT`          | `@unique`                                                                 |
+| `emailVerified` | `Boolean`   | `BOOLEAN`       | `@default(false)` — whether the user's email is confirmed                 |
+| `image`         | `String?`   | `TEXT`          | Avatar URL from OAuth provider or Gravatar fallback                       |
+| `role`          | `String`    | `TEXT`          | `@default("user")` — application role string, not an enum                 |
+| `banned`        | `Boolean`   | `BOOLEAN`       | `@default(false)` — banned users have sessions revoked on next request    |
+| `createdAt`     | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                                                         |
+| `updatedAt`     | `DateTime`  | `TIMESTAMPTZ`   | `@updatedAt`                                                              |
+
+**Relations:**
+
+| Field      | Type        | Notes                           |
+| ---------- | ----------- | ------------------------------- |
+| `accounts` | `Account[]` | OAuth provider accounts         |
+| `sessions` | `Session[]` | Active sessions                 |
+| `settings` | `Settings?` | One-to-one application settings |
+| `reviews`  | `Review[]`  | Blog-style review posts         |
+| `apiKeys`  | `ApiKey[]`  | API access keys                 |
+
+---
+
+### Account
+
+BetterAuth OAuth account record. Links a user to an OAuth provider. Multiple providers per user are supported (e.g., both Discord and GitHub linked to one account).
+
+| Field                      | Prisma Type  | PostgreSQL Type | Constraints / Notes                                    |
+| -------------------------- | ------------ | --------------- | ------------------------------------------------------ |
+| `id`                       | `String`     | `TEXT`          | `@id @default(uuid(7))`                                |
+| `userId`                   | `String`     | `TEXT`          | FK → `User.id`, `onDelete: Cascade`                    |
+| `accountId`                | `String`     | `TEXT`          | Provider's identifier for this account (replaces old `providerAccountId`) |
+| `providerId`               | `String`     | `TEXT`          | Provider name, e.g., `"discord"`, `"github"` (replaces old `provider`)   |
+| `accessToken`              | `String?`    | `TEXT`          | `@db.Text` — OAuth access token                       |
+| `refreshToken`             | `String?`    | `TEXT`          | `@db.Text` — OAuth refresh token                      |
+| `accessTokenExpiresAt`     | `DateTime?`  | `TIMESTAMPTZ`   | Access token expiry (replaces old integer `expires_at`) |
+| `refreshTokenExpiresAt`    | `DateTime?`  | `TIMESTAMPTZ`   | Refresh token expiry                                   |
+| `idToken`                  | `String?`    | `TEXT`          | `@db.Text` — OIDC identity token                      |
+| `scope`                    | `String?`    | `TEXT`          | OAuth scopes granted                                   |
+| `password`                 | `String?`    | `TEXT`          | Unused — present for BetterAuth email/password auth (not configured) |
+| `createdAt`                | `DateTime`   | `TIMESTAMPTZ`   | `@default(now())`                                      |
+| `updatedAt`                | `DateTime`   | `TIMESTAMPTZ`   | `@updatedAt`                                           |
+
+**Indexes:** `@@index([userId])`
+
+> Unlike the previous NextAuth.js schema, `userId` no longer has a `@unique` constraint. BetterAuth allows multiple OAuth accounts per user, enabling users to link both Discord and GitHub.
+
+---
+
+### Session
+
+BetterAuth database session. Each row represents an active session with metadata.
+
+| Field       | Prisma Type | PostgreSQL Type | Constraints / Notes                                       |
+| ----------- | ----------- | --------------- | --------------------------------------------------------- |
+| `id`        | `String`    | `TEXT`          | `@id @default(uuid(7))`                                   |
+| `token`     | `String`    | `TEXT`          | `@unique` — opaque session token (replaces old `sessionToken`) |
+| `userId`    | `String`    | `TEXT`          | FK → `User.id`, `onDelete: Cascade`                       |
+| `expiresAt` | `DateTime`  | `TIMESTAMPTZ`   | Session expiry (replaces old `expires`)                    |
+| `ipAddress` | `String?`   | `TEXT`          | Client IP at session creation                              |
+| `userAgent` | `String?`   | `TEXT`          | Client user agent at session creation                      |
+| `createdAt` | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                                          |
+| `updatedAt` | `DateTime`  | `TIMESTAMPTZ`   | `@updatedAt`                                               |
+
+**Indexes:** `@@index([userId])`
+
+---
+
+### Verification
+
+BetterAuth verification tokens for email verification and other confirmation flows.
+
+| Field        | Prisma Type | PostgreSQL Type | Constraints / Notes                        |
+| ------------ | ----------- | --------------- | ------------------------------------------ |
+| `id`         | `String`    | `TEXT`          | `@id @default(uuid(7))`                    |
+| `identifier` | `String`    | `TEXT`          | Typically the user's email address          |
+| `value`      | `String`    | `TEXT`          | Verification token value (replaces old `token`) |
+| `expiresAt`  | `DateTime`  | `TIMESTAMPTZ`   | Token expiry                                |
+| `createdAt`  | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                           |
+| `updatedAt`  | `DateTime`  | `TIMESTAMPTZ`   | `@updatedAt`                                |
+
+**Constraints:** `@@unique([identifier, value])` — composite uniqueness on identifier + value pair.
+
+---
+
+### Settings
+
+One-to-one with `User`. Stores all user preferences as a single JSON blob. Uses `userId` as both the primary key and the FK, enforcing the one-to-one relationship at the database level.
+
+| Field      | Prisma Type | PostgreSQL Type | Constraints / Notes                                          |
+| ---------- | ----------- | --------------- | ------------------------------------------------------------ |
+| `userId`   | `String`    | `TEXT`          | `@id @unique` FK → `User.id`. PK and FK are the same column. |
+| `settings` | `Json`      | `JSONB`         | Arbitrary user preference data                               |
+
+---
+
+### Review
+
+Blog-style user-submitted content. Currently unpublished by default, suggesting a moderation workflow.
+
+| Field       | Prisma Type | PostgreSQL Type | Constraints / Notes                                  |
+| ----------- | ----------- | --------------- | ---------------------------------------------------- |
+| `id`        | `String`    | `TEXT`          | `@id @default(uuid(7))`                              |
+| `createdAt` | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                                    |
+| `updatedAt` | `DateTime`  | `TIMESTAMPTZ`   | `@updatedAt`                                         |
+| `title`     | `String`    | `TEXT`          | Required                                             |
+| `content`   | `String?`   | `TEXT`          | Optional body                                        |
+| `published` | `Boolean`   | `BOOLEAN`       | `@default(false)` — requires explicit publish action |
+| `authorId`  | `String`    | `TEXT`          | FK → `User.id`                                       |
+
+---
+
+### ApiKey
+
+Application API keys for external consumers. A random UUID is generated as the key, SHA-256 hashed for storage. The plaintext key is shown once at creation and never stored, making the `visible` field the only partially-readable remnant.
+
+| Field         | Prisma Type | PostgreSQL Type | Constraints / Notes                                                                   |
+| ------------- | ----------- | --------------- | ------------------------------------------------------------------------------------- |
+| `id`          | `String`    | `TEXT`          | `@id @default(uuid(7))` — surrogate PK                                                |
+| `hash`        | `String`    | `TEXT`          | `@unique` — SHA-256 hash of the API key. Used for constant-time lookup on incoming requests. |
+| `visible`     | `String`    | `TEXT`          | Last 4 characters of the key, for display in the dashboard (e.g., `"...a3f2"`)        |
+| `userId`      | `String`    | `TEXT`          | FK → `User.id`, `onDelete: Cascade`                                                   |
+| `description` | `String`    | `TEXT`          | User-provided label for the key                                                       |
+| `createdAt`   | `DateTime`  | `TIMESTAMPTZ`   | `@default(now())`                                                                     |
+| `enabled`     | `Boolean`   | `BOOLEAN`       | `@default(true)` — keys can be disabled without deletion                              |
+
+> **Security note:** SHA-256 is used as a one-way hash for key lookup. The key space is a random UUID (128 bits of entropy), which provides the actual security. The hash allows O(1) database lookups without storing the raw key. Validation logic is in `src/db/queries/validateApiKey.mjs`.
+
+---
+
+## 6. Push Notifications
+
+### push_subscription
+
+Stores Web Push API subscriptions for server-initiated push notifications. Subscriptions are anonymous (no user link required). Created via `POST /api/notifications/subscribe`, removed on unsubscribe or when the push service returns 410/404 (stale endpoint).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | Int | PK, auto-increment | Sequential identifier |
+| `endpoint` | String | Unique, indexed | Push service endpoint URL (max ~2048 chars) |
+| `keys_p256dh` | String | Required | ECDH public key (base64) |
+| `keys_auth` | String | Required | Auth secret (base64) |
+| `created_at` | DateTime | Default `now()` | Subscription creation time |
+
+**Relationships:** None (standalone table, not linked to User).
+
+**Used by:** `src/update/pushNotifier.mjs` (queries all subscriptions on event transitions), `src/app/api/notifications/subscribe/route.js` (CRUD).
+
+---
+
+## 7. App Configuration Model
+
+### App
+
+A single-row configuration table for application-level state. Intended to have exactly one row at runtime.
+
+| Field           | Prisma Type | PostgreSQL Type | Constraints / Notes                                     |
+| --------------- | ----------- | --------------- | ------------------------------------------------------- |
+| `id`            | `String`    | `TEXT`          | `@id @default(uuid(7))`                                 |
+| `version`       | `String`    | `TEXT`          | Application version string                              |
+| `active_season` | `Int`       | `INTEGER`       | `@default(0)` — the currently active game season number |
+
+Several fields are commented out in the schema (`is_db_initialized`, `last_updated_status`, `last_updated_season`, `settings`), indicating planned but deferred functionality.
+
+---
+
+## 8. Index and Constraint Summary
+
+This table enumerates every uniqueness constraint and index across the schema.
+
+| Model                   | Constraint Type | Fields                          | Notes                                       |
+| ----------------------- | --------------- | ------------------------------- | ------------------------------------------- |
+| `h1_season`             | `@unique`       | `season`                        | Game season number is globally unique       |
+| `h1_season`             | `@@index`       | `[season]`                      |                                             |
+| `h1_season`             | `@@index`       | `[last_updated]`                |                                             |
+| `h1_introduction_order` | `@unique`       | `season`                        | Enforces one-to-one with `h1_season`        |
+| `h1_introduction_order` | `@@index`       | `[season]`                      |                                             |
+| `h1_points_max`         | `@unique`       | `season`                        | Enforces one-to-one with `h1_season`        |
+| `h1_points_max`         | `@@index`       | `[season]`                      |                                             |
+| `h1_snapshot`           | `@@unique`      | `[season, time]`                | One snapshot per timestamp per season       |
+| `h1_snapshot`           | `@@index`       | `[season]`                      |                                             |
+| `h1_event`              | `@@unique`      | `[type, event_id]`              | Compound unique on type + event ID          |
+| `h1_event`              | `@@index`       | `[season, type]`                |                                             |
+| `h1_event`              | `@@index`       | `[season, status]`              |                                             |
+| `h1_event`              | `@@index`       | `[season, enemy]`               |                                             |
+| `h1_event_snapshot`     | `@@unique`      | `[type, event_id, time]`        | One snapshot per event per timestamp        |
+| `h1_event_snapshot`     | `@@index`       | `[season, time]`                | Range queries by season and time window     |
+| `h1_event_snapshot`     | `@@index`       | `[event_id, time]`              | Time-series for a specific event            |
+| `h1_live`               | `@@unique`      | `[season, enemy]`               | One live row per enemy per season           |
+| `h1_live`               | `@@index`       | `[season]`                      |                                             |
+| `h1_live_snapshot`      | `@@unique`      | `[season, enemy, time]`         | One snapshot per enemy per timestamp        |
+| `h1_live_snapshot`      | `@@index`       | `[season, time]`                | Range queries by season and time window     |
+| `rebroadcast_status`    | `@unique`       | `season`                        | One raw status record per season            |
+| `rebroadcast_snapshot`  | `@unique`       | `season`                        | One raw snapshot record per season          |
+| `User`                  | `@unique`       | `username`                      |                                             |
+| `User`                  | `@unique`       | `email`                         |                                             |
+| `Account`               | `@@index`       | `[userId]`                      |                                             |
+| `Session`               | `@unique`       | `token`                         | Opaque session token                        |
+| `Session`               | `@@index`       | `[userId]`                      |                                             |
+| `Verification`          | `@@unique`      | `[identifier, value]`           | Composite uniqueness for verification tokens |
+| `Settings`              | `@id`           | `userId`                        | PK is also the FK                           |
+| `Settings`              | `@unique`       | `userId`                        | Redundant given `@id`, but explicit         |
+| `ApiKey`                | `@unique`       | `hash`                          | MD5 hash lookup                             |
+
+---
+
+## Cross-References
+
+- See [Data Flow](/docs/data-flow) for the sequence in which these tables are populated during an update cycle, including the two-table strategy (rebroadcast then normalised).
+- See [API Reference](/docs/api) for the API endpoints that read from and write to these tables, including the `GET /api/h1/campaign` query shape and the rebroadcast endpoint.

--- a/src/app/docs/hd1-api/page.mdx
+++ b/src/app/docs/hd1-api/page.mdx
@@ -1,0 +1,401 @@
+export const metadata = {
+    title: 'Official API | Helldivers Bot',
+    description:
+        'Unofficial documentation for the official Helldivers 1 API — endpoints, request formats, and response structures.',
+    alternates: { canonical: '/docs/hd1-api' },
+    openGraph: { url: '/docs/hd1-api' },
+    robots: { index: false },
+};
+
+# Unofficial Helldivers 1 API Documentation
+
+by XTC
+
+> This is external reference material documenting the official Helldivers 1 API at `api.helldiversgame.com`. It is not part of the helldivers.bot API. For the helldivers.bot API, see [API Reference](/docs/api).
+
+---
+
+## General Infrastructure
+
+There are two servers the client connects to:
+
+- **api.helldiversgame.com** — global stats, events, and battlefield data
+- **helldivers.api.wwsga.me** — userdata (do not connect to this server)
+
+The client uses [libcurl](https://curl.haxx.se/download.html) with SSL. Certificate pinning may be in use.
+
+Global statistics are available via HTTPS POST to `https://api.helldiversgame.com/1.0/`.
+
+If no POST parameters are given, the server returns:
+
+```json
+{"time": <unix_time>, "error_code": 1, "error_message": "No action set"}
+```
+
+Valid `action` POST parameter values:
+
+- `get_campaign_status`
+- `get_usernames`
+- `get_available_entitlements`
+- `get_snapshots`
+- `get_leaderboards`
+
+---
+
+## get_campaign_status
+
+Returns the current war state including campaign progress, events, and statistics.
+
+**Response structure:**
+
+| Key               | Value                                                    |
+| ----------------- | -------------------------------------------------------- |
+| `time`            | Unix timestamp of request                                |
+| `error_code`      | `0`                                                      |
+| `campaign_status` | Array of faction status objects (see below)               |
+| `defend_event`    | Current/most recent defense event object                 |
+| `attack_events`   | Array of homeworld assault objects (one per faction)     |
+| `statistics`      | Array of global stats objects (one per faction)           |
+
+### campaign_status
+
+Array of 3 objects ordered by faction: index 0 = Bugs, 1 = Cyborgs, 2 = Illuminate.
+
+| Key                  | Data Type | Value                                                                                              |
+| -------------------- | :-------: | -------------------------------------------------------------------------------------------------- |
+| `season`             |  number   | Season / War number                                                                                |
+| `points`             |  number   | Current influence points (decreases over time)                                                     |
+| `points_taken`       |  number   | Total influence points gained by players                                                           |
+| `points_max`         |  number   | Points required to trigger a homeworld assault event                                               |
+| `status`             |  string   | `'active'`, `'defeated'`, or `'hidden'`                                                            |
+| `introduction_order` |  number   | Order in which faction was introduced to the war (255 if not yet introduced)                       |
+
+### defend_event
+
+Single object for the most recent or currently active defense event.
+
+| Key          | Data Type | Value                                                                  |
+| ------------ | :-------: | ---------------------------------------------------------------------- |
+| `season`     |  number   | Season / War number                                                    |
+| `event_id`   |  number   | Defense event ID                                                       |
+| `start_time` |  number   | Unix timestamp of event start                                          |
+| `end_time`   |  number   | Unix timestamp of event deadline                                       |
+| `region`     |  number   | ID of the region containing the defended planet                        |
+| `enemy`      |  number   | Enemy faction ID (0=Bugs, 1=Cyborgs, 2=Illuminate)                    |
+| `points`     |  number   | Current influence points gained                                        |
+| `points_max` |  number   | Points needed for the defense to succeed                               |
+| `status`     |  string   | `'active'`, `'success'`, or `'failure'`                                |
+
+### attack_events
+
+Array of 3 objects (one per faction) for the most recent homeworld assault of each faction.
+
+| Key                | Data Type | Value                                                              |
+| ------------------ | :-------: | ------------------------------------------------------------------ |
+| `season`           |  number   | Season / War number                                                |
+| `event_id`         |  number   | Attack event ID                                                    |
+| `start_time`       |  number   | Unix timestamp of event start                                      |
+| `end_time`         |  number   | Unix timestamp of event deadline                                   |
+| `enemy`            |  number   | Enemy faction ID                                                   |
+| `points`           |  number   | Current influence points gained                                    |
+| `points_max`       |  number   | Points needed for the assault to succeed                           |
+| `status`           |  string   | `'active'`, `'success'`, or `'failure'`                            |
+| `players_at_start` |  number   | Players in mission when the event started                          |
+| `max_event_id`     |  number   | Same as `event_id` (purpose unclear)                               |
+
+### statistics
+
+Array of 3 objects (one per faction). Sum all three for global totals.
+
+| Key                        | Data Type | Value                                        |
+| -------------------------- | :-------: | -------------------------------------------- |
+| `season`                   |  number   | Season / War number                          |
+| `season_duration`          |  number   | Seconds the current war has been going       |
+| `enemy`                    |  number   | Enemy faction ID                             |
+| `players`                  |  number   | Players currently online                     |
+| `total_unique_players`     |  number   | Unique players this season                   |
+| `missions`                 |  number   | Total missions played                        |
+| `successful_missions`      |  number   | Successful missions                          |
+| `total_mission_difficulty` |  number   | Sum of difficulty of successful missions     |
+| `completed_planets`        |  number   | Planets where all missions were completed    |
+| `defend_events`            |  number   | Total defend events                          |
+| `successful_defend_events` |  number   | Successful defend events                     |
+| `attack_events`            |  number   | Total homeworld assaults                     |
+| `successful_attack_events` |  number   | Successful homeworld assaults                |
+| `deaths`                   |  number   | Player deaths                                |
+| `accidentals`              |  number   | Player-caused deaths (friendly fire)         |
+| `shots`                    |  number   | Shots fired                                  |
+| `hits`                     |  number   | Shots hit                                    |
+| `kills`                    |  number   | Enemies killed                               |
+
+---
+
+## get_usernames
+
+**POST parameters:**
+
+| Key       | Value                                 |
+| --------- | ------------------------------------- |
+| `action`  | `'get_usernames'`                     |
+| `network` | `'steam'` (PC) or `'psn'` (PlayStation) |
+| `count`   | Number of users to retrieve           |
+
+**Response:**
+
+| Key          | Data Type | Value                     |
+| ------------ | :-------: | ------------------------- |
+| `time`       |  number   | Unix timestamp            |
+| `error_code` |  number   | `0`                       |
+| `usernames`  |  Array    | Array of user identifiers |
+
+For `network: 'steam'`, the array contains hex Steam IDs. For `network: 'psn'`, it contains PSN usernames.
+
+---
+
+## get_available_entitlements
+
+DLC availability (details undocumented).
+
+---
+
+## get_snapshots
+
+Historical war data for a specific season.
+
+**POST parameters:**
+
+| Key      | Value                         |
+| -------- | ----------------------------- |
+| `action` | `'get_snapshots'`             |
+| `season` | Season number to retrieve     |
+
+**Response:**
+
+| Key                  | Data Type | Value                                                  |
+| -------------------- | :-------: | ------------------------------------------------------ |
+| `time`               |  number   | Unix timestamp                                         |
+| `error_code`         |  number   | `0`                                                    |
+| `introduction_order` |  Array    | 3 numbers showing faction introduction order (0/1/2 or 255) |
+| `points_max`         |  Array    | Points needed per faction to trigger homeworld assault  |
+| `snapshots`          |  Array    | Time-series data points                                |
+| `defend_events`      |  Array    | Completed defense events                               |
+| `attack_events`      |  Array    | Completed homeworld assaults                           |
+
+### snapshots
+
+Each snapshot object has `season` (number), `time` (Unix timestamp), and `data` (stringified JSON array of 3 objects):
+
+| Key            | Data Type | Value                                    |
+| -------------- | :-------: | ---------------------------------------- |
+| `points`       |  number   | Points needed for homeworld assault      |
+| `points_taken` |  number   | Points players have gained               |
+| `status`       |  string   | `'hidden'`, `'active'`, `'success'`, or `'fail'` |
+
+### defend_events / attack_events
+
+Same structure as `defend_event` / `attack_events` in `get_campaign_status`, but with `status` values limited to `'success'` or `'fail'` (only completed events).
+
+---
+
+## get_leaderboards
+
+**POST parameters:**
+
+| Key       | Value                                     |
+| --------- | ----------------------------------------- |
+| `action`  | `'get_leaderboards'`                      |
+| `network` | `'steam'` or `'psn'`                     |
+| `season`  | Season number                             |
+
+**Optional parameters:**
+
+| Key     | Value                                              |
+| ------- | -------------------------------------------------- |
+| `count` | Number of users to retrieve                        |
+| `users` | Array of Steam IDs to filter                       |
+
+**Response:**
+
+| Key                 | Data Type | Value                                                |
+| ------------------- | :-------: | ---------------------------------------------------- |
+| `time`              |  number   | Unix timestamp                                       |
+| `error_code`        |  number   | `0`                                                  |
+| `leaderboards`      |  Array    | 4 arrays: Bugs, Cyborgs, Illuminate, Global          |
+| `user_leaderboards` |  Array    | Filtered leaderboard data (only if `users` provided) |
+
+### Leaderboard entry
+
+| Key         | Data Type | Value                              |
+| ----------- | :-------: | ---------------------------------- |
+| `online_id` |  string   | Steam ID (hex) or PSN username     |
+| `playtime`  |  number   | Playtime in seconds                |
+| `planets`   |  number   | Liberated planets                  |
+| `score`     |  number   | Community points                   |
+| `player_xp` |  number   | Experience points                  |
+
+---
+
+## Sample Responses
+
+<details>
+<summary>get_campaign_status</summary>
+
+```json
+{
+    "time": 1774438558,
+    "error_code": 0,
+    "campaign_status": [
+        {
+            "season": 156,
+            "points": 170123,
+            "points_taken": 387515,
+            "points_max": 543480,
+            "status": "active",
+            "introduction_order": 0
+        },
+        {
+            "season": 156,
+            "points": 176310,
+            "points_taken": 260874,
+            "points_max": 352100,
+            "status": "active",
+            "introduction_order": 1
+        },
+        {
+            "season": 156,
+            "points": 166514,
+            "points_taken": 115874,
+            "points_max": 253200,
+            "status": "active",
+            "introduction_order": 2
+        }
+    ],
+    "defend_event": {
+        "season": 156,
+        "event_id": 4888,
+        "start_time": 1774425902,
+        "end_time": 1774433161,
+        "region": 5,
+        "enemy": 1,
+        "points_max": 502,
+        "points": 502,
+        "status": "success"
+    },
+    "attack_events": [
+        {
+            "season": 155,
+            "event_id": 915,
+            "start_time": 1772992682,
+            "end_time": 1773165482,
+            "enemy": 0,
+            "points_max": 44933,
+            "points": 22592,
+            "status": "fail",
+            "players_at_start": 331,
+            "max_event_id": 915
+        },
+        {
+            "season": 156,
+            "event_id": 916,
+            "start_time": 1774216801,
+            "end_time": 1774389601,
+            "enemy": 1,
+            "points_max": 35014,
+            "points": 19611,
+            "status": "fail",
+            "players_at_start": 378,
+            "max_event_id": 916
+        },
+        {
+            "season": 155,
+            "event_id": 907,
+            "start_time": 1769891101,
+            "end_time": 1770063901,
+            "enemy": 2,
+            "points_max": 35795,
+            "points": 15931,
+            "status": "fail",
+            "players_at_start": 300,
+            "max_event_id": 907
+        }
+    ],
+    "statistics": [
+        {
+            "season": 156,
+            "season_duration": 1261959,
+            "enemy": 0,
+            "players": 88,
+            "total_unique_players": 14544,
+            "missions": 94795,
+            "successful_missions": 58952,
+            "total_mission_difficulty": 283978,
+            "completed_planets": 20589,
+            "defend_events": 13,
+            "successful_defend_events": 4,
+            "attack_events": 1,
+            "successful_attack_events": 0,
+            "deaths": 368138,
+            "kills": 19327247,
+            "accidentals": 90764,
+            "shots": 87879653,
+            "hits": 40746802
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+<summary>get_snapshots (season 1)</summary>
+
+```json
+{
+    "time": 1774438591,
+    "error_code": 0,
+    "introduction_order": [2, 1, 0],
+    "points_max": [30000, 30000, 30000],
+    "snapshots": [
+        {
+            "season": 1,
+            "time": 1424881142,
+            "data": "[{\"points\":1500,\"points_taken\":0,\"status\":\"hidden\"},{\"points\":1500,\"points_taken\":0,\"status\":\"hidden\"},{\"points\":1500,\"points_taken\":0,\"status\":\"active\"}]"
+        }
+    ],
+    "defend_events": [
+        {
+            "season": 1,
+            "event_id": 1,
+            "start_time": 1424881201,
+            "end_time": 1424881321,
+            "region": 5,
+            "enemy": 2,
+            "points_max": 48,
+            "points": 48,
+            "status": "success",
+            "players_at_start": 1
+        }
+    ],
+    "attack_events": [
+        {
+            "season": 1,
+            "event_id": 1,
+            "start_time": 1425099481,
+            "end_time": 1425272281,
+            "enemy": 0,
+            "points_max": 17960,
+            "points": 1265,
+            "status": "success",
+            "players_at_start": 1
+        }
+    ]
+}
+```
+
+</details>
+
+---
+
+## Disclaimer
+
+The Helldivers API servers and the entire API are not intended for third-party use. The writers behind this documentation do not take responsibility for legal action taken against the usage of the API.

--- a/src/app/docs/infrastructure/page.mdx
+++ b/src/app/docs/infrastructure/page.mdx
@@ -1,0 +1,412 @@
+export const metadata = {
+    title: 'Infrastructure | Helldivers Bot',
+    description: 'Docker strategy, CI/CD pipelines, initialization flow, and environment variables for helldivers.bot.',
+    alternates: { canonical: '/docs/infrastructure' },
+    openGraph: { url: '/docs/infrastructure' },
+};
+
+# Infrastructure
+
+Technical reference for the helldivers.bot infrastructure layer. Audience: project owner and AI assistants.
+
+```mermaid
+graph LR
+    subgraph Startup["Container Startup Order"]
+        direction TB
+        M["Dockerfile.migrate"] --> |"1. prisma migrate deploy"| MIG["Run Migrations"]
+        MIG --> |"2. seed.mjs"| SEED["Seed Historical Data"]
+        SEED --> |"exit 0"| DONE["Container Exits"]
+    end
+
+    subgraph App["Application Container"]
+        direction TB
+        A["Dockerfile"] --> |"npm start"| SERVER["Next.js Server"]
+        SERVER --> |"instrumentation.js"| WORKER["Worker Thread"]
+        WORKER --> |"setTimeout loop"| POLL["Poll Official API"]
+    end
+
+    Startup --> |"then"| App
+
+    style Startup fill:#1c1917,stroke:#f59e0b,color:#fbbf24
+    style App fill:#0f1a0f,stroke:#22c55e,color:#4ade80
+```
+
+---
+
+## Section 1: Docker Strategy
+
+The project uses two separate Dockerfiles. Migrations and the application server run in separate containers with a defined startup order.
+
+### Dockerfile.migrate
+
+**Image:** `ghcr.io/elfensky/helldiversbot-migrate:staging`
+
+**Purpose:** Runs `prisma migrate deploy` once and exits. It never stays alive.
+
+**Build process:**
+
+1. Base image: `node:22-alpine`
+2. Install `tini` via `apk` (init system for zombie process prevention)
+3. Upgrade npm to `11.7.0`
+4. `WORKDIR /app`
+5. Copy `package.json`, `package-lock.json`, `prisma/`, and `prisma.config.mjs`
+6. Extract the Prisma version from `package.json` at build time and install only that version — no full `npm ci`
+7. Run `npx prisma generate` to produce the client
+8. Entrypoint: `/sbin/tini --`
+9. CMD: `npx prisma migrate deploy && node --experimental-strip-types prisma/seed/seed.mjs` — runs migrations first, then seeds historical season data from JSON files in `prisma/seed/seasons/`. The seed uses upserts and is idempotent (safe to re-run on every deploy). If no season files exist, the seed exits gracefully.
+
+The Prisma version extraction uses a shell one-liner:
+
+```dockerfile
+COPY package.json package-lock.json ./
+COPY prisma ./prisma/
+COPY prisma.config.mjs ./
+RUN PRISMA_VERSION=$(node -p "require('./package.json').devDependencies?.prisma || require('./package.json').dependencies?.prisma") && \
+    ADAPTER_PG_VERSION=$(node -p "require('./package.json').dependencies?.['@prisma/adapter-pg'] || ''") && \
+    DOTENV_VERSION=$(node -p "require('./package.json').dependencies?.dotenv || ''") && \
+    npm install prisma@$PRISMA_VERSION @prisma/client@$PRISMA_VERSION @prisma/adapter-pg@$ADAPTER_PG_VERSION dotenv@$DOTENV_VERSION && \
+    npx prisma generate
+```
+
+Prisma 7 CLI no longer auto-loads `.env` files. The `prisma.config.mjs` file imports `dotenv/config` to handle local env loading; in Docker, `POSTGRES_URL` is injected via `docker-compose`'s `env_file`.
+
+This keeps the migrate image small — it carries only the Prisma CLI, not the entire application dependency tree.
+
+### Dockerfile.app
+
+**Image:** `ghcr.io/elfensky/helldiversbot:staging`
+
+**Purpose:** Runs the Next.js standalone server. This container never touches migrations.
+
+**Build stages:**
+
+| Stage     | Base             | What it does                                                                                      |
+| --------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| `base`    | `node:22-alpine` | Installs `tini` and upgrades npm to `11.7.0`                                                      |
+| `deps`    | `base`           | Runs `npm ci` from lockfile; fails explicitly if lockfile is absent                               |
+| `builder` | `base`           | Copies `node_modules` from `deps`, copies source, runs `npx prisma generate` then `npm run build` |
+| `runner`  | `base`           | Copies only `.next/standalone`, `.next/static`, and `public`; runs as non-root user               |
+
+**Runner stage details:**
+
+- `ARG NODE_ENV=production` — overridable at build time; staging CI passes `NODE_ENV=staging`
+- Creates system group `nodejs` (gid 1001) and user `nextjs` (uid 1001)
+- All copied files are `--chown=nextjs:nodejs`
+- `USER nextjs` is set before the entrypoint
+- OCI labels: `org.opencontainers.image.source`, `org.opencontainers.image.licenses`, `org.opencontainers.image.title`, `version`, `description`
+- Entrypoint: `/sbin/tini --`
+- CMD: `node server.js` (the Next.js standalone output file)
+- `EXPOSE 3000`, `ENV PORT=3000`, `ENV HOSTNAME="0.0.0.0"`
+- Healthcheck (Dockerfile-level): `curl -f http://0.0.0.0:3000/api/healthcheck` every 30s, timeout 5s, start period 5s, 3 retries
+
+### docker-compose.yml
+
+```
+migrate (helldiversbot-migrate:staging)
+  env_file: .docker.env
+  → runs once and exits
+
+helldiversbot (helldiversbot:staging)
+  env_file: .docker.env
+  environment: SKIP_MIGRATIONS=true
+  ports: 127.0.0.1:58102:3000
+  restart: unless-stopped
+  depends_on: migrate (condition: service_completed_successfully)
+  healthcheck: curl localhost:3000/api/healthcheck every 60s, timeout 10s, 3 retries, 10s start_period
+```
+
+The port binding `127.0.0.1:58102:3000` deliberately limits exposure to the host loopback interface. External traffic must arrive through a reverse proxy (e.g., nginx or Caddy) on the host.
+
+The `depends_on: condition: service_completed_successfully` ensures the app container does not start until migrations finish and the migrate container exits with code 0.
+
+`SKIP_MIGRATIONS=true` is passed to the app container environment to signal the initialization code that database setup has already been handled externally.
+
+### Why two containers
+
+Running migrations inside the app container creates a race condition when scaling to multiple replicas — each replica would attempt to apply migrations simultaneously. By delegating migrations to a one-shot container that must complete before the app starts, the compose startup sequence is deterministic and safe.
+
+---
+
+## Section 2: CI/CD Pipelines
+
+### Staging (`staging.docker.yml`)
+
+**Trigger:** Push to `main`, or manual `workflow_dispatch`
+
+**Jobs:** A `changes` job detects which files were modified. `build-app` always runs. `build-migrate` only runs when migration-related files changed (or on manual `workflow_dispatch`). A `cleanup` job runs after both builds complete (or are skipped).
+
+| Job             | Dockerfile           | Tag pushed                                       | Condition                                                                                                        |
+| --------------- | -------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `changes`       | ---                  | ---                                              | Always runs; outputs `migrate` boolean via `dorny/paths-filter`                                                  |
+| `build-migrate` | `Dockerfile.migrate` | `ghcr.io/elfensky/helldiversbot-migrate:staging` | Only when `prisma/**`, `prisma.config.mjs`, `package.json`, `package-lock.json`, or `Dockerfile.migrate` changed |
+| `build-app`     | `Dockerfile.app`     | `ghcr.io/elfensky/helldiversbot:staging`         | Always                                                                                                           |
+
+Both build jobs pass `NODE_ENV=staging` as a build arg.
+
+**Registry auth:** `secrets.GITHUB_TOKEN` — the default token with `contents: write` and `packages: write` permissions declared at the workflow level.
+
+**Cleanup job:** Uses `snok/container-retention-policy@v3.0.1`. Deletes untagged versions of both `helldiversbot` and `helldiversbot-migrate` packages that are older than 30 minutes. This keeps GHCR from accumulating dangling layers from every push.
+
+### Production (`release.docker.yml`)
+
+**Trigger:** Version tags matching the pattern `*.*.*` (e.g., `1.2.3`)
+
+**Jobs:** Single `build` job — only the app image is built; no migrate image is produced for production.
+
+**Tags pushed:**
+
+```
+ghcr.io/elfensky/helldiversbot:{git-tag}
+ghcr.io/elfensky/helldiversbot:production
+ghcr.io/elfensky/helldiversbot:latest
+```
+
+**Version extraction:** The workflow reads the version from `package.json` via `jq -r '.version' package.json` and injects it into the image via the `VERSION` ARG (used by the Dockerfile label `version="${VERSION}"`).
+
+**Registry auth:** `secrets.ACCESS_TOKEN` — a personal access token with elevated permissions. The default `GITHUB_TOKEN` is not used here because the job also creates a GitHub Release, which requires broader write access.
+
+**GitHub Release:** Created by `softprops/action-gh-release@v2`. The release body is sourced from `RELEASE.md` at the repository root.
+
+### Metrics (`metrics.yml`)
+
+**Trigger:** Scheduled (Mondays at 00:00 UTC, Fridays at 06:00 UTC), or manual dispatch.
+
+**Job:** Generates a PageSpeed Insights badge SVG using `lowlighter/metrics@latest` targeting `https://helldivers.bot`. The resulting `metrics.plugin.pagespeed.svg` is committed back to the repository. Requires `secrets.PAGESPEED_TOKEN`.
+
+---
+
+## Section 3: Initialization Flow
+
+**Entry point:** `src/instrumentation.js` — Next.js calls `register()` automatically on server startup via the instrumentation hook.
+
+### Full flow
+
+```
+register()   [src/instrumentation.js]
+│
+├── NEXT_RUNTIME === 'nodejs'
+│   └── import sentry.server.config.js     → Sentry.init() for server runtime
+│
+└── NEXT_RUNTIME === 'nodejs'
+    └── initializeHelldivers1Api()
+        │
+        ├── Step 1: initializeEnvironmentVariables()   [src/utils/initialize.env.mjs]
+        │   ├── checkDatabase()    → POSTGRES_URL                              ← REQUIRED, throws
+        │   ├── checkUpdates()     → UPDATE_KEY, UPDATE_INTERVAL               ← REQUIRED, throws (PORT optional)
+        │   ├── checkAnalytics()   → UMAMI_SITE_ID, SENTRY_DSN, SENTRY_AUTH_TOKEN  ← OPTIONAL, warns
+        │   ├── checkAuth()        → BETTER_AUTH_SECRET + 5 auth vars          ← OPTIONAL, warns (partial = throws)
+        │   └── Returns { auth: boolean, analytics: boolean }
+        │
+        ├── Step 2: initializeOpenApiSpec()            [src/utils/initialize.openapi.mjs]
+        │   ├── development: generates public/openapi.json from the OpenAPI registry, validates JSON
+        │   ├── production:  reads existing public/openapi.json, validates it parses as JSON
+        │   ├── staging:     falls through to false (neither branch matches NODE_ENV=staging)
+        │   └── false → throw (crashes the process)
+        │
+        └── Step 3: initializeWorker()                 [src/utils/initialize.worker.mjs]
+            ├── Resolves worker path:
+            │   ├── development: path.resolve(process.cwd(), 'public/workers/cron.js')
+            │   └── production:  path.resolve('/app/public/workers/cron.js')
+            ├── new Worker(workerPath)
+            ├── worker.postMessage({ key, interval, port })
+            ├── Attaches message/error/exit handlers
+            ├── Registers SIGINT/SIGTERM handlers that terminate the worker before exit
+            └── false → throw (crashes the process)
+```
+
+### Failure behavior
+
+Every initialization step fails hard: any error or falsy return causes a `throw new Error(...)` inside the `register()` function. Since Next.js does not catch errors thrown from `register()`, this crashes the process. There is no graceful degradation. The intent is that Docker's `restart: unless-stopped` will restart the container, giving the underlying problem (missing env var, bad database, missing OpenAPI spec) a chance to be resolved.
+
+### onRequestError export
+
+`src/instrumentation.js` also exports:
+
+```js
+export const onRequestError = Sentry.captureRequestError;
+```
+
+Next.js calls this hook for errors that occur inside Server Components, middleware, and proxied routes — errors that do not surface through the normal React error boundary. This is the server-side equivalent of `global-error.jsx`.
+
+---
+
+## Section 4: Error Tracking (Sentry / GlitchTip)
+
+The project uses the Sentry SDK (`@sentry/nextjs`) but targets a **self-hosted GlitchTip** instance rather than Sentry SaaS. GlitchTip is Sentry-protocol-compatible and supports error aggregation and performance traces but not session replay.
+
+### Configuration files
+
+| File                            | Runtime | Role                                                              |
+| ------------------------------- | ------- | ----------------------------------------------------------------- |
+| `sentry.server.config.js`       | Node.js | `Sentry.init()` called on server startup via `instrumentation.js` |
+| `src/instrumentation-client.js` | Browser | `Sentry.init()` called when a page loads in the browser           |
+| `src/app/api/glitchtip/route.js` | Node.js | Client tunnel — proxies Sentry envelopes to GlitchTip, bypassing ad blockers |
+
+### Shared SDK settings
+
+```js
+{
+    dsn: process.env.SENTRY_DSN,        // server: SENTRY_DSN, client: NEXT_PUBLIC_SENTRY_DSN
+    environment: process.env.NODE_ENV,  // "development" or "production" — filterable in GlitchTip
+    sendDefaultPii: true,               // safe on a self-hosted instance
+    tracesSampleRate: 1.0,              // 100% of requests traced
+    debug: false,
+}
+```
+
+Client-only additions: `autoSessionTracking: false` (GlitchTip doesn't support sessions), `tunnel: '/api/glitchtip'` (ad blocker bypass).
+
+### Client tunnel
+
+The `/api/glitchtip` route proxies Sentry envelope payloads to GlitchTip's ingest endpoint. This prevents ad blockers from blocking error reports since the SDK sends to the app's own domain. The tunnel extracts the DSN's public key and forwards to `https://<host>/api/<project>/envelope/?sentry_key=<key>&sentry_version=7`.
+
+### Error boundaries
+
+Three levels of error isolation:
+
+1. **`global-error.jsx`** — last-resort boundary wrapping the entire React tree. Renders its own `<html>`/`<body>` since the root layout is unavailable. Reuses the shared `RouteError` component.
+2. **Route-level `error.jsx`** — at root (`src/app/error.jsx`) and archives (`src/app/archives/error.jsx`). Thin wrappers around `RouteError` that catch errors within the layout.
+3. **`ComponentErrorBoundary`** — React class component wrapping Galaxy Map, Regions, Stats, Dashboard, and Timeline. Shows inline "failed to load" + retry button. Layout containers stay outside boundaries to preserve CSS grid/flex structure on error.
+
+Sentry captures errors automatically via its global handler — no manual `captureException` in any boundary.
+
+### Analytics proxy
+
+Umami v3 analytics use a same-origin proxy to bypass ad blockers:
+
+1. **Script proxy:** `/stats.js` → `umami.drunik.be/script.js` (Next.js rewrite in `next.config.mjs`)
+2. **Data proxy:** `/api/send` → `/api/umami` (Next.js rewrite) → `umami.drunik.be/api/send` (API route proxy)
+
+The proxy forwards `X-Forwarded-For` so Umami receives the real client IP for its cookieless session hash. No external Umami domain appears in CSP — both `script-src` and `connect-src` only reference `'self'`.
+
+Env vars: `UMAMI_SITE_URL` (domain without protocol, e.g., `umami.drunik.be`), `UMAMI_SITE_ID` (website UUID).
+
+### CSP violation reporting
+
+The CSP in `src/proxy.js` includes a `report-uri` directive pointing to GlitchTip's security endpoint. Browser-native CSP violations appear as issues in GlitchTip alongside application errors.
+
+### next.config.mjs Sentry settings
+
+The `withSentryConfig` wrapper controls build-time behavior:
+
+```js
+export default withSentryConfig(withMDX(nextConfig), {
+    silent: true,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    sentryUrl: process.env.SENTRY_URL,
+});
+```
+
+Source maps are uploaded to GlitchTip at build time for readable stack traces. The `authToken`, `org`, `project`, and `sentryUrl` env vars are only used during builds.
+
+---
+
+## Section 5: Environment Variables
+
+Variables are checked at startup by `initializeEnvironmentVariables()` in `src/utils/initialize.env.mjs`. The function uses **progressive enhancement**: core variables throw on missing (app cannot function), while auth and analytics variables warn and degrade gracefully. Returns `{ auth: boolean, analytics: boolean }` so the startup log shows which features are active.
+
+**Validation rules:**
+- **Core (database, worker):** Missing → throws, crashes the process.
+- **Auth:** `BETTER_AUTH_SECRET` absent → all auth disabled (warn). `BETTER_AUTH_SECRET` present but other auth vars missing → throws (partial config is a misconfiguration).
+- **Analytics:** Missing → warns. `SENTRY_DSN` set without `SENTRY_AUTH_TOKEN` → warns about degraded source maps.
+
+### Full variable reference
+
+| Variable                | Required    | Category       | Description                                                                                              |
+| ----------------------- | ----------- | -------------- | -------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_URL`          | **Yes**     | Database       | PostgreSQL connection string                                                                             |
+| `UPDATE_KEY`            | **Yes**     | Updates        | Bearer token for `/api/h1/update` — used by the worker to authenticate its polling requests              |
+| `UPDATE_INTERVAL`       | **Yes**     | Updates        | Polling interval in seconds (e.g., `"20"`); passed to the worker thread                                  |
+| `PORT`                  | No          | Updates        | Server port; defaults to `3000`; passed to the worker so it knows which port to poll                     |
+| `UMAMI_SITE_ID`         | No          | Analytics      | Umami website tracking ID; if absent, Umami script not loaded and server-side tracking skipped            |
+| `UMAMI_SITE_URL`        | No          | Analytics      | Umami instance URL; used in server-side fetch calls                                                      |
+| `SENTRY_DSN`            | No          | Error tracking | Sentry DSN for server-side error reporting (points to GlitchTip); if absent, error tracking disabled     |
+| `NEXT_PUBLIC_SENTRY_DSN`| No          | Error tracking | Sentry DSN for client-side error reporting (same DSN, exposed to browser)                                |
+| `SENTRY_AUTH_TOKEN`     | No          | Error tracking | GlitchTip API token for source map uploads; if absent, `withSentryConfig` build plugin skipped           |
+| `SENTRY_URL`            | No          | Error tracking | GlitchTip instance URL; used by `withSentryConfig` for source map uploads                                |
+| `SENTRY_ORG`            | No          | Error tracking | GlitchTip organization slug; used for source map uploads                                                 |
+| `SENTRY_PROJECT`        | No          | Error tracking | GlitchTip project slug; used for source map uploads                                                      |
+| `GLITCHTIP_HEARTBEAT_URL`| No         | Error tracking | GlitchTip uptime heartbeat endpoint; worker POSTs after each successful update                           |
+| `BETTER_AUTH_SECRET`    | No (all-or-none) | Auth    | BetterAuth session encryption secret; 128+ chars recommended. If absent, all auth features disabled. If present, all other auth vars are required |
+| `BETTER_AUTH_URL`       | If auth     | Auth           | Base URL for BetterAuth (e.g., `http://localhost:3000`; production: `https://helldivers.bot`)            |
+| `AUTH_DISCORD_ID`       | If auth     | Auth           | Discord OAuth application client ID                                                                      |
+| `AUTH_DISCORD_SECRET`   | If auth     | Auth           | Discord OAuth application client secret                                                                  |
+| `AUTH_GITHUB_ID`        | If auth     | Auth           | GitHub OAuth application client ID                                                                       |
+| `AUTH_GITHUB_SECRET`    | If auth     | Auth           | GitHub OAuth application client secret                                                                   |
+| `VAPID_PUBLIC_KEY`      | No (all-or-none) | Push    | Web Push VAPID public key; if absent, push notifications disabled                                        |
+| `VAPID_PRIVATE_KEY`     | No          | Push           | Web Push VAPID private key                                                                               |
+| `VAPID_SUBJECT`         | No          | Push           | VAPID contact identifier (`mailto:` email)                                                               |
+| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | No   | Push           | Client-side VAPID public key (same value as `VAPID_PUBLIC_KEY`)                                          |
+| `POSTGRES_SSL`          | No          | Database       | Set to `"false"` for local dev without SSL; defaults to SSL enabled                                      |
+| `SKIP_MIGRATIONS`       | No          | Docker         | Set to `"true"` in the app container; has no effect on initialization logic currently but signals intent |
+| `NODE_ENV`              | No          | App            | `development`, `staging`, or `production`; affects OpenAPI spec behavior and worker path resolution      |
+| `NEXT_RUNTIME`          | Internal    | Next.js        | Set automatically by Next.js; controls which Sentry config and init steps run                            |
+
+### Connection string formats
+
+Local development connects directly to the host machine:
+
+```
+postgresql://user:pass@127.0.0.1:5432/dbname
+```
+
+Inside Docker, the app container reaches the host's PostgreSQL via the special Docker DNS name:
+
+```
+postgresql://user:pass@host.docker.internal:5432/dbname
+```
+
+The `.docker.env` file (not checked into version control) holds the Docker-specific values and is referenced by both services in `docker-compose.yml`.
+
+### Behavior note on `NODE_ENV=staging`
+
+The staging CI workflow passes `NODE_ENV=staging` as a Docker build arg. At runtime this means `initializeOpenApiSpec()` returns `false` immediately (neither the `development` nor `production` branch matches), which causes `instrumentation.js` to throw and crash the process. In practice the OpenAPI spec is baked into the image at build time and the staging environment is expected to run with `NODE_ENV=production` at runtime, not at build time. The build arg is used only for labeling purposes.
+
+---
+
+## Section 6: PWA Assets
+
+The app is an installable Progressive Web App. PWA assets are static files that ship with the build — no build-time generation step is needed.
+
+### Web App Manifest
+
+Source: `src/app/site.webmanifest` (auto-served by Next.js from the app directory)
+
+Linked in `<head>` via `metadata.manifest` in `src/app/layout.jsx`. Contains `start_url`, `scope`, `orientation: portrait`, and two icons with `purpose: "any maskable"`.
+
+### iOS Splash Screens
+
+20 portrait PNG images in `public/splash/` covering all current iPhone and iPad device sizes. Generated once via `npx pwa-asset-generator` with solid `#282828` background + centered logo. Linked via `<link rel="apple-touch-startup-image">` tags with device-specific media queries in `layout.jsx`.
+
+To regenerate after logo changes:
+
+```bash
+npx pwa-asset-generator public/images/logo_square.png public/splash \
+  --splash-only --background "#282828" --padding "30%" --type png
+# Then delete landscape images (width > height) since orientation is portrait-only
+```
+
+### Cache Headers (next.config.mjs)
+
+Static assets served from `public/` have cache headers configured in `next.config.mjs`:
+
+| Asset Type | `max-age` | `immutable` |
+|------------|-----------|-------------|
+| Favicons | 1 day | Yes |
+| Fonts | 1 year | Yes |
+| Icons | 7 days | Yes |
+| Images | 7 days | Yes |
+| SVGs | 7 days | Yes |
+| Workers | 1 day | Yes |
+
+The service worker (`public/sw.js`) has a 1-day `max-age`, ensuring browsers check for new versions daily. The SW itself handles cache versioning via the `CACHE_NAME` constant.
+
+---
+
+## Cross-references
+
+- See [Data Flow](/docs/data-flow) for the worker thread's role in the continuous update pipeline
+- See [Database Schema](/docs/database) for the Prisma schema and migration strategy
+- See [Notifications](/docs/notifications) for the service worker update lifecycle, caching strategy, and PWA metadata details

--- a/src/app/docs/notifications/page.mdx
+++ b/src/app/docs/notifications/page.mdx
@@ -1,9 +1,18 @@
 import MermaidDiagram from '@/shared/components/MermaidDiagram/MermaidDiagram';
-import { DEFINITION_LR, DEFINITION_TD } from '@/features/notifications/notificationFlowDefinition';
+import {
+    DEFINITION_LR,
+    DEFINITION_TD,
+} from '@/features/notifications/notificationFlowDefinition';
 import { notificationFlowConfig } from '@/features/notifications/notificationFlowConfig';
-import { DEFINITION_LR as INAPP_LR, DEFINITION_TD as INAPP_TD } from '@/features/notifications/inAppFlowDefinition';
+import {
+    DEFINITION_LR as INAPP_LR,
+    DEFINITION_TD as INAPP_TD,
+} from '@/features/notifications/inAppFlowDefinition';
 import { inAppFlowConfig } from '@/features/notifications/inAppFlowConfig';
-import { DEFINITION_LR as PUSH_LR, DEFINITION_TD as PUSH_TD } from '@/features/notifications/pushFlowDefinition';
+import {
+    DEFINITION_LR as PUSH_LR,
+    DEFINITION_TD as PUSH_TD,
+} from '@/features/notifications/pushFlowDefinition';
 import { pushFlowConfig } from '@/features/notifications/pushFlowConfig';
 
 export const metadata = {
@@ -22,26 +31,41 @@ Real-time notification system that keeps the dashboard live and alerts users to 
 
 Four notification layers, each serving a different purpose:
 
-| Layer                  | When                | Persistence        | Requires     |
-| ---------------------- | ------------------- | ------------------ | ------------ |
-| **Live Polling**       | Page is open        | Updates every 10s  | Nothing      |
-| **Sonner Toasts**      | Event transition    | Until dismissed    | Nothing      |
-| **Web Notifications**  | Tab is backgrounded | OS notification    | Permission   |
-| **Push Notifications** | Browser is closed   | OS notification    | Subscription |
+| Layer                  | When                | Persistence       | Requires     |
+| ---------------------- | ------------------- | ----------------- | ------------ |
+| **Live Polling**       | Page is open        | Updates every 10s | Nothing      |
+| **Sonner Toasts**      | Event transition    | Until dismissed   | Nothing      |
+| **Web Notifications**  | Tab is backgrounded | OS notification   | Permission   |
+| **Push Notifications** | Browser is closed   | OS notification   | Subscription |
 
 ## Data Flow
 
 How notifications travel from the official API to the user. Click any node for details. Use the filters to trace individual flows.
 
-<MermaidDiagram id="notification-flow" definition={DEFINITION_LR} mobileDefinition={DEFINITION_TD} config={notificationFlowConfig} />
+<MermaidDiagram
+    id="notification-flow"
+    definition={DEFINITION_LR}
+    mobileDefinition={DEFINITION_TD}
+    config={notificationFlowConfig}
+/>
 
 ### In-App (Polling + Toasts)
 
-<MermaidDiagram id="inapp-flow" definition={INAPP_LR} mobileDefinition={INAPP_TD} config={inAppFlowConfig} />
+<MermaidDiagram
+    id="inapp-flow"
+    definition={INAPP_LR}
+    mobileDefinition={INAPP_TD}
+    config={inAppFlowConfig}
+/>
 
 ### Push (Separate Channel)
 
-<MermaidDiagram id="push-flow" definition={PUSH_LR} mobileDefinition={PUSH_TD} config={pushFlowConfig} />
+<MermaidDiagram
+    id="push-flow"
+    definition={PUSH_LR}
+    mobileDefinition={PUSH_TD}
+    config={pushFlowConfig}
+/>
 
 ## Live Data Transport
 
@@ -56,6 +80,20 @@ The dashboard uses client-side polling to fetch live campaign data.
 - **Module-level singleton**: One poll interval per tab, shared across all hook instances
 - **Status tri-state**: `'polling'` (request in flight), `'live'` (last poll succeeded), `'offline'` (last poll failed or `navigator.onLine` is false)
 - **Leader election**: BroadcastChannel ensures only one tab fires Web Notifications
+
+### Why useSyncExternalStore
+
+Poll data lives outside React in a module-level store object. React pulls snapshots via `useSyncExternalStore` when it is safe to render — it never pushes updates into the Fiber queue. This prevents a crash (`Cannot read properties of null (reading 'enqueueModel')`) caused by state updates injecting into React's concurrent work queue during RSC Flight stream processing on client-side navigation.
+
+`Object.freeze(INITIAL_STORE)` guarantees `getServerSnapshot` returns a stable reference for hydration. The `isFirstMessage` flag resets in `onopen` to handle both initial connect and auto-reconnect without false change detection.
+
+### Data Fallback Chain
+
+```
+snapshot.data ?? initialData ?? cachedState ?? null
+     ↑               ↑              ↑
+  live poll    server-rendered   localStorage
+```
 
 ## Change Detection
 
@@ -161,11 +199,11 @@ Serwist manages two layers of caching:
 
 **Runtime caching:** Serwist's `defaultCache` from `@serwist/next/worker` provides Next.js-optimized strategies:
 
-| Request Type | Strategy | Rationale |
-| ------------ | -------- | --------- |
-| API routes (`/api/*`) | NetworkOnly (explicit) | Live data must never be served from cache |
-| Navigation | Network-first | HTML must match current build |
-| Static assets | Stale-while-revalidate | Serve fast from cache, update in background |
+| Request Type          | Strategy               | Rationale                                   |
+| --------------------- | ---------------------- | ------------------------------------------- |
+| API routes (`/api/*`) | NetworkOnly (explicit) | Live data must never be served from cache   |
+| Navigation            | Network-first          | HTML must match current build               |
+| Static assets         | Stale-while-revalidate | Serve fast from cache, update in background |
 
 ### Offline Behavior
 
@@ -192,24 +230,24 @@ The web app manifest (`src/app/site.webmanifest`) and layout metadata enable ful
 
 `StatusDot` component shows poll status from `LiveDataContext`:
 
-| State   | Indicator  | Meaning                                          |
-| ------- | ---------- | ------------------------------------------------ |
-| live    | Green dot  | Last poll succeeded                              |
-| polling | Orange dot | Poll request in flight                           |
-| offline | Red dot    | Last poll failed or `navigator.onLine` is false  |
+| State   | Indicator  | Meaning                                         |
+| ------- | ---------- | ----------------------------------------------- |
+| live    | Green dot  | Last poll succeeded                             |
+| polling | Orange dot | Poll request in flight                          |
+| offline | Red dot    | Last poll failed or `navigator.onLine` is false |
 
 ## Key Files
 
-| File                                                | Role                                           |
-| --------------------------------------------------- | ---------------------------------------------- |
-| `src/sw.js`                                         | Serwist SW source (precache + push handlers)   |
-| `serwist.config.js`                                 | Serwist build config (configurator mode)       |
+| File                                                | Role                                             |
+| --------------------------------------------------- | ------------------------------------------------ |
+| `src/sw.js`                                         | Serwist SW source (precache + push handlers)     |
+| `serwist.config.js`                                 | Serwist build config (configurator mode)         |
 | `src/app/api/h1/live/route.js`                      | Polling endpoint (getCampaign + computeMapState) |
-| `src/shared/hooks/useLiveData.mjs`                  | Polling hook + BroadcastChannel leader         |
-| `src/shared/utils/game/detectChanges.mjs`           | Event transition detection (shared)            |
-| `src/features/notifications/LiveToasts.jsx`         | Sonner toasts + Web Notifications              |
-| `src/features/notifications/NotificationToggle.jsx` | Combined notification + push toggle            |
-| `src/shared/components/StatusDot.jsx`               | Tri-state connection indicator                 |
-| `src/update/pushNotifier.mjs`                       | Server-side push fan-out                       |
-| `src/app/api/notifications/subscribe/route.js`      | Push subscription CRUD                         |
-| `src/app/site.webmanifest`                          | PWA manifest (install, icons, orientation)     |
+| `src/shared/hooks/useLiveData.mjs`                  | Polling hook + BroadcastChannel leader           |
+| `src/shared/utils/game/detectChanges.mjs`           | Event transition detection (shared)              |
+| `src/features/notifications/LiveToasts.jsx`         | Sonner toasts + Web Notifications                |
+| `src/features/notifications/NotificationToggle.jsx` | Combined notification + push toggle              |
+| `src/shared/components/StatusDot.jsx`               | Tri-state connection indicator                   |
+| `src/update/pushNotifier.mjs`                       | Server-side push fan-out                         |
+| `src/app/api/notifications/subscribe/route.js`      | Push subscription CRUD                           |
+| `src/app/site.webmanifest`                          | PWA manifest (install, icons, orientation)       |

--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -14,6 +14,23 @@ Welcome to the helldivers.bot documentation. This site caches the official Helld
 
 - [About](/docs/about) — learn about the project and its creator
 - [FAQ](/docs/faq) — frequently asked questions about the war and how progress is tracked
-- [Architecture](/docs/architecture) — interactive data flow diagram and key technical concepts
-- [API Reference](/docs/api) — interactive OpenAPI documentation for the Helldivers API
+
+## Architecture
+
+- [Data Pipeline](/docs/architecture) — interactive data flow diagram and key technical concepts
+- [Update Flow](/docs/data-flow) — worker pipeline, two-table strategy, and snapshot throttling
+- [Database Schema](/docs/database) — Prisma 7 models, relationships, indexes, and ERD
+- [Notifications](/docs/notifications) — live polling, toasts, Web Notifications, and push
+- [Authentication](/docs/authentication) — BetterAuth OAuth, sessions, roles, and API keys
+
+## Reference
+
+- [Rebroadcast](/docs/api) — interactive OpenAPI documentation for the Helldivers Bot API
+- [Utilities](/docs/utilities) — shared helpers, Zod validators, formatting, and analytics
+- [Official](/docs/hd1-api) — unofficial documentation of the official Helldivers 1 API
 - [Brand Kit](/docs/brandkit) — design tokens, colors, typography, and component reference
+
+## Development
+
+- [Infrastructure](/docs/infrastructure) — Docker, CI/CD, initialization flow, and environment variables
+- [Testing](/docs/testing) — Vitest unit tests, Playwright E2E, and testing conventions

--- a/src/app/docs/testing/page.mdx
+++ b/src/app/docs/testing/page.mdx
@@ -1,0 +1,198 @@
+export const metadata = {
+    title: 'Testing | Helldivers Bot',
+    description: 'Vitest unit tests, Playwright E2E tests, and testing conventions for helldivers.bot.',
+    alternates: { canonical: '/docs/testing' },
+    openGraph: { url: '/docs/testing' },
+};
+
+# Testing
+
+Technical reference for the helldivers.bot testing infrastructure. Audience: project owner and AI assistants.
+
+---
+
+## Overview
+
+The project uses two testing frameworks:
+
+- **Vitest** — unit tests for utilities, validators, and API route handlers
+- **Playwright** — end-to-end smoke tests against a running dev server
+
+Tests live in `src/__tests__/` following conventions from the euraika/aegis projects.
+
+---
+
+## Directory Structure
+
+```
+src/__tests__/
+├── unit/                    # Vitest unit tests
+│   ├── utils/               # Tests for src/utils/*
+│   ├── validators/          # Tests for src/validators/*
+│   └── components/          # Component tests (future, requires jsdom)
+├── e2e/                     # Playwright E2E tests
+│   ├── smoke.spec.mjs       # Page loads + API endpoint checks
+│   ├── fixtures/             # Custom Playwright fixtures
+│   └── helpers/              # Shared E2E helpers
+└── utils/                   # Shared test utilities
+    └── index.mjs            # Mock factories and helpers
+```
+
+Root-level config files:
+
+| File                    | Purpose                                       |
+| ----------------------- | --------------------------------------------- |
+| `vitest.config.mjs`     | Vitest configuration (env, aliases, coverage) |
+| `vitest.setup.mjs`      | Global mocks (auth, Prisma, Next.js modules)  |
+| `playwright.config.mjs` | Playwright configuration (testDir, artifacts) |
+
+---
+
+## NPM Scripts
+
+| Script                       | Description                           |
+| ---------------------------- | ------------------------------------- |
+| `npm test`                   | Run all unit tests then all E2E tests |
+| `npm run test:unit`          | Vitest in watch mode (for local TDD)  |
+| `npm run test:unit:run`      | Vitest single run (for CI)            |
+| `npm run test:unit:coverage` | Vitest with v8 coverage report        |
+| `npm run test:e2e`           | Playwright full suite                 |
+| `npm run test:e2e:ui`        | Playwright with interactive UI        |
+| `npm run test:smoke`         | Playwright smoke tests only           |
+
+**Note:** `test:unit` runs in interactive watch mode by default — use `test:unit:run` for CI or single execution.
+
+**Note:** E2E tests require a running dev server at `http://localhost:3000`. Never start the dev server from Claude — ask the user.
+
+---
+
+## Vitest Configuration
+
+**Environment:** `node` (default). Component tests opt in to `jsdom` via per-file comment:
+
+```js
+// @vitest-environment jsdom
+```
+
+**Globals:** `true` — `describe`, `test`, `expect`, `vi` are available without import.
+
+**Path aliases:**
+
+- `@` → `./src` (matches `jsconfig.json`)
+- `@test-utils` → `./src/__tests__/utils`
+
+**Coverage:**
+
+- Provider: v8
+- Reporters: text, html
+- Excludes: `src/generated/**`, test files, `src/__tests__/**`, malformed enum files
+
+No global thresholds are set yet — add them once meaningful coverage exists.
+
+---
+
+## Global Mocks (vitest.setup.mjs)
+
+The setup file runs before each test file and provides mocks for:
+
+### BetterAuth
+
+```js
+// Default: logged out (null session)
+// Override in tests:
+import { auth } from '@/auth';
+vi.mocked(auth.api.getSession).mockResolvedValue(createMockSession());
+```
+
+### Prisma Client
+
+All models from the schema are mocked with stub CRUD methods (`findMany`, `findUnique`, `create`, `update`, `delete`, etc.). The mock targets `@/db/db` (the singleton export).
+
+```js
+import db from '@/db/db';
+vi.mocked(db.h1_season.findMany).mockResolvedValue([{ id: 1, season: 1 }]);
+```
+
+### Next.js Modules
+
+- `next/navigation` — `useRouter`, `usePathname`, `useSearchParams`, `redirect`, `notFound`
+- `next/headers` — `headers`, `cookies`
+- `next/image` — passthrough (no optimization)
+- `next/link` — passthrough
+
+All mocks are cleared via `vi.clearAllMocks()` in `beforeEach`.
+
+---
+
+## Test Utilities
+
+Location: `src/__tests__/utils/index.mjs` (importable as `@test-utils`)
+
+### createMockRequest(url, method, body, headers)
+
+Wraps `new Request()` for API route handler tests. Sets `content-type: application/json` by default.
+
+### createMockSession(overrides)
+
+Returns a BetterAuth session object with `user` and `session` sub-objects (test user, 24h expiry). Merge overrides for custom scenarios.
+
+### createMockModel()
+
+Returns a Prisma model stub with all standard CRUD methods as `vi.fn()`. Useful for ad-hoc mocks beyond what `vitest.setup.mjs` provides.
+
+---
+
+## Test Naming Conventions
+
+| Type         | Pattern      | Location                       |
+| ------------ | ------------ | ------------------------------ |
+| Unit test    | `*.test.mjs` | `src/__tests__/unit/`          |
+| E2E test     | `*.spec.mjs` | `src/__tests__/e2e/`           |
+| E2E fixture  | `*.mjs`      | `src/__tests__/e2e/fixtures/`  |
+| E2E helper   | `*.mjs`      | `src/__tests__/e2e/helpers/`   |
+| Test utility | `*.mjs`      | `src/__tests__/utils/`         |
+
+---
+
+## API Route Testing Pattern
+
+App Router route handlers are tested by importing the handler directly:
+
+```js
+import { GET } from '@/app/api/healthcheck/route';
+
+test('returns 200 with alive: true', async () => {
+    const req = new Request('http://localhost/api/healthcheck');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.alive).toBe(true);
+});
+```
+
+For routes that depend on Prisma or auth, mock those modules first — the global mocks in `vitest.setup.mjs` handle the defaults.
+
+---
+
+## Playwright Configuration
+
+- **Test directory:** `./src/__tests__/e2e`
+- **Artifacts:** `./playwright/test-results/` (gitignored via `/playwright/`)
+- **Screenshots:** only on failure
+- **Traces:** on first retry
+- **Browser:** Chromium only
+- **Base URL:** `http://localhost:3000`
+
+---
+
+## Gitignore
+
+Test artifacts are excluded from version control:
+
+```
+/coverage            # Vitest coverage reports
+/test-results/       # Legacy Playwright output
+/playwright-report/  # Playwright HTML report
+/playwright/         # Playwright screenshots & artifacts
+.playwright-mcp/     # Playwright MCP state
+```

--- a/src/app/docs/utilities/page.mdx
+++ b/src/app/docs/utilities/page.mdx
@@ -1,0 +1,925 @@
+export const metadata = {
+    title: 'Utilities | Helldivers Bot',
+    description: 'Shared utilities, Zod validators, formatting helpers, and analytics architecture for helldivers.bot.',
+    alternates: { canonical: '/docs/utilities' },
+    openGraph: { url: '/docs/utilities' },
+};
+
+# Utilities Reference
+
+Lookup reference for all shared utility functions and validation schemas — signatures, behavior, edge cases, and source locations.
+
+---
+
+## 1. Error Handling — `tryCatch`
+
+`src/utils/tryCatch.mjs`
+
+```js
+export async function tryCatch(promise) {
+    try {
+        const data = await promise;
+        return { data, error: null };
+    } catch (error) {
+        return { data: null, error };
+    }
+}
+```
+
+### Behavior
+
+Wraps any `Promise` and returns a two-field result object instead of throwing. This is the project-wide substitute for `try/catch` blocks; every async operation in the codebase goes through this wrapper.
+
+| Field   | On success     | On failure            |
+| ------- | -------------- | --------------------- |
+| `data`  | Resolved value | `null`                |
+| `error` | `null`         | Caught `Error` object |
+
+### Usage pattern
+
+```js
+const { data, error } = await tryCatch(someAsyncOp());
+if (error) {
+    // handle error
+}
+// use data
+```
+
+### Called from
+
+`src/update/status.mjs`, `src/update/season.mjs`, `src/instrumentation.js`, API route handlers, page-level server components.
+
+---
+
+## 2. Response Helpers
+
+`src/utils/responses.mjs`
+
+Both helpers return a `NextResponse.json()` with a consistent envelope shape and include elapsed time via `performanceTime(start)`.
+
+### `errorResponse(code, start, error?)`
+
+```ts
+errorResponse(code: number, start: number, error?: any): NextResponse
+```
+
+**Behavior:**
+
+- Throws `Error('Invalid error code')` if `code` starts with `'1'`, `'2'`, or `'3'` — callers must pass a 4xx or 5xx code.
+- Returns `NextResponse.json({ time, code, message, error }, { status: code })`.
+- `error` parameter defaults to `null` when omitted.
+- Unknown codes fall through to the `default` branch: message becomes `'Unknown error'` and HTTP status is overridden to `500`.
+
+**Response envelope:**
+
+```json
+{
+  "time": "<number>",
+  "code": "<number>",
+  "message": "<string>",
+  "error": "<any | null>"
+}
+```
+
+**Supported codes:**
+
+| Code      | Message                                   |
+| --------- | ----------------------------------------- |
+| 400       | Bad Request                               |
+| 401       | Unauthorized                              |
+| 403       | Forbidden                                 |
+| 404       | Not found                                 |
+| 405       | Method not allowed                        |
+| 418       | I'm a teapot                              |
+| 429       | Too many requests                         |
+| 451       | Unavailable for legal reasons             |
+| 500       | Internal server error                     |
+| 501       | Not implemented                           |
+| 502       | Bad gateway                               |
+| 503       | Service unavailable                       |
+| _(other)_ | Unknown error — HTTP status forced to 500 |
+
+> **Note:** Code 401 means "I don't know who you are." Code 403 means "I know who you are but you're still not allowed." Code 502 is used specifically when the upstream official Helldivers API is unreachable.
+
+---
+
+### `successResponse(code, start, data)`
+
+```ts
+successResponse(code: number, start: number, data: any): NextResponse
+```
+
+**Behavior:**
+
+- Throws `Error('Invalid success code')` if `code` does not start with `'2'`.
+- Returns `NextResponse.json({ time, code, message, data }, { status: code })`.
+- Unknown 2xx codes fall through to the `default` branch: message becomes `'Unknown'` and HTTP status is overridden to `200`.
+
+**Response envelope:**
+
+```json
+{
+  "time": "<number>",
+  "code": "<number>",
+  "message": "<string>",
+  "data": "<any>"
+}
+```
+
+**Supported codes:**
+
+| Code          | Message                             |
+| ------------- | ----------------------------------- |
+| 200           | OK                                  |
+| 201           | Created                             |
+| 202           | Accepted                            |
+| 203           | Non-authoritative information       |
+| 204           | No content                          |
+| _(other 2xx)_ | Unknown — HTTP status forced to 200 |
+
+---
+
+## 3. Time Utilities
+
+`src/utils/time.mjs`
+
+### Performance measurement (server-side)
+
+| Function                 | Signature                  | Returns    | Description                                                                                                                                                                                                                                    |
+| ------------------------ | -------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `performanceTime`        | `(start: number) → number` | Elapsed ms | `performance.now() - start`. Used directly inside `responses.mjs` for the `time` field on every API response.                                                                                                                                  |
+| `roundedPerformanceTime` | `(start: number) → number` | Rounded ms | Rounds elapsed time up to the nearest 50ms using `Math.ceil(elapsed / 50) * 50`. Examples: 33ms → 50, 60ms → 100, 111ms → 150. Purpose: coarse bucketing for Umami analytics events so individual requests don't create unbounded cardinality. |
+
+### Relative and formatted time (UI helpers)
+
+| Function     | Signature               | Returns                      | Description                                                                                                                                                                               |
+| ------------ | ----------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeSince`  | `(date: Date) → string` | `"X minutes/hours/days ago"` | Converts a past date to a human-readable relative string. Threshold: < 60 min → minutes, < 24 h → hours, otherwise days. Pluralization handled (e.g., "1 minute ago" vs "2 minutes ago"). |
+| `formatDate` | `(date: Date) → string` | `"YYYY-MM-DD HH:MM:SS"`      | Zero-pads all components. Uses local time (not UTC). Used wherever consistent date display is needed.                                                                                     |
+
+### Elapsed time computations
+
+| Function            | Signature                            | Returns                             | Description                                                                                                                                                                            |
+| ------------------- | ------------------------------------ | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `elapsedSeconds`    | `(past: Date) → number`              | Integer seconds                     | `Math.floor((now - past) / 1000)`.                                                                                                                                                     |
+| `elapsedDateTime`   | `(past: Date) → number`              | Milliseconds                        | Raw `now - past` with no rounding.                                                                                                                                                     |
+| `elapsedSeasonTime` | `(season_duration: number) → object` | `{ days, hours, minutes, seconds }` | Breaks a total-seconds value into human-readable components. Input is the `season_duration` integer from the statistics table. All components use `Math.floor` with modulo arithmetic. |
+
+#### `elapsedSeasonTime` decomposition
+
+```
+days    = Math.floor(season_duration / 86400)
+hours   = Math.floor((season_duration % 86400) / 3600)
+minutes = Math.floor((season_duration % 3600) / 60)
+seconds = season_duration % 60
+```
+
+---
+
+## 4. Season Extraction
+
+`src/utils/getSeason.mjs`
+
+Both functions extract the current season number from an already-validated API response object. They throw synchronously on error — callers must handle or wrap with `tryCatch`.
+
+---
+
+### `getSeasonFromStatus(data)`
+
+```ts
+getSeasonFromStatus(data: object): number
+```
+
+**Sources consulted:**
+
+| Field                      | Included                        |
+| -------------------------- | ------------------------------- |
+| `campaign_status[].season` | Yes                             |
+| `defend_event.season`      | Yes (single object, not array)  |
+| `statistics[].season`      | Yes                             |
+| `attack_events[].season`   | **No** — intentionally excluded |
+
+**Why `attack_events` is excluded:** Attack events can reference an old season when the current season has no recorded attacks yet. Including them would produce a false season mismatch.
+
+**Algorithm:**
+
+1. Collect seasons from included sources into a flat array.
+2. Deduplicate with `new Set`.
+3. If zero unique values → throw `Error('No seasons found in status data')`.
+4. If more than one unique value → `console.warn` (does not throw; uses the first).
+5. Validate the first value with `isValidNumber.safeParse` → throw `Error('Invalid Current Season')` on failure.
+6. Return `Number(uniqueSeasons[0])`.
+
+**Throws on:**
+
+- `data` is falsy → `Error('status is missing')`
+- No seasons found → `Error('No seasons found in status data')`
+- Season value fails `isValidNumber` → `Error('Invalid Current Season')`
+
+---
+
+### `getSeasonFromSnapshot(data)`
+
+```ts
+getSeasonFromSnapshot(data: object): number
+```
+
+**Sources consulted:**
+
+| Field                    | Included |
+| ------------------------ | -------- |
+| `snapshots[].season`     | Yes      |
+| `defend_events[].season` | Yes      |
+| `attack_events[].season` | Yes      |
+
+Snapshot data includes attack events because historical season data is already fully resolved — the old-season contamination risk present in live status does not apply here.
+
+**Algorithm:** Identical to `getSeasonFromStatus` once sources are gathered. Same deduplication, warn-on-multiple, and `isValidNumber` validation.
+
+**Throws on:** Same conditions as `getSeasonFromStatus`.
+
+---
+
+## 5. Formatting
+
+### `formatNumber(n)`
+
+`src/utils/formatNumber.mjs`
+
+```ts
+formatNumber(n: number | null | undefined): string
+```
+
+**Behavior:**
+
+1. `null` / `undefined` → `'—'`
+2. `NaN` / `Infinity` → `'—'`
+3. `>= 1,000,000,000` → `(n / 1B).toFixed(1) + 'B'`
+4. `>= 1,000,000` → `(n / 1M).toFixed(1) + 'M'`
+5. `>= 1,000` → `n.toLocaleString()` (with commas)
+6. Otherwise → `String(n)`
+
+**Examples:** `1_500_000_000` → `"1.5B"`, `12_300_000` → `"12.3M"`, `12345` → `"12,345"`, `847` → `"847"`.
+
+**Used by:** `StatGrid`, `EventCard`.
+
+---
+
+### `formatTimeAgo(date, now?)`
+
+`src/utils/formatTimeAgo.mjs`
+
+```ts
+formatTimeAgo(date: Date | null, now?: Date): string | null
+```
+
+**Behavior:**
+
+1. `null` / `undefined` → `null`
+2. Invalid date / future date → `'Updated just now'`
+3. `< 60 seconds` → `'Updated Xs ago'`
+4. `< 60 minutes` → `'Updated Xm ago'`
+5. `>= 60 minutes` → `'Updated Xh ago'`
+
+**Examples:** 45 seconds elapsed → `"Updated 45s ago"`, 3 minutes → `"Updated 3m ago"`.
+
+**Used by:** `Galaxy` component (timestamp below the map).
+
+---
+
+### `addOrdinalSuffix(num)`
+
+```ts
+addOrdinalSuffix(num: number): string
+```
+
+**Behavior:** Appends the English ordinal suffix to an integer. Handles the teen exception (11th, 12th, 13th) by checking `num % 100` before `num % 10`.
+
+| Condition        | Suffix |
+| ---------------- | ------ |
+| `% 100` in 11-13 | `th`   |
+| `% 10 === 1`     | `st`   |
+| `% 10 === 2`     | `nd`   |
+| `% 10 === 3`     | `rd`   |
+| otherwise        | `th`   |
+
+**Examples:** `1` → `"1st"`, `11` → `"11th"`, `21` → `"21st"`, `112` → `"112th"`.
+
+---
+
+## 6. Other Utilities
+
+### `formDataToObject(formData)`
+
+`src/utils/formdata.mjs`
+
+```ts
+formDataToObject(formData: FormData): Record<string, string>
+```
+
+Iterates `formData.entries()` and builds a plain object. The result is what gets passed to `isValidFormData` for Zod validation in the rebroadcast endpoint. No type coercion is performed here — that is the validator's job.
+
+---
+
+### `getGravatarUrl(email)`
+
+`src/utils/gravatar.mjs`
+
+```ts
+getGravatarUrl(email: string): string
+```
+
+**Behavior:**
+
+1. Normalizes email: `email.trim().toLowerCase()`.
+2. MD5-hashes the normalized string using Node's built-in `crypto.createHash('md5')`.
+3. Returns `https://www.gravatar.com/avatar/{hash}?s=64`.
+
+Size parameter is hardcoded to 64px. Used in dashboard UI to display user avatars.
+
+---
+
+### Analytics Architecture
+
+Umami v3 (self-hosted, cookieless) with three tracking layers:
+
+1. **`data-umami-event` HTML attributes** — for click tracking on static elements. The Umami tracker script (loaded in `layout.jsx` via `/stats.js` proxy) captures these automatically. Preferred for simple interactions.
+2. **`useTrack()` hook / `window.umami?.track()`** — for dynamic client-side interactions where event names or data depend on runtime state.
+3. **`sendUmamiEvent()` server utility** — for API route tracking. Sends server-to-server directly to Umami (not subject to ad blockers).
+
+**Ad-blocker bypass:** The client-side tracker posts through a same-origin proxy chain: tracker → `/api/send` (Next.js rewrite) → `/api/umami` (proxy route) → `umami.drunik.be/api/send`. No external domain appears in CSP or network requests. The proxy forwards `X-Forwarded-For` so Umami receives the real client IP for its cookieless session hash.
+
+**User identification:** Authenticated users are identified via `umami.identify(userId, { provider })` in `UserSection.jsx`. Anonymous visitors remain fully anonymous.
+
+**Event naming:** `category-action` format. Categories: `nav`, `auth`, `footer`, `docs`, `diagram`, `faction`, `archive`, `notification`, `push`, `sw`, `toast`, `dashboard`, `api`.
+
+**Production-only:** Both server-side (`NODE_ENV` guard) and client-side (Script tag conditional) tracking only run in production.
+
+---
+
+### `useTrack()` (hook)
+
+`src/shared/hooks/useTrack.mjs`
+
+```ts
+useTrack(): (eventName: string, data?: object) => void
+```
+
+**Behavior:**
+
+- Returns a stable `useCallback`-memoized function that calls `window.umami.track(eventName, data)`.
+- Guards against `window.umami` being undefined (ad blockers, dev mode, SSR).
+- Silently no-ops when the tracker is unavailable — analytics never affects user experience.
+- For tracking inside `useEffect` callbacks (where hooks can't be called), use `window.umami?.track()` directly.
+
+**Used by:** `FactionTabs`, `SeasonSelector`, `NotificationToggle`.
+
+---
+
+### `umamiTrackPage(title, url)`
+
+`src/shared/utils/umami.mjs`
+
+```ts
+umamiTrackPage(title: string, url: string): Promise<void>
+```
+
+**Behavior:**
+
+- **Production-only.** Returns immediately (no-op) if `NODE_ENV !== 'production'`.
+- POSTs a page-view event directly to `https://{UMAMI_SITE_URL}/api/send` (server-to-server).
+- Uses a hardcoded macOS Chrome User-Agent string (required by Umami's bot-detection).
+- Payload includes `website` (from `UMAMI_SITE_ID`), `hostname` (from `getHostname()`), `screen: '1x1'`, `language: 'en'`, `title`, `url`.
+- Errors are caught and logged to `console.error`; failures do not propagate.
+
+---
+
+### `umamiTrackEvent(title, url, name, data?)`
+
+`src/shared/utils/umami.mjs`
+
+```ts
+umamiTrackEvent(title: string, url: string, name: string, data?: object): Promise<void>
+```
+
+**Behavior:**
+
+- **Production-only.** Same early-return guard as `umamiTrackPage`.
+- Identical POST structure but adds `name` (event name) and `data` (optional custom properties object, defaults to `{}`) to the payload.
+- Event names use `category-action` format: `api-campaign`, `api-rebroadcast`, `api-live-poll`.
+- Called from API routes via Next.js `after()` hook so analytics does not block the response.
+
+---
+
+### `getHostname()` (internal)
+
+`src/shared/utils/umami.mjs` — not exported
+
+```ts
+function getHostname(): string;
+```
+
+Maps `NODE_ENV` to hostname:
+
+| `NODE_ENV`        | Returns                            |
+| ----------------- | ---------------------------------- |
+| `'development'`   | `'localhost'`                      |
+| `'staging'`       | `'staging.helldivers.bot'`         |
+| `'production'`    | `'helldivers.bot'`                 |
+| _(anything else)_ | throws `Error('Unknown NODE_ENV')` |
+
+---
+
+### `/api/umami` (proxy route)
+
+`src/app/api/umami/route.js`
+
+Same-origin proxy for the Umami tracker script. Receives POST from the client-side tracker (via `/api/send` rewrite in `next.config.mjs`) and forwards to `https://{UMAMI_SITE_URL}/api/send`.
+
+**Forwarded headers:** `Content-Type`, `User-Agent`, `X-Forwarded-For` (critical for Umami's cookieless IP+UA session hash).
+
+**Error handling:** Returns 502 Bad Gateway if the Umami instance is unreachable. Non-POST methods return 405.
+
+---
+
+## 7. War Outcome — `getWarOutcome`
+
+`src/utils/getWarOutcome.mjs`
+
+```ts
+getWarOutcome(data: { snapshots?, events?, live? }): { outcome: 'victory'|'defeat', reason: string } | null
+```
+
+Determines whether a war ended in victory or defeat. Extracted from `War.jsx` for reuse.
+
+**Decision tree:**
+
+1. No data (all arrays empty) → `null`
+2. All 3 live factions `status === 'defeated'` → `{ outcome: 'victory' }` (early return)
+3. Victory signal: any snapshot shows all 3 defeated, OR all 3 homeworlds captured via attack events
+4. Defeat signal: last region-0 defend event has `status === 'fail'`
+5. Victory AND no defeat → victory. Defeat signal → defeat. No victory signal → defeat.
+
+**Consumers:** `War.jsx` (UI banner), potentially future features. Note: the OG image route does NOT use this — it derives status directly from events.
+
+**Tests:** `src/__tests__/unit/utils/getWarOutcome.test.mjs` (8 cases)
+
+---
+
+## 8. Shared Map Data — `mapPaths`
+
+`src/enums/mapPaths.mjs`
+
+Shared SVG path geometry for the Galaxy map. Single source of truth consumed by both `Map.jsx` (CSS class styling) and the OG image route (inline styling).
+
+**Exports:**
+
+- `viewBox` — `'0 0 806.93 868.81'`
+- `bugPaths` — `Array<{ id, sector, d }>` (11 items, sectors 1-11)
+- `cyborgPaths` — same structure (11 items)
+- `illuminatePaths` — same structure (11 items)
+- `superEarthCircle` — `{ id, cx, cy, r }`
+- `factionIcons` — `Array<{ id, href, x, y, width, height }>` (4 items: bugs, cyborgs, illuminate, superearth)
+
+The `sector` field is a number to avoid string parsing from `id`.
+
+---
+
+## 9. Event Progress — `evaluateProgress`
+
+`src/utils/evaluateProgress.mjs`
+
+Evaluates how a live event is performing relative to the expected linear progress rate. Returns a human-readable status string for active events, or `null` for completed/inactive events.
+
+```ts
+evaluateProgress(event: { start_time, end_time, points, points_max, status }) → string | null
+```
+
+**Algorithm:**
+
+1. Calculate expected points at current time assuming linear progress (`expectedRate × elapsedTime`).
+2. Compare actual `points` against expected with a 10% buffer.
+3. Return status:
+    - `"Ahead by N points"` — actual > expected + 10% buffer
+    - `"Behind by N points"` — actual < expected
+    - `"On track by N points"` — within buffer
+    - `null` — event `status` is not `'active'`
+
+**Tests:** `src/__tests__/unit/utils/evaluateProgress.test.mjs`
+
+---
+
+## 10. Validation Schemas
+
+`src/validators/`
+
+All schemas use Zod v4 (`"zod": "^4.3.6"` in `package.json`). Every validator imports from `'zod'`, which is the standard import path for Zod v4.
+
+---
+
+### `isValidStatus`
+
+`src/validators/isValidStatus.mjs`
+
+**Zod import:** `import { z } from 'zod'` (Zod v4)
+
+**Export type:** Function — `(data: unknown) => SafeParseReturnType`
+
+Validates the official API `get_campaign_status` response.
+
+**Root schema fields:**
+
+| Field             | Type                                           |
+| ----------------- | ---------------------------------------------- |
+| `time`            | `number`                                       |
+| `error_code`      | `number`                                       |
+| `campaign_status` | `campaignStatusSchema[]`                       |
+| `defend_event`    | `defendEventSchema` (single object, not array) |
+| `attack_events`   | `attackEventSchema[]`                          |
+| `statistics`      | `statisticsSchema[]`                           |
+
+**`campaignStatusSchema`:**
+
+| Field                | Type                                       |
+| -------------------- | ------------------------------------------ |
+| `season`             | `number`                                   |
+| `points`             | `number`                                   |
+| `points_taken`       | `number`                                   |
+| `points_max`         | `number`                                   |
+| `status`             | `enum: 'active' \| 'defeated' \| 'hidden'` |
+| `introduction_order` | `number`                                   |
+
+**`defendEventSchema`:**
+
+| Field        | Type                                    |
+| ------------ | --------------------------------------- |
+| `season`     | `number`                                |
+| `event_id`   | `number`                                |
+| `start_time` | `number`                                |
+| `end_time`   | `number`                                |
+| `region`     | `number`                                |
+| `enemy`      | `number`                                |
+| `points_max` | `number`                                |
+| `points`     | `number`                                |
+| `status`     | `enum: 'active' \| 'success' \| 'fail'` |
+
+**`attackEventSchema`:** Same as defend event but **without** `region`, and with two additional fields:
+
+| Additional field   | Type     |
+| ------------------ | -------- |
+| `players_at_start` | `number` |
+| `max_event_id`     | `number` |
+
+**`statisticsSchema`:**
+
+| Field                      | Type     |
+| -------------------------- | -------- |
+| `season`                   | `number` |
+| `season_duration`          | `number` |
+| `enemy`                    | `number` |
+| `players`                  | `number` |
+| `total_unique_players`     | `number` |
+| `missions`                 | `number` |
+| `successful_missions`      | `number` |
+| `total_mission_difficulty` | `number` |
+| `completed_planets`        | `number` |
+| `defend_events`            | `number` |
+| `successful_defend_events` | `number` |
+| `attack_events`            | `number` |
+| `successful_attack_events` | `number` |
+| `deaths`                   | `number` |
+| `kills`                    | `number` |
+| `accidentals`              | `number` |
+| `shots`                    | `number` |
+| `hits`                     | `number` |
+
+---
+
+### `isValidSeason`
+
+`src/validators/isValidSeason.mjs`
+
+**Zod import:** `import { z } from 'zod'` (Zod v4)
+
+**Export type:** Function — `(data: unknown) => SafeParseReturnType`
+
+Validates the official API `get_snapshots` response.
+
+**Root schema fields:**
+
+| Field                | Type                                              |
+| -------------------- | ------------------------------------------------- |
+| `time`               | `number`                                          |
+| `error_code`         | `number`                                          |
+| `introduction_order` | `number[]`                                        |
+| `points_max`         | `number[]`                                        |
+| `snapshots`          | `snapshotSchema[]`                                |
+| `defend_events`      | `eventSchema[]` (refined: must have `region`)     |
+| `attack_events`      | `eventSchema[]` (refined: must not have `region`) |
+
+**`snapshotSchema`:**
+
+| Field    | Type     | Notes                                                                                           |
+| -------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `season` | `number` |                                                                                                 |
+| `time`   | `number` |                                                                                                 |
+| `data`   | `string` | Stringified JSON. Validated by parsing and checking each item against `snapshotDataItemSchema`. |
+
+`snapshotDataItemSchema` (not exported):
+
+| Field          | Type                                       |
+| -------------- | ------------------------------------------ |
+| `points`       | `number`                                   |
+| `points_taken` | `number`                                   |
+| `status`       | `enum: 'hidden' \| 'active' \| 'defeated'` |
+
+**`eventSchema`** (shared base for defend and attack events):
+
+| Field              | Required | Type                        |
+| ------------------ | -------- | --------------------------- |
+| `season`           | Yes      | `number`                    |
+| `event_id`         | Yes      | `number`                    |
+| `start_time`       | Yes      | `number`                    |
+| `end_time`         | Yes      | `number`                    |
+| `enemy`            | Yes      | `number`                    |
+| `points_max`       | Yes      | `number`                    |
+| `points`           | Yes      | `number`                    |
+| `status`           | Yes      | `enum: 'fail' \| 'success'` |
+| `players_at_start` | Yes      | `number`                    |
+| `region`           | No       | `number` (optional)         |
+
+The distinction between defend and attack events is enforced via `.refine()`:
+
+- `defend_events` entries: `region` must be **present** (not `undefined`).
+- `attack_events` entries: `region` must be **absent** (`undefined`).
+
+> **Note:** Unlike `isValidStatus`'s `attackEventSchema`, `isValidSeason`'s event status enum only includes `'fail' | 'success'` — there is no `'active'` status in historical snapshot data.
+
+---
+
+### `isValidFormData`
+
+`src/validators/isValidFormData.mjs`
+
+**Zod import:** `import { z } from 'zod'` (Zod v4)
+
+**Export type:** Zod schema object (not a function) — call `.safeParse(data)` directly
+
+Discriminated union on the `action` field. Used by the `/api/h1/rebroadcast` endpoint after `formDataToObject` converts the request body.
+
+**Actions and their required/optional fields:**
+
+| `action` value               | Required fields                  | Optional fields             | Extra keys         |
+| ---------------------------- | -------------------------------- | --------------------------- | ------------------ |
+| `get_campaign_status`        | _(none beyond action)_           | —                           | Forbidden (strict) |
+| `get_snapshots`              | `season` (via `schemaNumber`)    | —                           | Allowed            |
+| `get_available_entitlements` | _(none beyond action)_           | —                           | Forbidden (strict) |
+| `get_leaderboards`           | `network` (steam\|psn), `season` | `count`, `users` (string[]) | Allowed            |
+| `get_usernames`              | `network` (steam\|psn), `count`  | —                           | Allowed            |
+
+**`schemaNumber`** (also exported separately):
+
+```ts
+export const schemaNumber = z.preprocess(
+    (val) => (typeof val === 'string' ? Number(val) : val),
+    z.number().int().positive(),
+);
+```
+
+Preprocesses a string to a number before validation. Used for form fields where numeric values arrive as strings. Validates: integer and positive (> 0).
+
+---
+
+### `isValidContentType`
+
+`src/validators/isValidContentType.mjs`
+
+**Zod import:** `import { z } from 'zod'` (Zod v4)
+
+**Export type:** Zod schema object — call `.safeParse(value)` directly
+
+```ts
+export const isValidContentType = z
+    .string()
+    .refine(
+        (val) =>
+            val.includes('multipart/form-data') ||
+            val.includes('application/x-www-form-urlencoded'),
+        { message: 'Invalid content type' },
+    );
+```
+
+Validates the `Content-Type` request header. Uses `.includes()` (not exact match) so boundary parameters in `multipart/form-data` headers do not cause false failures. Used exclusively by the `/api/h1/rebroadcast` endpoint.
+
+---
+
+### `isValidNumber`
+
+`src/validators/isValidNumber.mjs`
+
+**Zod import:** `import { z } from 'zod'` (Zod v4)
+
+**Export type:** Zod schema object — call `.safeParse(value)` directly
+
+```ts
+export const isValidNumber = z.preprocess(
+    (val) => (typeof val === 'string' ? Number(val) : val),
+    z.number().int().positive(),
+);
+```
+
+Identical preprocessing behavior to `schemaNumber` in `isValidFormData.js` — converts string to number then validates integer and positive. Used specifically for season number validation in `getSeason.mjs` and query parameter validation on the `/api/h1/campaign` endpoint.
+
+> **Note:** `isValidNumber` and `schemaNumber` are functionally identical schemas defined in separate files. `isValidNumber` is in `src/validators/`, `schemaNumber` is co-located in `isValidFormData.js` and exported from there.
+
+---
+
+## 11. Snapshot Throttle Timers
+
+`src/update/snapshotTimers.mjs`
+
+In-memory throttle layer that prevents the status pipeline from writing snapshots too frequently. Each function checks whether enough time has elapsed since the last snapshot before allowing a new write. On cold start (first call after process boot), the timers seed themselves from the database so restarts do not lose track of the last write time.
+
+Called from `src/update/status.mjs` during the status update pipeline.
+
+### Constants
+
+| Constant                  | Value | Meaning                                          |
+| ------------------------- | ----- | ------------------------------------------------ |
+| `LIVE_SNAPSHOT_INTERVAL`  | `900` | Minimum seconds between live snapshots (15 min)  |
+| `EVENT_SNAPSHOT_INTERVAL` | `600` | Minimum seconds between event snapshots (10 min) |
+
+### In-memory state
+
+| Variable                 | Type                  | Description                                         |
+| ------------------------ | --------------------- | --------------------------------------------------- |
+| `currentSeason`          | `number \| null`      | Tracks the current season; triggers reset on change |
+| `lastLiveSnapshotTime`   | `number \| null`      | Epoch-seconds of the most recent live snapshot      |
+| `lastEventSnapshotTimes` | `Map<string, number>` | Key: `${type}:${event_id}`, value: epoch-seconds    |
+
+---
+
+### `shouldTakeLiveSnapshot(season, apiTime)`
+
+```ts
+shouldTakeLiveSnapshot(season: number, apiTime: number): Promise<boolean>
+```
+
+**Behavior:**
+
+1. Calls `resetIfSeasonChanged(season)` — if the season has changed since the last call, clears all in-memory state.
+2. If `lastLiveSnapshotTime` is `null` (cold start), queries `h1_live_snapshot` for the most recent snapshot time for the given season. Seeds the in-memory timer with the result (or `0` if no rows exist).
+3. Returns `true` if `apiTime - lastLiveSnapshotTime >= 900`.
+
+**Throws:** Re-throws any Prisma error from the cold-start query.
+
+---
+
+### `recordLiveSnapshotTime(time)`
+
+```ts
+recordLiveSnapshotTime(time: number): Promise<void>
+```
+
+Updates `lastLiveSnapshotTime` in memory. Called after a successful live snapshot database write to advance the throttle window.
+
+---
+
+### `shouldTakeEventSnapshot(type, eventId, apiTime)`
+
+```ts
+shouldTakeEventSnapshot(type: string, eventId: number, apiTime: number): Promise<boolean>
+```
+
+**Behavior:**
+
+1. Builds a lookup key as `${type}:${eventId}`.
+2. If the key is not in `lastEventSnapshotTimes` (cold start for this event), queries `h1_event_snapshot` for the most recent snapshot time matching `type` and `event_id`. Seeds the map entry with the result (or `0` if no rows exist).
+3. Returns `true` if `apiTime - lastEventSnapshotTimes.get(key) >= 600`.
+
+**Throws:** Re-throws any Prisma error from the cold-start query.
+
+---
+
+### `recordEventSnapshotTime(type, eventId, time)`
+
+```ts
+recordEventSnapshotTime(type: string, eventId: number, time: number): Promise<void>
+```
+
+Updates the `lastEventSnapshotTimes` map entry for the given `${type}:${eventId}` key. Called after a successful event snapshot database write.
+
+---
+
+### `resetSnapshotTimers()`
+
+```ts
+resetSnapshotTimers(): Promise<void>
+```
+
+Clears all in-memory state: sets `lastLiveSnapshotTime` to `null` and clears the `lastEventSnapshotTimes` map. Not called internally — `resetIfSeasonChanged` performs its own inline reset. Exported for external callers that need a full manual reset.
+
+---
+
+## 12. Map State — `computeMapState`
+
+`src/utils/computeMapState.mjs`
+
+```ts
+computeMapState(factionStates: Array, events?: Array): Object
+```
+
+Computes the visual state of the galaxy map from faction campaign data and events. Returns a deep clone of the map template with computed sector statuses — never mutates the template.
+
+### Sector calculation (regions 1-10)
+
+Uses `campaign.points` (current influence score) divided by `campaign.points_max / 10` (per-sector threshold) to determine how many sectors are captured:
+
+- `sectorsEarned = Math.trunc(points / pointsPerSector)` — fully captured sectors
+- `sectorsInProgress = sectorsEarned + 1` — the sector currently being contested
+- Remaining sectors default to `lost`
+
+**Important:** `campaign.points` is the correct field, not `campaign.points_taken`. The `points` field reflects current influence (can decrease due to counter-attacks), while `points_taken` is cumulative. The game's sector display corresponds to `points`.
+
+### Homeworld (region 11)
+
+Region 11 is **only** affected by attack events. Campaign score has no effect. Attack events set region 11 to `active` (in progress), `captured` (success), or `lost` (fail).
+
+### Event filtering — critical for callers
+
+**For live views** (homepage, OG image): only pass events with `status === 'active'`. Completed events are already reflected in the campaign score. Passing completed defend events will incorrectly overwrite score-based sector ownership.
+
+```js
+// Correct (live view)
+const activeEvents = (data.events ?? []).filter((e) => e.status === 'active');
+const mapState = computeMapState(data.live, activeEvents);
+```
+
+**For the timeline** (`WarTimeline`): pass time-filtered events including completed ones, as the timeline reconstructs historical state from snapshots where the score at that moment matches the events.
+
+### Defend event behavior
+
+Defend events are sorted by `end_time` (most recent wins per region):
+
+- `status === 'active'` — sets `event: 'active'` on the region (visual overlay)
+- `status === 'fail'` — reverts the region **and all regions beyond it** (to region 10) to `lost`
+- `status === 'success'` — sets `event: 'idle'` (preserves score-based status)
+- Region 0 defend events affect Super Earth (`map[3][0]`)
+
+### Used by
+
+| Caller | Events passed |
+|--------|--------------|
+| `src/app/page.jsx` (homepage) | Active only |
+| `src/app/api/og/route.js` (OG image) | Active only |
+| `src/app/war/page.jsx` (history) | None (`[]`) — timeline handles its own |
+| `src/components/h1/WarTimeline/WarTimeline.jsx` | Time-filtered (active + completed at that moment) |
+
+---
+
+## 13. On-Demand Season Fetching — `fetchAndSeedSeason`
+
+`src/db/queries/fetchAndSeedSeason.mjs`
+
+```ts
+fetchAndSeedSeason(season: number): Promise<void>
+```
+
+Fetches a single season from the official Helldivers API and seeds it into the normalized `h1_*` tables. Called on-demand by the `/war` history page when a user requests a season not yet stored in the database.
+
+### Behavior
+
+1. Calls `fetchSeason(season)` from `src/update/fetch.mjs` (official API `get_snapshots` endpoint)
+2. Returns early (no-op) if the API returns no meaningful data (no snapshots, no events)
+3. Upserts into: `h1_season`, `h1_introduction_order`, `h1_points_max`, `h1_event` (defend + attack), `h1_snapshot`
+4. All operations use Prisma upserts — idempotent, safe to call multiple times for the same season
+5. Throws if the API fetch itself fails
+
+### Usage
+
+```js
+// In /war page — fetch missing season on first request
+const { data, error } = await tryCatch(getCampaign(season));
+if (!error && !data) {
+    await tryCatch(fetchAndSeedSeason(season));
+    // Re-query after seeding
+    ({ data, error } = await tryCatch(getCampaign(season)));
+}
+```
+
+### Season selector derivation
+
+The `/war` page no longer queries the database for available seasons. Instead, it derives the list from the current active season number:
+
+```js
+const seasons = Array.from({ length: activeSeason - 1 }, (_, i) => activeSeason - 1 - i);
+```
+
+This ensures all past seasons are always selectable, even if they haven't been fetched yet. First access triggers `fetchAndSeedSeason()`, after which the data is cached in the DB permanently.
+
+---
+
+## Cross-References
+
+- See [API Reference](/docs/api) for where these utilities are used in route handlers.
+- See [Data Flow](/docs/data-flow) for how `isValidStatus` and `isValidSeason` fit into the update pipeline.

--- a/src/shared/components/MermaidDiagram/MermaidDiagram.jsx
+++ b/src/shared/components/MermaidDiagram/MermaidDiagram.jsx
@@ -82,23 +82,28 @@ function applyFlowFilter(container, activeView, flows) {
         }
     });
 
-    // Highlight edges where both source and target are in the active flow
-    allEdgePaths.forEach((edge) => {
+    // Mermaid v11 renders multiple .edgeLabel elements per edge (background + text).
+    // Compute stride to map each edge path to its corresponding label group.
+    const labelsPerEdge =
+        allEdgePaths.length > 0 ? Math.round(allEdgeLabels.length / allEdgePaths.length) : 1;
+
+    // Highlight edges + their labels
+    allEdgePaths.forEach((edge, i) => {
         const dataId = edge.getAttribute('data-id');
         const endpoints = parseEdgeEndpoints(dataId, allNodeIds);
-        if (endpoints && activeNodeIds.has(endpoints.source) && activeNodeIds.has(endpoints.target)) {
-            edge.classList.remove('diagram-dimmed');
-            edge.classList.add('diagram-highlighted');
-        } else {
-            edge.classList.remove('diagram-highlighted');
-            edge.classList.add('diagram-dimmed');
-        }
-    });
+        const isActive =
+            endpoints && activeNodeIds.has(endpoints.source) && activeNodeIds.has(endpoints.target);
 
-    // Dim all edge labels (they don't carry source/target info)
-    allEdgeLabels.forEach((el) => {
-        el.classList.remove('diagram-highlighted');
-        el.classList.add('diagram-dimmed');
+        const applyClass = (el, active) => {
+            if (!el) return;
+            el.classList.remove(active ? 'diagram-dimmed' : 'diagram-highlighted');
+            el.classList.add(active ? 'diagram-highlighted' : 'diagram-dimmed');
+        };
+
+        applyClass(edge, isActive);
+        for (let j = 0; j < labelsPerEdge; j++) {
+            applyClass(allEdgeLabels[i * labelsPerEdge + j], isActive);
+        }
     });
 }
 


### PR DESCRIPTION
## Summary

- Migrated all 10 GitHub wiki pages into 7 new MDX pages + 3 merges into existing pages
- Fixed stale references (SSE → polling, sseManager → deleted)
- Sidebar restructured into 4 surface-card sections (General, Architecture, Reference, Development)
- Renamed API pages: "Rebroadcast" and "Official"
- Updated CLAUDE.md reference table from wiki URLs to `/docs/` paths
- Disabled GitHub wiki

## Test plan

- [x] `npm run build` — all 34 routes compile
- [x] `npm run test:unit` — 729/729 tests pass
- [x] No stale wiki URLs in `src/`
- [x] No stale SSE/sseManager references in docs

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)