### PR TITLE
chore: soft CDN cache header on HTML page routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Chores
+
+- **Soft CDN cache header on HTML page routes** — `next.config.mjs` now emits `Cache-Control: public, s-maxage=30, stale-while-revalidate=60` for all non-API, non-asset paths so a shared cache (e.g. Cloudflare) can collapse concurrent visitors into one origin render per 30s window, and serve the stale copy for another 60s while it refetches. `s-maxage` targets shared caches only, so browsers still revalidate normally and `useLiveData` keeps polling `/api/h1/live` for fresh game state. The source pattern uses a negative lookahead to exclude `/api/*` (preserves `no-store` on live data), `/_next/*` (content-hashed), the asset directories that already have `immutable` long-TTL headers, `/sw.js`, `/workers/*`, and `/profile/*` (per-user content that must not be shared). Note: Cloudflare ignores `s-maxage` on HTML by default — a Cache Rule with "Respect existing headers" is required for this to take effect at the edge.
+
 ## 0.46.2
 
 ### Chores

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -153,6 +153,32 @@ const nextConfig = {
                     },
                 ],
             },
+            {
+                // Soft CDN cache for HTML page routes so Cloudflare collapses
+                // concurrent visitors into one origin hit per 30s window
+                // instead of pass-through on every navigation. The page
+                // itself stays interactive — `s-maxage` only targets shared
+                // caches, so individual browsers still revalidate normally,
+                // and `useLiveData` keeps polling /api/h1/live (no-store) for
+                // fresh game state. `stale-while-revalidate` lets the edge
+                // serve the cached copy while it refetches in the background,
+                // so visitors don't pay origin latency on the TTL boundary.
+                //
+                // Excludes:
+                //   /api/*       — route handlers set their own Cache-Control
+                //   /_next/*     — Next.js asset/data chunks (content-hashed)
+                //   asset roots  — pinned `immutable` above with longer TTLs
+                //   /sw.js       — service worker must always revalidate
+                //   /workers/*   — cron worker source (immutable above)
+                //   /profile/*   — per-user content, must not be shared
+                source: '/((?!api/|_next/|profile|favicons/|fonts/|icons/|images/|svgs/|sw\\.js|workers/).*)',
+                headers: [
+                    {
+                        key: 'Cache-Control',
+                        value: 'public, s-maxage=30, stale-while-revalidate=60',
+                    },
+                ],
+            },
         ];
     },
 };


### PR DESCRIPTION
## Summary

- Adds `Cache-Control: public, s-maxage=30, stale-while-revalidate=60` to non-API, non-asset routes in `next.config.mjs` so a shared cache (Cloudflare) can collapse concurrent visitors into one origin render per 30s window.
- `s-maxage` only targets shared caches, so browser revalidation is unchanged and `useLiveData` keeps polling `/api/h1/live` (still `no-store`).
- Negative-lookahead source excludes `/api/*`, `/_next/*`, asset roots already pinned `immutable`, `/sw.js`, `/workers/*`, and `/profile/*` (per-user content).
- CHANGELOG `## Unreleased` updated.

## Notes

Cloudflare ignores `s-maxage` on HTML by default. A Cache Rule with "Respect existing headers" (or equivalent) is required on the CF side for this to take effect at the edge — the code change is necessary but not sufficient on its own.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (1296 passed)
- [x] `npm run build`
- [ ] After merge + deploy: `curl -I https://helldivers.bot/` shows `Cache-Control: public, s-maxage=30, stale-while-revalidate=60`
- [ ] After merge + deploy: `curl -I https://helldivers.bot/api/h1/live` shows `Cache-Control: no-store` (unchanged)
- [ ] After merge + deploy: `curl -I https://helldivers.bot/profile` does NOT carry the page cache header
- [ ] Cloudflare Cache Rule configured to respect origin `s-maxage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)