### PR TITLE
feat: timeline duration blocks and proportional spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.30.0
+
+### Features
+
+- **Timeline duration blocks** — replace rail dots with proportional duration blocks that visualize event length. Cards show compact duration pills (`2d3h`, `14h22m`). Active events pulse with danger color scheme. Empty days fill gaps between event groups for proportional timeline spacing.
+
 ## 0.29.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.29.1
+
+### Fixes
+
+- **Defer poll emissions to `requestIdleCallback`** — prevents `enqueueModel` crashes caused by `setState` firing during RSC Flight stream processing on navigation. Coalesces rapid-fire emissions to skip intermediate status flickers.
+
 ## 0.29.0 (retroactive)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.29.2
+
+### Fixes
+
+- **Docs overview Mermaid diagram** — replace raw `mermaid` code block on `/docs` with the shared `MermaidDiagram` component so it actually renders as an interactive diagram with consistent styling, detail panels, and accessibility
+- **Notification flow `db` node** — add missing details entry for the Database node in the notification-flow diagram so it's clickable like all other nodes
+
 ## 0.29.1
 
 ### Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ After any frontend/CSS change, verify via DevTools before declaring done:
 **Rules:**
 
 1. **Create feature/bugfix/chore branches from `develop`.** Features merge back via PR. Bugfix and chore branches merge via fast-forward into `develop` (branch → commit → `git merge` into develop → push → delete branch). No PR needed.
-2. **Version on merge to `develop`:** When merging a branch into `develop`, move its changelog entries from `## Unreleased` into a new `## X.Y.Z` section and bump `"version"` in `package.json` to match. Use semver: patch for bugfixes, minor for features, major for breaking changes. Skipping version numbers between releases is fine — not every version on `develop` will be tagged on `main`.
+2. **Version on merge to `develop`:** When merging a branch into `develop`, **in the same commit** move its changelog entries from `## Unreleased` into a new `## X.Y.Z` section and bump `"version"` in `package.json` to match. Do not defer this to a separate commit or ask — it is part of the merge step. Use semver: patch for bugfixes, minor for features, major for breaking changes. Skipping version numbers between releases is fine — not every version on `develop` will be tagged on `main`.
 3. **Release process:** Merge `develop` → `main` via PR → **tag `vX.Y.Z` on the merge commit on `main`** (use the latest version from `CHANGELOG.md`) → push tag. The production Docker build only triggers on version tags, so forgetting to tag means no deployment.
 4. **Hotfix process:** Cut `hotfix/X.Y.Z` from `main` → fix → update `CHANGELOG.md` with new version section → PR to `main` → tag `vX.Y.Z` → merge back to `develop`
 5. **Semver tagging:** `v<major>.<minor>.<patch>` on `main` only (always use `v` prefix)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const COMMIT_SHA = (() => {
         return 'unknown';
     }
 })();
-console.info(`next.config.mjs | v${APP_VERSION} (${COMMIT_SHA})`);
+console.info(`next.config.mjs    | v${APP_VERSION} (${COMMIT_SHA})`);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,22 +10,13 @@ const COMMIT_SHA = (() => {
         return 'unknown';
     }
 })();
-const COMMIT_MESSAGE = (() => {
-    try {
-        return execSync('git log -1 --format=%s').toString().trim();
-    } catch {
-        return '';
-    }
-})();
-
-console.log(`[helldivers.bot] v${APP_VERSION} (${COMMIT_SHA}) ${COMMIT_MESSAGE}`);
+console.log(`[helldivers.bot] v${APP_VERSION} (${COMMIT_SHA})`);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     env: {
         NEXT_PUBLIC_APP_VERSION: APP_VERSION,
         NEXT_PUBLIC_COMMIT_SHA: COMMIT_SHA,
-        NEXT_PUBLIC_COMMIT_MESSAGE: COMMIT_MESSAGE,
     },
     pageExtensions: ['js', 'jsx', 'mdx'],
     reactCompiler: true,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const COMMIT_SHA = (() => {
         return 'unknown';
     }
 })();
-console.log(`[helldivers.bot] v${APP_VERSION} (${COMMIT_SHA})`);
+console.info(`next.config.mjs | v${APP_VERSION} (${COMMIT_SHA})`);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.29.2",
+    "version": "0.30.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/__tests__/unit/features/timeline/Event.test.jsx
+++ b/src/__tests__/unit/features/timeline/Event.test.jsx
@@ -71,10 +71,10 @@ describe('Event', () => {
         expect(container.querySelector('.bg-success')).toBeInTheDocument();
     });
 
-    test('renders failed status with danger styling', () => {
+    test('renders failed status with muted styling', () => {
         const failedEvent = { ...activeEvent, status: 'fail' };
         const { container } = render(<Event event={failedEvent} />);
         expect(screen.getByText('Failed defend Event')).toBeInTheDocument();
-        expect(container.querySelector('.bg-danger')).toBeInTheDocument();
+        expect(container.querySelector('.bg-ghost')).toBeInTheDocument();
     });
 });

