### PR TITLE
ci: Docker smoke test for main PRs

### DIFF
--- a/.github/workflows/main-pr-docker-smoke.yml
+++ b/.github/workflows/main-pr-docker-smoke.yml
@@ -1,0 +1,87 @@
+name: Main PR Docker Smoke
+
+# Catches the class of bugs that only manifest when the production-shaped
+# Docker stack actually builds and runs — image-level dependency issues,
+# missing COPY lines in Dockerfiles, raw-Node module resolution (the v0.47.0
+# `@/shared` regression), runtime env-var requirements, etc. These all pass
+# `npm run lint/typecheck/test:unit/build` locally because the local tooling
+# resolves jsconfig aliases and provides full env mocking.
+#
+# Scoped to `pull_request: branches: [main]` only — runs on release PRs from
+# develop → main and on hotfix PRs to main. Not on develop PRs (too slow for
+# the integration loop) and not on pushes (by then the merge already happened).
+
+on:
+    pull_request:
+        branches: [main]
+
+concurrency:
+    group: docker-smoke-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    smoke:
+        name: Docker Compose smoke test
+        runs-on: ubuntu-latest
+        # The Next.js image build takes ~5-7 minutes from a cold cache; the
+        # migrate image ~1 minute; postgres start + migrate run + app boot ~30s.
+        # 20 minutes leaves comfortable headroom for runner variability.
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - name: Set up Docker Buildx
+              # Buildx is needed for the BuildKit features Dockerfile.app uses:
+              # `# syntax=docker/dockerfile:1`, `RUN --mount=type=cache,...`,
+              # and `RUN --mount=type=secret,...`. Without buildx, those parse
+              # as ordinary RUNs and break the build.
+              uses: docker/setup-buildx-action@v4.0.0
+
+            - name: Build images
+              # `docker compose build` invokes buildx per service. No GHA cache
+              # configured here — adding it requires the `x-bake` extension or
+              # rewriting as standalone `docker buildx build` calls per image.
+              # Cold-cache cost is ~7 minutes total which is acceptable for the
+              # main-PR cadence; revisit if it becomes painful.
+              run: docker compose -f docker-compose.ci.yml build
+
+            - name: Start the stack
+              # `--wait` (compose >= 2.17) blocks until every service reaches
+              # `healthy` (per `healthcheck:`) or `completed_successfully`
+              # (for one-shot containers like migrate), then exits 0.
+              # On any service failure or healthcheck timeout it exits non-zero
+              # — which is precisely the assertion we want.
+              run: docker compose -f docker-compose.ci.yml up -d --wait
+
+            - name: HTTP sanity check from runner host
+              # Compose reported all services healthy via the in-container
+              # probe. This step verifies the host port mapping works end-to-end
+              # and that the response body is sensible JSON, not just a 200.
+              run: |
+                  set -euo pipefail
+                  curl -sf --max-time 10 http://127.0.0.1:3000/api/healthcheck | tee /dev/stderr | grep -q '"data"'
+
+            - name: Dump container logs on failure
+              if: failure()
+              run: |
+                  echo "::group::postgres logs"
+                  docker compose -f docker-compose.ci.yml logs postgres || true
+                  echo "::endgroup::"
+                  echo "::group::migrate logs"
+                  docker compose -f docker-compose.ci.yml logs migrate || true
+                  echo "::endgroup::"
+                  echo "::group::helldiversbot logs"
+                  docker compose -f docker-compose.ci.yml logs helldiversbot || true
+                  echo "::endgroup::"
+                  echo "::group::compose ps"
+                  docker compose -f docker-compose.ci.yml ps || true
+                  echo "::endgroup::"
+
+            - name: Tear down
+              if: always()
+              run: docker compose -f docker-compose.ci.yml down -v --remove-orphans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Chores
+
+- **Docker smoke CI for main PRs.** New `.github/workflows/main-pr-docker-smoke.yml` (scoped to `pull_request: branches: [main]` only) brings up the full production-shaped stack — postgres + migrate + helldiversbot, all built from the working-tree Dockerfiles — and asserts both that migrate exits 0 and that the app's `/api/healthcheck` returns a sensible payload. Backed by a new `docker-compose.ci.yml` (standalone, not an override) that swaps `image: ghcr.io/...` for `build:` and replaces `env_file: .env.development` with inline `environment:` blocks so CI can inject stub credentials. Closes the gap exposed by the v0.47.1 hotfix, where `npm run lint`/`typecheck`/`test:unit`/`build` all passed locally while the production migrate container crashed on a jsconfig-alias import (`@/shared/...`) that only fails under raw Node. The compose file is also usable locally — `docker compose -f docker-compose.ci.yml up --build` reproduces the exact CI check before pushing. Cold-cache cost is ~7 minutes per main PR; no GHA build cache configured yet (revisit if it becomes painful).
+
 ## 0.47.1
 
 ### Bug fixes

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,113 @@
+# =============================================================================
+# docker-compose.ci.yml — Local-build smoke test for main PRs
+# =============================================================================
+#
+# WHAT THIS FILE DOES
+#
+# Spins up the full production-shaped stack (postgres + migrate + app) using
+# images built from the local working tree, NOT pulled from GHCR. Used by
+# .github/workflows/main-pr-docker-smoke.yml to catch the class of bugs that
+# only manifest at image build / container runtime — e.g. the v0.47.0 migrate
+# crash where `isValidSeason.mjs` imported `@/shared/...` and raw Node could
+# not resolve the jsconfig alias. That regression passed `npm run build`,
+# `npm run typecheck`, and `npm run test:unit` locally because every one of
+# those tools honors the jsconfig path alias. Only running the actual migrate
+# container caught it.
+#
+# WHY A SEPARATE COMPOSE FILE (not an override of docker-compose.yml)
+#
+# docker-compose.yml is the production-shaped file: `image: ghcr.io/...` (pulls
+# pre-built images), `env_file: .env.development` (uses a host-side env file).
+# CI needs the opposite: `build:` (build from local source), `environment:`
+# (inject vars from the workflow). Override files can flip these, but the diff
+# would be larger than the inheritance saves. A standalone file is also
+# trivially runnable by developers locally — `docker compose -f docker-compose.ci.yml up --build`
+# reproduces the exact CI check before pushing.
+#
+# WHY POSTGRES IS BUNDLED IN HERE (and not a GHA service container)
+#
+# Compose service-name DNS — the migrate and app containers reach the database
+# at `postgres:5432`. That keeps the connection string identical to what
+# .env.development would use locally with docker compose, and avoids the
+# host-port-mapping dance of GHA services (which expose on localhost:5432 of
+# the runner host, not the container network).
+# =============================================================================
+
+services:
+    postgres:
+        image: postgres:17-alpine
+        environment:
+            POSTGRES_USER: ci
+            POSTGRES_PASSWORD: ci
+            POSTGRES_DB: ci
+        # No published ports — the migrate and app containers reach postgres
+        # via compose's internal network DNS. Keeping postgres unpublished
+        # avoids port conflicts on the CI runner and reduces the attack surface.
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U ci -d ci']
+            interval: 2s
+            timeout: 3s
+            retries: 20
+            start_period: 5s
+
+    migrate:
+        build:
+            context: .
+            dockerfile: Dockerfile.migrate
+        environment:
+            POSTGRES_URL: postgresql://ci:ci@postgres:5432/ci?sslmode=disable
+        depends_on:
+            postgres:
+                condition: service_healthy
+        # No restart policy — this is a one-shot container that runs
+        # `prisma migrate deploy && node prisma/seed/seed.mjs`, exits 0 on
+        # success, non-zero on failure. The app's depends_on gate uses
+        # service_completed_successfully to wait for exit 0.
+
+    helldiversbot:
+        build:
+            context: .
+            dockerfile: Dockerfile.app
+            args:
+                # Tag CI builds distinctly from staging/production so any
+                # accidental Sentry events from a smoke-test run are
+                # identifiable. The SDK still no-ops without SENTRY_DSN
+                # (gated at runtime per the v0.47.0 observability work).
+                NEXT_PUBLIC_DEPLOY_ENV: ci
+        ports:
+            # Published on localhost only so the workflow can curl the
+            # healthcheck from the runner host as a final HTTP sanity check
+            # after `compose up --wait` reports healthy.
+            - '127.0.0.1:3000:3000'
+        environment:
+            POSTGRES_URL: postgresql://ci:ci@postgres:5432/ci?sslmode=disable
+            POSTGRES_SSL: 'false'
+            UPDATE_KEY: ci-smoke-stub-key
+            UPDATE_INTERVAL: '60'
+            NODE_ENV: production
+            # Intentionally NOT set: BETTER_AUTH_SECRET, SENTRY_DSN,
+            # UMAMI_SITE_ID, VAPID_*. Each of those features gates itself
+            # to a graceful no-op when its required env var is absent —
+            # exactly what we want for a smoke test that exercises the boot
+            # path without depending on external services.
+        depends_on:
+            postgres:
+                condition: service_healthy
+            migrate:
+                condition: service_completed_successfully
+        healthcheck:
+            # Same probe shape as docker-compose.yml's production config,
+            # but with tighter intervals because CI doesn't need a 60s
+            # production cadence — we want to know within seconds whether
+            # the app booted.
+            test:
+                [
+                    'CMD',
+                    'node',
+                    '-e',
+                    "fetch('http://127.0.0.1:3000/api/healthcheck').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+                ]
+            interval: 5s
+            timeout: 5s
+            retries: 30
+            start_period: 10s


### PR DESCRIPTION
## Summary

Closes the verification gap exposed by the v0.47.1 hotfix.

**The gap**: `npm run lint`, `typecheck`, `test:unit`, and `build` all passed on v0.47.0 locally and in CI, but the production migrate container crashed at the seed step on `ERR_MODULE_NOT_FOUND: Cannot find package '@/shared'`. Every local tool resolves the `@/*` jsconfig alias (Next, Vitest, tsc); raw Node — which the migrate container uses to run `prisma/seed/seed.mjs` — doesn't. The bug class is "passes all in-process JS gates, fails when the actual Docker image runs."

**The fix**: a new CI job that brings up the production-shaped stack (postgres + migrate + helldiversbot) from working-tree builds and asserts that migrate exits 0 and the app's `/api/healthcheck` returns sensible JSON.

## What's added

1. **`docker-compose.ci.yml`** — standalone (not an override of `docker-compose.yml`):
    - Adds a `postgres` service with healthcheck (`pg_isready`).
    - Both `migrate` and `helldiversbot` use `build:` instead of `image:` (works from local Dockerfiles, no GHCR pull).
    - Inline `environment:` blocks replace `env_file: .env.development` so CI can inject stub credentials directly.
    - `depends_on: postgres condition: service_healthy` and `migrate condition: service_completed_successfully` enforce the production startup order.
    - Tighter healthcheck cadences than production (5s vs 60s) so failures surface in seconds, not minutes.
    - Also runnable by developers: `docker compose -f docker-compose.ci.yml up --build` reproduces the exact CI check locally before pushing.

2. **`.github/workflows/main-pr-docker-smoke.yml`**:
    - Trigger: `pull_request: branches: [main]` only — runs on release PRs (develop → main) and hotfix PRs. Not on develop PRs (would slow the integration loop) and not on pushes (the merge has already happened by then).
    - `concurrency:` cancels in-progress runs on the same PR.
    - `docker compose up --wait` (compose ≥ 2.17) does the heavy lifting: blocks until every service is `healthy` or `completed_successfully`, exits non-zero on timeout/failure.
    - Final host-side `curl` against the published `127.0.0.1:3000/api/healthcheck` verifies the port mapping end-to-end and that the response body contains `"data"`.
    - On failure: dumps grouped logs for postgres / migrate / helldiversbot + `compose ps`.
    - Always tears down (`down -v --remove-orphans`).

## Cost

~7 min wall-clock per main PR (cold cache). No GHA build cache configured yet — adding it requires the `x-bake` extension or rewriting as standalone `docker buildx build` calls per image. Acceptable at main-PR cadence; documented as a follow-up in the workflow comment.

## Verification

Local:
- `docker compose -f docker-compose.ci.yml config --quiet` — YAML parses ✅
- `npm run lint` — clean ✅
- `npm run typecheck` — clean ✅
- `npm run test:unit` — 1320 tests pass ✅
- `npm run build` — succeeds ✅

**Did NOT run** the full docker-compose stack locally (~7 min build); will validate on the workflow's first real run.

## Test plan

- [ ] CI green on this PR (the usual lint/typecheck/test/build — the new workflow only triggers on main PRs, so it won't run here)
- [ ] On merge to develop, version bumps per CLAUDE.md rule 2 (chore → 0.47.2, or feature → 0.48.0 — your call)
- [ ] On the next release PR (develop → main), confirm the new "Docker Compose smoke test" job runs and passes
- [ ] **Counterfactual sanity check**: if you ever want to verify it actually catches the kind of regression it's designed for, temporarily reintroduce `import ... from '@/shared/enums/events.mjs'` in `isValidSeason.mjs` on a throwaway branch and open a PR to main — the smoke step should fail at migrate startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)