### PR TITLE
feat(archives): merge Statistics + Faction Analysis under one heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.40.1
+
+### Changed
+
+- **Archives `Statistics` and `Faction Analysis` sections merged into
+  one.** The `Global` tab in `FactionTabs` previously rendered nothing
+  (since `FactionStats` only maps Bugs/Cyborgs/Illuminate to enemy
+  indices); it now renders the whole-war `<ArchiveStats>` overview
+  instead. Bugs/Cyborgs/Illuminate tabs continue to render
+  `<FactionStats>` per-faction. `/archives` now defaults to the
+  `Global` tab on first load so visitors land on the overview before
+  drilling into factions. The standalone `Faction Analysis` H2 is
+  gone; all stat cards live under the single `Statistics` heading now.
+  Composition change only — `ArchiveStats`, `FactionStats`, and
+  `FactionTabs` internals are unchanged.
+
 ## 0.40.0
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/features/archives/ArchivesClient.jsx
+++ b/src/features/archives/ArchivesClient.jsx
@@ -72,7 +72,10 @@ export default function ArchivesClient({
     isAdmin = false,
 }) {
     const events = data?.events ?? [];
-    const [faction, setFaction] = useState('bugs');
+    // 'global' shows the whole-war overview (ArchiveStats); bugs/cyborgs/illuminate
+    // show a per-faction breakdown (FactionStats). Default to 'global' so visitors
+    // land on the big-picture view before drilling into factions.
+    const [faction, setFaction] = useState('global');
     // Mobile-only: toggle whether the archives map column is sticky
     // (pinned at the top as the user scrolls). Default ON here (unlike
     // the homepage) so the archives map is pinned from first paint —
@@ -154,13 +157,22 @@ export default function ArchivesClient({
                             )}
                         </div>
                     </div>
-                    <ArchiveStats
-                        events={events}
-                        live={data?.live}
-                        data={data}
-                        effects={effects}
-                        glitchPhase={glitchPhase}
-                    />
+                    <FactionTabs active={faction} onChange={setFaction} />
+                    {faction === 'global' ?
+                        <ArchiveStats
+                            events={events}
+                            live={data?.live}
+                            data={data}
+                            effects={effects}
+                            glitchPhase={glitchPhase}
+                        />
+                    :   <FactionStats
+                            events={events}
+                            snapshots={data?.snapshots}
+                            pointsMax={data?.points_max}
+                            faction={faction}
+                        />
+                    }
                 </section>
 
                 <section className="mt-4 flex flex-col gap-2">
@@ -168,17 +180,6 @@ export default function ArchivesClient({
                     <FactionHealthChart
                         snapshots={data?.snapshots}
                         pointsMax={data?.points_max}
-                    />
-                </section>
-
-                <section className="mt-4 flex flex-col gap-2">
-                    <h2>Faction Analysis</h2>
-                    <FactionTabs active={faction} onChange={setFaction} />
-                    <FactionStats
-                        events={events}
-                        snapshots={data?.snapshots}
-                        pointsMax={data?.points_max}
-                        faction={faction}
                     />
                 </section>
             </div>


### PR DESCRIPTION
## Summary

- Merged the standalone \`Statistics\` and \`Faction Analysis\` sections on \`/archives\` into a single \`Statistics\` section with \`FactionTabs\` inside it.
- The \`Global\` tab (previously rendered nothing because \`FactionStats\` returns null when the faction key isn't \`bugs\`/\`cyborgs\`/\`illuminate\`) now renders the whole-war \`ArchiveStats\` overview.
- \`/archives\` now defaults to the \`Global\` tab on first load — visitors land on the overview before drilling into per-faction breakdowns.
- Composition change only. \`ArchiveStats\`, \`FactionStats\`, and \`FactionTabs\` internals are unchanged.

## Test plan

- [x] \`npm run test:unit\` — 820/820 passing
- [x] \`npm run build\` — succeeds
- [x] Chrome DevTools verification on \`/archives?season=155\`:
  - [x] Section H2s reduced from 3 → 2: \`Statistics\` + \`Conquest Progress\` (no more \`Faction Analysis\`)
  - [x] \`FactionTabs\` now lives inside the Statistics section below the H2 header row
  - [x] First-load active tab is \`Global\`
  - [x] Clicking \`Bugs\`/\`Illuminate\` swaps the card body to \`FactionStats\` (\`DEFENSE_RATE\`, \`ATTACK_RATE\`, \`BATTLES\`, \`AVG_BATTLE\`, \`HOTSPOT\`, \`CONQUEST\`)
  - [x] Clicking back to \`Global\` restores \`ArchiveStats\` (\`OUTCOME\`, \`DURATION\`, \`DEFENSE_RATE\`, \`ATTACK_RATE\`, \`WORST_CASCADE\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)