--- a/src/app/docs/notifications/page.mdx
+++ b/src/app/docs/notifications/page.mdx
@@ -81,11 +81,11 @@ The dashboard uses client-side polling to fetch live campaign data.
 - **Status tri-state**: `'polling'` (request in flight), `'live'` (last poll succeeded), `'offline'` (last poll failed or `navigator.onLine` is false)
 - **Leader election**: BroadcastChannel ensures only one tab fires Web Notifications
 
-### Why useSyncExternalStore
+### Deferred emissions
 
-Poll data lives outside React in a module-level store object. React pulls snapshots via `useSyncExternalStore` when it is safe to render — it never pushes updates into the Fiber queue. This prevents a crash (`Cannot read properties of null (reading 'enqueueModel')`) caused by state updates injecting into React's concurrent work queue during RSC Flight stream processing on client-side navigation (originally discovered with SSE, preserved in polling migration).
+Poll data lives outside React in a module-level store object. React subscribes via `useState` + `useEffect` — the `emit()` function notifies listeners when the store changes. To prevent a crash (`chunk.reason.enqueueModel is not a function`) caused by `setState` firing during RSC Flight stream processing on client-side navigation (`vercel/next.js#92362`), `emit()` defers listener notification to `requestIdleCallback` (with `setTimeout` fallback). Rapid-fire emissions are coalesced so listeners always receive the latest snapshot.
 
-`Object.freeze(INITIAL_STORE)` guarantees `getServerSnapshot` returns a stable reference for hydration. The `isFirstMessage` flag tracks whether the first successful poll has occurred, preventing false change detection on initial page load.
+`Object.freeze(INITIAL_STORE)` guarantees the initial state is a stable reference for hydration. The `isFirstMessage` flag tracks whether the first successful poll has occurred, preventing false change detection on initial page load.
 
 ### Data Fallback Chain
 

