### PR TITLE
hotfix: v0.47.1 — migrate container crashed on '@/shared' import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.47.1
+
+### Bug fixes
+
+- **Migrate container crashed at seed step on `@/shared` import.** The v0.46.x "enum migration" replaced inline string enums in `src/validators/isValidSeason.mjs` and `isValidStatus.mjs` with `import { CAMPAIGN_STATUS, EVENT_STATUS } from '@/shared/enums/events.mjs'`. The `@/*` alias is a `jsconfig.json` construct honored by Next.js and Vitest but not by raw Node — so `npm run build` and `npm run test:unit` passed locally while the production migrate container (which runs `node --experimental-strip-types prisma/seed/seed.mjs` after `prisma migrate deploy`) crashed with `ERR_MODULE_NOT_FOUND: Cannot find package '@/shared' imported from /app/src/validators/isValidSeason.mjs`. Fix: switched both validator imports to relative paths (`../shared/enums/events.mjs`), added a clarifying comment on the seed-loaded file documenting the constraint, and updated `Dockerfile.migrate` to also `COPY src/shared/enums/events.mjs` alongside the validator (the enums module has no further imports, so the copy chain terminates there).
+
 ## 0.47.0
 
 ### Features

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -64,8 +64,11 @@ COPY package.json /tmp/project-package.json
 COPY prisma ./prisma/
 
 # The seed script imports isValidSeason (Zod schema) from src/validators/.
-# Only this one file is needed — zod is installed below alongside prisma.
+# isValidSeason in turn imports CAMPAIGN_STATUS / EVENT_STATUS from
+# src/shared/enums/events.mjs (a pure-constants module with no further
+# imports), so both files are copied. zod is installed below alongside prisma.
 COPY src/validators/isValidSeason.mjs ./src/validators/isValidSeason.mjs
+COPY src/shared/enums/events.mjs ./src/shared/enums/events.mjs
 
 # Loaded by every prisma CLI invocation. Imports dotenv at top-of-file and
 # calls env('POSTGRES_URL') to validate the connection string is present.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.0",
+    "version": "0.47.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/validators/isValidSeason.mjs
+++ b/src/validators/isValidSeason.mjs
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { CAMPAIGN_STATUS, EVENT_STATUS } from '@/shared/enums/events.mjs';
+// Relative import (not '@/shared/...') because this file is loaded by the
+// raw-Node migrate container's seed script, where jsconfig path aliases
+// don't resolve.
+import { CAMPAIGN_STATUS, EVENT_STATUS } from '../shared/enums/events.mjs';
 
 // Schema for the objects inside the stringified "data" field in snapshots
 const snapshotDataItemSchema = z.object({

--- a/src/validators/isValidStatus.mjs
+++ b/src/validators/isValidStatus.mjs
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CAMPAIGN_STATUS, EVENT_STATUS } from '@/shared/enums/events.mjs';
+import { CAMPAIGN_STATUS, EVENT_STATUS } from '../shared/enums/events.mjs';
 
 const campaignStatusSchema = z.object({
     season: z.number(),


### PR DESCRIPTION
## Summary

Emergency hotfix for **v0.47.0** — production migrate container crash-loops on seed step. Cuts **v0.47.1** from `main`.

### Failure (reported from production)
```
helldiversbot-migrate  | Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/shared'
helldiversbot-migrate  |   imported from /app/src/validators/isValidSeason.mjs
helldiversbot-migrate  |   code: 'ERR_MODULE_NOT_FOUND'
Container helldiversbot-migrate Error
service "migrate" didn't complete successfully: exit 1
```
Because `helldiversbot` depends on `service_completed_successfully` from `migrate`, the app never starts.

### Root cause
The v0.46.x enum-migration commit (`94850eda`) replaced inline string enums with `import { CAMPAIGN_STATUS, EVENT_STATUS } from '@/shared/enums/events.mjs'` in `src/validators/isValidSeason.mjs` and `src/validators/isValidStatus.mjs`. The `@/*` alias is a **`jsconfig.json` construct** — honored by Next.js, Webpack, and Vitest, but **not by raw Node**.

The migrate container runs `node --experimental-strip-types prisma/seed/seed.mjs` after `prisma migrate deploy`, with no Next.js/bundler in the picture. `seed.mjs` imports `isValidSeason` directly, and that file's alias-import blows up.

Local `npm run build`, `npm run test:unit`, and `npm run typecheck` all passed because each of those tools resolves the alias — so the regression slipped through every local gate.

### Fix
1. `src/validators/isValidSeason.mjs` — alias import → relative path (`../shared/enums/events.mjs`), plus a comment documenting the constraint so future edits don't reintroduce the bug.
2. `src/validators/isValidStatus.mjs` — same change, sister file, same latent bug.
3. `Dockerfile.migrate` — also `COPY src/shared/enums/events.mjs` alongside the validator. The enums file has no further imports, so the copy chain terminates.
4. `package.json` → `0.47.1`. `CHANGELOG.md` → new `## 0.47.1` section.

### Verification (local, on `hotfix/0.47.1`)
- **Raw-Node import smoke test reproducing the production failure path:**
  ```
  $ node --input-type=module -e "import('./src/validators/isValidSeason.mjs')..."
  isValidSeason loaded OK; export is object
  ```
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:unit` — 118 files / 1320 tests pass
- `npm run build` — succeeds

### Post-merge actions (per CLAUDE.md hotfix process, rule 4)
1. Tag the merge commit on `main` as `v0.47.1` and push — triggers production Docker build.
2. Merge `main` back into `develop` so `develop` carries the hotfix.

### Followup (not in this hotfix; KISS)
The same alias trap exists in `src/db/queries/*.mjs`, `src/auth.js`, and others — but none of those are currently loaded outside the Next.js runtime. Worth tracking a chore to either migrate everything to Node's official `package.json#imports` subpath aliases (so the same syntax works everywhere) or to add a CI smoke test that loads the seed entrypoint under raw Node.

## Test plan

- [ ] CI green
- [ ] After merge: `v0.47.1` tag pushed, `release.docker.yml` produces new images
- [ ] On production host: `sudo docker compose pull && sudo docker compose up` completes; `helldiversbot-migrate` exits 0; `helldiversbot` reaches healthy
- [ ] `main` merged back into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)