--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -1,3 +1,10 @@
+import MermaidDiagram from '@/shared/components/MermaidDiagram/MermaidDiagram';
+import {
+    DEFINITION_LR,
+    DEFINITION_TD,
+} from '@/features/docs/overviewDefinition';
+import { overviewConfig } from '@/features/docs/overviewConfig';
+
 export const metadata = {
     title: 'Docs | Helldivers Bot',
     description:
@@ -10,38 +17,12 @@ export const metadata = {
 
 Welcome to the helldivers.bot documentation. This site caches the official Helldivers 1 API, stores historic game data, and provides API access along with frontend visualizations.
 
-```mermaid
-graph TB
-    subgraph Frontend["FRONTEND"]
-        DASH["Dashboard<br/><small>Live campaign view</small>"]
-        ARCH["/archives<br/><small>War history</small>"]
-        PROFILE["/profile<br/><small>Account & API keys</small>"]
-        DOCS["/docs<br/><small>Documentation</small>"]
-    end
-
-    subgraph Backend["BACKEND"]
-        API_LIVE["/api/h1/live<br/><small>Polling endpoint</small>"]
-        API_RB["/api/h1/rebroadcast<br/><small>API proxy</small>"]
-        API_UPDATE["/api/h1/update<br/><small>Worker trigger</small>"]
-        AUTH_API["/api/auth/*<br/><small>BetterAuth OAuth</small>"]
-    end
-
-    subgraph Data["DATA LAYER"]
-        WORKER["Worker Thread<br/><small>Polls every 10-20s</small>"]
-        DB[("PostgreSQL<br/><small>Prisma 7</small>")]
-        HD1["Official HD1 API<br/><small>api.helldiversgame.com</small>"]
-    end
-
-    DASH -->|"poll 10s"| API_LIVE
-    API_LIVE --> DB
-    WORKER -->|"setTimeout loop"| API_UPDATE
-    API_UPDATE --> DB
-    WORKER --> HD1
-
-    style Frontend fill:#1a1a2e,stroke:#a855f7,color:#c084fc
-    style Backend fill:#0f1a0f,stroke:#22c55e,color:#4ade80
-    style Data fill:#1c1917,stroke:#f59e0b,color:#fbbf24
-```
+<MermaidDiagram
+    id="docs-overview"
+    definition={DEFINITION_LR}
+    mobileDefinition={DEFINITION_TD}
+    config={overviewConfig}
+/>
 
 ## Getting Started
 

--- a/src/db/queries/api.mjs
+++ b/src/db/queries/api.mjs
@@ -76,7 +76,7 @@ export async function generateApiKey(_, formData) {
 
     const schema = z.object({
         userId: z.string().min(1),
-        description: z.string().min(3).max(200),
+        description: z.string().min(3).max(32),
     });
     const check = schema.safeParse(formValues);
     if (!check.success) {

--- a/src/features/account/ApiForm.jsx
+++ b/src/features/account/ApiForm.jsx
@@ -1,7 +1,10 @@
 'use client';
+import { useState } from 'react';
 import Form from 'next/form';
 import { useActionState } from 'react';
 import { generateApiKey, deleteApiKey } from '@/db/queries/api';
+
+const MAX_DESCRIPTION_LENGTH = 32;
 
 export function GenerateApiKeyForm({ userId }) {
     if (!userId) {
@@ -9,6 +12,7 @@ export function GenerateApiKeyForm({ userId }) {
     }
 
     const [state, formAction, pending] = useActionState(generateApiKey, null);
+    const [descLength, setDescLength] = useState(0);
 
     return (
         <>
@@ -41,12 +45,18 @@ export function GenerateApiKeyForm({ userId }) {
                         type="text"
                         id="description"
                         name="description"
-                        placeholder="e.g. My Discord Bot, Personal Project"
-                        className="w-full bg-surface-2 px-3 py-2 text-body text-text placeholder:text-text-muted"
+                        placeholder="e.g. My Discord Bot"
+                        maxLength={MAX_DESCRIPTION_LENGTH}
+                        onChange={(e) => setDescLength(e.target.value.length)}
+                        size={MAX_DESCRIPTION_LENGTH}
+                        className="bg-surface-2 px-3 py-2 text-body text-text placeholder:text-text-muted"
                         aria-describedby={
                             state?.errors?.description ? 'description-error' : undefined
                         }
                     />
+                    <span className={`text-small ${descLength >= MAX_DESCRIPTION_LENGTH ? 'text-danger' : 'text-text-muted'}`}>
+                        {descLength}/{MAX_DESCRIPTION_LENGTH}
+                    </span>
                 </fieldset>
 
                 <button

--- a/src/features/docs/overviewConfig.js
+++ b/src/features/docs/overviewConfig.js
@@ -1,0 +1,143 @@
+/**
+ * Configuration for the docs overview diagram.
+ * Single-view diagram (no flow filtering) with node details.
+ */
+export const overviewConfig = {
+    views: [{ key: 'all', label: 'All' }],
+
+    flows: {},
+
+    legend: [
+        { color: '#a855f7', label: 'Frontend' },
+        { color: '#22c55e', label: 'Backend' },
+        { color: '#f59e0b', label: 'Data Layer' },
+    ],
+
+    title: 'System Overview',
+    description:
+        'High-level architecture showing how the frontend, backend API routes, and data layer connect',
+
+    details: {
+        dash: {
+            title: 'Dashboard',
+            subtitle: 'src/app/(app)/page.jsx',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Live campaign dashboard with galaxy map, faction stats, event cards, and timeline. Polls /api/h1/live every 10 seconds via the useLiveData hook.',
+                },
+            ],
+        },
+        archives: {
+            title: 'Archives',
+            subtitle: 'src/app/archives/page.jsx',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Historical war browser. Season selector derives available seasons from the current season number. Missing seasons are fetched from the official API on first request.',
+                },
+            ],
+        },
+        profile: {
+            title: 'Profile',
+            subtitle: 'src/app/profile/page.jsx',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Account management page with API key generation, session management, and linked OAuth accounts. Requires authentication — redirects home when auth is disabled.',
+                },
+            ],
+        },
+        docs: {
+            title: 'Documentation',
+            subtitle: 'src/app/docs/',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'MDX-based documentation with interactive Mermaid diagrams, code samples, and architecture guides.',
+                },
+            ],
+        },
+        api_live: {
+            title: 'Live Endpoint',
+            subtitle: 'src/app/api/h1/live/route.js',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Lightweight GET endpoint returning current campaign data and computed map state. No authentication required. Called by the useLiveData hook every 10 seconds.',
+                },
+            ],
+        },
+        api_rb: {
+            title: 'Rebroadcast API',
+            subtitle: 'src/app/api/h1/rebroadcast/',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Proxies the official Helldivers 1 API for external consumers. Returns cached raw JSON from the rebroadcast tables. Requires API key authentication.',
+                },
+            ],
+        },
+        api_update: {
+            title: 'Update Route',
+            subtitle: 'src/app/api/h1/update/route.js',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Internal POST endpoint called by the worker thread. Runs updateStatus() and updateSeason(), then triggers push notification check. Protected by bearer token (UPDATE_KEY).',
+                },
+            ],
+        },
+        auth_api: {
+            title: 'Auth API',
+            subtitle: 'src/app/api/auth/[...all]/route.js',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'BetterAuth catch-all route handling Discord and GitHub OAuth flows, session management, and account operations. Optional — returns 503 when BETTER_AUTH_SECRET is absent.',
+                },
+            ],
+        },
+        worker: {
+            title: 'Worker Thread',
+            subtitle: 'public/workers/cron.js',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Dedicated Worker Thread polling the official HD1 API every 10-20 seconds using setTimeout (not setInterval) to prevent overlapping requests. Validates with Zod before triggering the update route.',
+                },
+            ],
+        },
+        db: {
+            title: 'Database',
+            subtitle: 'PostgreSQL (Prisma 7)',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Two-table strategy: rebroadcast_* tables store raw API JSON, h1_* tables store normalized historical data. Both coexist — raw for fidelity, normalized for queries.',
+                },
+            ],
+        },
+        hd1: {
+            title: 'Official HD1 API',
+            subtitle: 'api.helldiversgame.com',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'The official Helldivers 1 community API. Provides live campaign status, historical snapshots, and introduction order data. Updates roughly every second.',
+                },
+            ],
+        },
+    },
+};

--- a/src/features/docs/overviewDefinition.js
+++ b/src/features/docs/overviewDefinition.js
@@ -1,0 +1,52 @@
+/**
+ * Mermaid definition for the docs overview diagram.
+ * Shows the high-level architecture: Frontend → Backend → Data Layer.
+ *
+ * Two variants: LR (horizontal, desktop) and TD (vertical, mobile).
+ */
+const BODY = `
+    subgraph Frontend["FRONTEND"]
+        dash["Dashboard<br/><small>Live campaign view</small>"]
+        archives["/archives<br/><small>War history</small>"]
+        profile["/profile<br/><small>Account & API keys</small>"]
+        docs["/docs<br/><small>Documentation</small>"]
+    end
+
+    subgraph Backend["BACKEND"]
+        api_live["/api/h1/live<br/><small>Polling endpoint</small>"]
+        api_rb["/api/h1/rebroadcast<br/><small>API proxy</small>"]
+        api_update["/api/h1/update<br/><small>Worker trigger</small>"]
+        auth_api["/api/auth/*<br/><small>BetterAuth OAuth</small>"]
+    end
+
+    subgraph Data["DATA LAYER"]
+        worker["Worker Thread<br/><small>Polls every 10-20s</small>"]
+        db[("PostgreSQL<br/><small>Prisma 7</small>")]
+        hd1["Official HD1 API<br/><small>api.helldiversgame.com</small>"]
+    end
+
+    dash -->|"poll 10s"| api_live
+    api_live --> db
+    worker -->|"setTimeout loop"| api_update
+    api_update --> db
+    worker --> hd1
+
+    %% Styles matching wiki color conventions
+    classDef frontend fill:#1c1b1b,stroke:#a855f7,color:#c084fc
+    classDef backend fill:#1c1b1b,stroke:#22c55e,color:#4ade80
+    classDef data fill:#1c1b1b,stroke:#f59e0b,color:#fbbf24
+
+    class dash,archives,profile,docs frontend
+    class api_live,api_rb,api_update,auth_api backend
+    class worker,db,hd1 data
+
+    style Frontend fill:#131313,stroke:#a855f7,color:#c084fc
+    style Backend fill:#131313,stroke:#22c55e,color:#4ade80
+    style Data fill:#131313,stroke:#f59e0b,color:#fbbf24
+`;
+
+/** Horizontal layout (desktop) */
+export const DEFINITION_LR = `graph LR\n${BODY}`;
+
+/** Vertical layout (mobile) */
+export const DEFINITION_TD = `graph TD\n${BODY}`;

--- a/src/features/notifications/notificationFlowConfig.js
+++ b/src/features/notifications/notificationFlowConfig.js
@@ -210,5 +210,26 @@ export const notificationFlowConfig = {
                 },
             ],
         },
+        db: {
+            title: 'Database',
+            subtitle: 'PostgreSQL (Prisma 7)',
+            sections: [
+                {
+                    type: 'text',
+                    content:
+                        'Central data store for all game state. The worker writes campaign status and snapshots via the Update Route. The Live Endpoint reads current campaign data for client polling.',
+                },
+                {
+                    type: 'table',
+                    headers: ['Table', 'Purpose'],
+                    rows: [
+                        ['rebroadcast_status', 'Raw API JSON (1 row/season)'],
+                        ['h1_live', 'Normalized campaigns + stats'],
+                        ['h1_event', 'Historical attack/defend events'],
+                        ['push_subscription', 'Web push subscription endpoints'],
+                    ],
+                },
+            ],
+        },
     },
 };

--- a/src/features/timeline/Event.jsx
+++ b/src/features/timeline/Event.jsx
@@ -8,29 +8,63 @@ const STATUS_STYLES = {
         bg: 'bg-success-tint/40',
         border: 'border-ghost',
         accent: 'bg-success',
+        card: '',
+        pill: 'bg-success/10 text-success border border-success/20',
     },
     fail: {
+        bg: 'bg-surface-1',
+        border: 'border-ghost',
+        accent: 'bg-ghost',
+        card: '',
+        pill: 'bg-surface-3 text-text-muted border border-ghost',
+    },
+    active: {
         bg: 'bg-danger-tint/50',
         border: 'border-ghost',
         accent: 'bg-danger',
-    },
-    active: {
-        bg: 'bg-primary-tint/40',
-        border: 'border-ghost',
-        accent: 'bg-primary',
+        card: 'animate-[card-flash_3s_ease-in-out_infinite] motion-reduce:animate-none',
+        pill: 'bg-danger/12 text-danger border border-danger/25 animate-[pill-flash_1.5s_ease-in-out_infinite] motion-reduce:animate-none',
     },
 };
+
+const shortEnglish = {
+    y: () => 'y',
+    mo: () => 'mo',
+    w: () => 'w',
+    d: () => 'd',
+    h: () => 'h',
+    m: () => 'm',
+    s: () => 's',
+    ms: () => 'ms',
+};
+
+function formatCompactDuration(seconds) {
+    return humanizeDuration(seconds * 1000, {
+        largest: 2,
+        round: true,
+        spacer: '',
+        language: 'shortEn',
+        languages: { shortEn: shortEnglish },
+    });
+}
 
 /**
  * Event card with status-colored accent bar.
  * Three types: won (green), lost (red), active (gold).
  */
 export default function Event({ event, onMouseEnter, onMouseLeave }) {
-    const elapsed = Math.floor(Date.now() / 1000) - event.start_time;
+    const now = Math.floor(Date.now() / 1000);
+    const isCompleted = event.status === 'success' || event.status === 'fail';
+    const elapsed = isCompleted ? now - event.end_time : now - event.start_time;
+    const duration = isCompleted
+        ? event.end_time - event.start_time
+        : now - event.start_time;
     const percent = ((event.points / event.points_max) * 100).toFixed(2);
     const faction = factions[event.enemy];
 
-    const timeText = `Started ${humanizeDuration(elapsed * 1000, { largest: 2, round: true })} ago`;
+    const timeText = isCompleted
+        ? `Ended ${humanizeDuration(elapsed * 1000, { largest: 2, round: true })} ago`
+        : `Started ${humanizeDuration(elapsed * 1000, { largest: 2, round: true })} ago`;
 
     const statusText =
         event.status === 'success' ? 'Won'
@@ -41,7 +75,7 @@ export default function Event({ event, onMouseEnter, onMouseLeave }) {
 
     return (
         <article
-            className={`grid grid-cols-[minmax(0,1fr)_6px] border border-r-0 ${s.border} ${s.bg}`}
+            className={`event-card border ${s.border} ${s.bg} ${s.card}`}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
         >
@@ -49,6 +83,12 @@ export default function Event({ event, onMouseEnter, onMouseLeave }) {
                 <div className="flex items-center justify-between">
                     <span className="font-body text-small font-bold text-text uppercase">
                         {statusText} {event.type} Event
+                    </span>
+                    <span
+                        className={`font-mono text-[10px] px-1.5 py-px ${s.pill}`}
+                        suppressHydrationWarning
+                    >
+                        {formatCompactDuration(duration)}
                     </span>
                     {faction && (
                         <img src={faction.icon} alt={faction.name} className="size-5" />
@@ -61,7 +101,7 @@ export default function Event({ event, onMouseEnter, onMouseLeave }) {
                     {event.points} / {event.points_max} ({percent}%)
                 </div>
             </div>
-            <div className={s.accent} />
+            <div className={`event-card-accent ${s.accent}`} />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{

--- a/src/features/timeline/TimelineSection.css
+++ b/src/features/timeline/TimelineSection.css
@@ -15,21 +15,21 @@
     padding: 2rem 0;
 }
 
-/* === Day groups === */
+/* === Day groups (mobile: no gap, accents form continuous line) === */
 
 .timeline-days {
     display: flex;
     flex-direction: column;
 }
 
-/* === Day header (mobile: grey right accent) === */
+/* === Day header (mobile: ghost right accent via box-shadow) === */
 
 .timeline-day-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    padding: 0.75rem calc(6px + 0.5rem) 0.25rem 0;
     box-shadow: inset -6px 0 0 0 var(--color-ghost);
-    padding: 1rem calc(12px + 6px) 0.25rem 0;
 }
 
 .timeline-day-label {
@@ -49,17 +49,67 @@
     white-space: nowrap;
 }
 
-/* === Event grid (mobile: single column, no gap so borders connect) === */
+/* === Empty day markers === */
+
+.timeline-day--empty .timeline-day-header,
+.timeline-day--no-events .timeline-day-header {
+    min-height: 3rem;
+    box-shadow: inset -6px 0 0 0 rgba(255, 255, 255, 0.06);
+}
+
+.timeline-day-label--empty {
+    color: rgba(255, 255, 255, 0.2);
+}
+
+/* === Event cards (mobile: keep accent column, borders connect) === */
+
+.event-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 6px;
+    border-right: none;
+}
 
 .timeline-day-grid {
     display: flex;
     flex-direction: column;
 }
 
-/* === Rail elements — hidden on mobile === */
+/* Collapse double borders between stacked cards */
+.timeline-day-grid > article + article {
+    margin-top: -1px;
+}
 
-.rail,
-.rail-separator {
+/* === Day-level accent element — not used on mobile === */
+
+.timeline-day-accent {
+    display: none;
+}
+
+/* === Keyframes === */
+
+@keyframes card-flash {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.7;
+    }
+}
+
+@keyframes pill-flash {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+/* === Rail — hidden on mobile === */
+
+.rail {
     display: none;
 }
 
@@ -87,7 +137,7 @@
         background: rgba(255, 255, 255, 0.08);
     }
 
-    /* Each day: 2-row grid — circle+header, then dots+cards */
+    /* Each day: 2-column grid with rail */
     .timeline-day {
         display: grid;
         grid-template-columns: 18px minmax(0, 1fr);
@@ -127,82 +177,114 @@
         transform: translateY(-50%);
     }
 
-    .rail-separator {
-        display: block;
-        width: 14px;
-        height: 2px;
-        background: var(--color-ghost);
-        margin-left: calc(8px - 7px);
-        position: relative;
-        z-index: 1;
+    .rail-circle--empty {
+        border-color: rgba(255, 255, 255, 0.06);
     }
 
-    .rail-separator + .rail-separator {
-        margin-top: calc(-1.25rem + 4px);
+    .rail-circle--empty::after {
+        background: rgba(255, 255, 255, 0.06);
     }
 
-    .rail-dot {
+    /* Duration blocks on rail */
+    .rail-block {
         width: 8px;
-        height: 8px;
-        border-radius: 50%;
+        min-height: 12px;
+        border-radius: 4px;
         position: absolute;
         left: 50%;
         transform: translateX(-50%);
-        z-index: 1;
         transition:
             transform 0.15s ease,
-            box-shadow 0.15s ease;
+            box-shadow 0.15s ease,
+            height 1s linear;
     }
 
-    .rail-dot[data-highlighted] {
-        transform: translateX(-50%) scale(1.75);
+    .rail-block[data-highlighted] {
+        transform: translateX(-50%);
+    }
+
+    .rail-block--success {
+        background: var(--color-success);
         z-index: 2;
     }
 
-    .rail-dot--success[data-highlighted] {
-        box-shadow: 0 0 6px 2px var(--color-success);
+    .rail-block--fail {
+        background: var(--color-ghost);
+        z-index: 1;
     }
 
-    .rail-dot--fail[data-highlighted] {
-        box-shadow: 0 0 6px 2px var(--color-danger);
-    }
-
-    .rail-dot--active[data-highlighted] {
-        box-shadow: 0 0 6px 2px var(--color-primary);
-    }
-
-    .rail-dot--success {
-        background: var(--color-success);
-    }
-
-    .rail-dot--fail {
+    .rail-block--active {
         background: var(--color-danger);
+        z-index: 3;
+        animation: rail-pulse 3s ease-in-out infinite;
     }
 
-    .rail-dot--active {
-        background: var(--color-primary);
+    .rail-block--success[data-highlighted] {
+        box-shadow: 0 0 6px 2px var(--color-success);
+        z-index: 10;
     }
 
-    /* Row 1, col 2: day header */
+    .rail-block--fail[data-highlighted] {
+        box-shadow: 0 0 6px 2px rgba(255, 255, 255, 0.2);
+        z-index: 10;
+    }
+
+    .rail-block--active[data-highlighted] {
+        box-shadow: 0 0 6px 2px var(--color-danger);
+        z-index: 10;
+    }
+
+    @keyframes rail-pulse {
+        0%,
+        100% {
+            opacity: 1;
+        }
+        50% {
+            opacity: 0.5;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .rail-block--active {
+            animation: none;
+        }
+    }
+
+    /* Empty day markers — match event day height on desktop */
+    .timeline-day--empty,
+    .timeline-day--no-events {
+        min-height: 8.2rem;
+    }
+
+    .timeline-day--empty .rail {
+        min-height: 100%;
+    }
+
+    /* Desktop: day header loses box-shadow accent, rail replaces it */
     .timeline-day-header {
         grid-row: 1;
         grid-column: 2;
         box-shadow: none;
-        flex-direction: row;
         padding: 0 0 0.25rem 0;
+    }
+
+    .timeline-day--empty .timeline-day-header,
+    .timeline-day--no-events .timeline-day-header {
+        box-shadow: none;
     }
 
     /* Row 2, col 2: event card grid */
     .timeline-day-grid {
         grid-row: 2;
         grid-column: 2;
-    }
-
-    /* Desktop: switch to grid layout for cards */
-    .timeline-day-grid {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 0.4rem;
+    }
+
+    /* Desktop cards have gap so no border collapse needed */
+    .timeline-day-grid > article + article {
+        margin-top: 0;
     }
 }
 

--- a/src/features/timeline/TimelineSection.jsx
+++ b/src/features/timeline/TimelineSection.jsx
@@ -3,17 +3,38 @@
 import { Fragment, useState } from 'react';
 import './TimelineSection.css';
 import Event from '@/features/timeline/Event';
-import { groupEventsByDay } from '@/features/timeline/groupEventsByDay.mjs';
+import {
+    groupEventsByDay,
+    formatDayLabel,
+} from '@/features/timeline/groupEventsByDay.mjs';
 import { countOutcomes } from '@/shared/utils/game/eventFilters.mjs';
 import { useLiveDataContext } from '@/shared/providers/LiveDataContext.mjs';
 
+const SECONDS_PER_DAY = 86400;
+const DAY_MS = 86_400_000;
+/** Max visual height (px) for a rail block representing a full 24h event */
+const RAIL_MAX_HEIGHT = 120;
+
+/** Generate date strings for empty days between two date strings (exclusive). */
+function getEmptyDaysBetween(newerDate, olderDate) {
+    const days = [];
+    const start = new Date(olderDate).getTime();
+    let cursor = new Date(newerDate).getTime() - DAY_MS;
+    while (cursor > start) {
+        const dateStr = new Date(cursor).toISOString().slice(0, 10);
+        days.push(dateStr);
+        cursor -= DAY_MS;
+    }
+    return days;
+}
+
 /**
  * Event log with vertical timeline rail (desktop only).
- * Groups events by calendar day, renders status-colored dots on a rail
- * with proportional vertical positioning (top = most recent, bottom = oldest).
- * Hovering an event card highlights its corresponding rail dot.
+ * Groups events by calendar day with empty days filling gaps for proportional spacing.
+ * Renders status-colored duration blocks on a rail with proportional vertical positioning.
+ * Hovering an event card highlights its corresponding rail block.
  *
- * Reads events from LiveDataContext — updates live as SSE delivers new data.
+ * Reads events from LiveDataContext — updates live as polling delivers new data.
  */
 export default function TimelineSection() {
     const { data } = useLiveDataContext();
@@ -31,47 +52,65 @@ export default function TimelineSection() {
                         {groups.map((group, i) => {
                             const { wins, losses } = countOutcomes(group.events);
 
-                            const dayMs = 86_400_000;
                             const thisMs = new Date(group.date).getTime();
-                            const prevMs =
-                                groups[i - 1] && new Date(groups[i - 1].date).getTime();
-                            const nextMs =
-                                groups[i + 1] && new Date(groups[i + 1].date).getTime();
-                            const gapBefore = prevMs != null && prevMs - thisMs > dayMs;
-                            const gapAfter = nextMs != null && thisMs - nextMs > dayMs;
+                            const nextGroup = groups[i + 1];
+                            const gapDays = nextGroup
+                                ? Math.round(
+                                      (thisMs -
+                                          new Date(
+                                              nextGroup.date,
+                                          ).getTime()) /
+                                          DAY_MS,
+                                  )
+                                : 0;
 
-                            // Dot positioning: map time-of-day to vertical %, inverted so top = most recent
+                            // Block positioning: map time-of-day to vertical %, inverted so top = most recent
                             const chronological = [...group.events].sort(
                                 (a, b) => a.start_time - b.start_time,
                             );
-                            const times = chronological.map((e) => e.start_time % 86400);
+                            const times = chronological.map(
+                                (e) => e.start_time % 86400,
+                            );
                             const minT = Math.min(...times);
                             const maxT = Math.max(...times);
                             const range = maxT - minT;
 
                             return (
                                 <Fragment key={group.date}>
-                                    {gapBefore && (
-                                        <div
-                                            className="rail-separator"
-                                            aria-hidden="true"
-                                        />
-                                    )}
-                                    <div className="timeline-day">
+                                    <div
+                                        className={`timeline-day${group.events.length === 0 ? ' timeline-day--no-events' : ''}`}
+                                    >
                                         <div className="rail" aria-hidden="true">
                                             <div className="rail-circle" />
                                             {chronological.map((event) => {
-                                                const t = event.start_time % 86400;
+                                                const t =
+                                                    event.start_time % 86400;
                                                 const pct =
                                                     range > 0 ?
-                                                        ((maxT - t) / range) * 100
+                                                        ((maxT - t) / range) *
+                                                        100
                                                     :   0;
+                                                const now = Math.floor(
+                                                    Date.now() / 1000,
+                                                );
+                                                const duration =
+                                                    event.status === 'active' ?
+                                                        now - event.start_time
+                                                    :   event.end_time -
+                                                        event.start_time;
+                                                const blockHeight = Math.max(
+                                                    12,
+                                                    (duration /
+                                                        SECONDS_PER_DAY) *
+                                                        RAIL_MAX_HEIGHT,
+                                                );
                                                 return (
                                                     <div
                                                         key={event.event_id}
-                                                        className={`rail-dot rail-dot--${event.status}`}
+                                                        className={`rail-block rail-block--${event.status}`}
                                                         style={{
-                                                            top: `calc(${pct}% - ${(pct * 8) / 100}px)`,
+                                                            top: `calc(${pct}% - ${(pct * 12) / 100}px)`,
+                                                            height: `${blockHeight}px`,
                                                         }}
                                                         data-highlighted={
                                                             (
@@ -81,6 +120,7 @@ export default function TimelineSection() {
                                                                 ''
                                                             :   undefined
                                                         }
+                                                        suppressHydrationWarning
                                                     />
                                                 );
                                             })}
@@ -101,7 +141,9 @@ export default function TimelineSection() {
                                                     key={event.event_id}
                                                     event={event}
                                                     onMouseEnter={() =>
-                                                        setHoveredEventId(event.event_id)
+                                                        setHoveredEventId(
+                                                            event.event_id,
+                                                        )
                                                     }
                                                     onMouseLeave={() =>
                                                         setHoveredEventId(null)
@@ -110,12 +152,31 @@ export default function TimelineSection() {
                                             ))}
                                         </div>
                                     </div>
-                                    {gapAfter && (
-                                        <div
-                                            className="rail-separator"
-                                            aria-hidden="true"
-                                        />
-                                    )}
+                                    {nextGroup &&
+                                        gapDays > 1 &&
+                                        getEmptyDaysBetween(
+                                            group.date,
+                                            nextGroup.date,
+                                        ).map((dateStr) => (
+                                            <div
+                                                key={`empty-${dateStr}`}
+                                                className="timeline-day timeline-day--empty"
+                                            >
+                                                <div
+                                                    className="rail"
+                                                    aria-hidden="true"
+                                                >
+                                                    <div className="rail-circle rail-circle--empty" />
+                                                </div>
+                                                <div className="timeline-day-header">
+                                                    <span className="timeline-day-label timeline-day-label--empty">
+                                                        {formatDayLabel(
+                                                            dateStr,
+                                                        )}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        ))}
                                 </Fragment>
                             );
                         })}

--- a/src/shared/components/Footer/Footer.jsx
+++ b/src/shared/components/Footer/Footer.jsx
@@ -137,9 +137,6 @@ export default function Footer() {
                         v{process.env.NEXT_PUBLIC_APP_VERSION} &ndash;{' '}
                         {process.env.NEXT_PUBLIC_COMMIT_SHA}
                     </span>
-                    <span className="text-[0.625rem] normal-case tracking-normal opacity-50">
-                        {process.env.NEXT_PUBLIC_COMMIT_MESSAGE}
-                    </span>
                 </div>
                 <span>
                     Not affiliated with Arrowhead Game Studios or Sony Interactive

--- a/src/shared/hooks/useLiveData.mjs
+++ b/src/shared/hooks/useLiveData.mjs
@@ -49,12 +49,28 @@ let isFirstMessage = true;
 let leaderChannel = null;
 let leaderTimeout = null;
 let visibilityHandler = null;
+let emitScheduled = false;
 
-/** Notify all React subscribers with the current store value. */
+/**
+ * Notify all React subscribers with the current store value.
+ *
+ * Deferred to requestIdleCallback (setTimeout fallback) to prevent
+ * setState from firing during RSC Flight stream processing, which
+ * causes `chunk.reason.enqueueModel is not a function` crashes
+ * (vercel/next.js#92362). Coalesces rapid-fire calls so listeners
+ * always receive the latest store snapshot.
+ */
 function emit() {
-    for (const listener of listeners) {
-        listener(store);
-    }
+    if (emitScheduled) return;
+    emitScheduled = true;
+    const schedule =
+        typeof requestIdleCallback === 'function' ? requestIdleCallback : setTimeout;
+    schedule(() => {
+        emitScheduled = false;
+        for (const listener of listeners) {
+            listener(store);
+        }
+    });
 }
 
 // --- Polling ---
@@ -141,6 +157,7 @@ function disconnect() {
         document.removeEventListener('visibilitychange', visibilityHandler);
         visibilityHandler = null;
     }
+    emitScheduled = false;
     store = INITIAL_STORE;
 }
 

--- a/vitest.setup.mjs
+++ b/vitest.setup.mjs
@@ -15,6 +15,7 @@ vi.mock('@/auth', () => ({
         api: {
             getSession: vi.fn(() => Promise.resolve(null)),
             revokeSession: vi.fn(() => Promise.resolve()),
+            revokeSessions: vi.fn(() => Promise.resolve()),
         },
     },
 }));


### PR DESCRIPTION
## Summary
- Replace timeline rail dots with proportional **duration blocks** that visualize event length relative to a 24h day
- Add compact **duration pills** to event cards (`2d3h`, `14h22m`) showing how long each event lasted
- **Active events** now use danger (red) color scheme with pulsing animation; failed events use muted ghost styling
- Fill **empty days** between event groups for proportional timeline spacing instead of separator dashes
- Bump version to **0.30.0**

## Test plan
- [ ] Verify timeline renders duration blocks on desktop rail (varying heights by event duration)
- [ ] Verify active event cards pulse with red accent
- [ ] Verify duration pills show correct compact format on all card types
- [ ] Verify empty days appear between event groups with dimmed styling
- [ ] Verify mobile layout still shows accent bars (no rail)
- [ ] `npm run build` passes
- [ ] `npm run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)