### PR TITLE
hotfix: v0.47.3 — seed caller missed in v0.46.4 validator migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.47.3
+
+### Bug fixes
+
+- **Second migrate-container crash from the v0.46.4 validator-protocol cleanup.** The v0.46.4 "Validator protocol unified to raw-schema exports" change turned `isValidSeason` from `(data) => rootSchema.safeParse(data)` (callable wrapper) into a raw Zod schema (`export const isValidSeason = rootSchema`). The CHANGELOG noted that callers in `src/update/season.mjs` and `src/update/status.mjs` plus tests were updated — but the `prisma/seed/seed.mjs:51` caller was missed. With v0.47.0 in production, the migrate container ran the seed and crashed with `TypeError: isValidSeason is not a function`. v0.47.1 fixed the prior `@/shared` import error in the same file but only verified the file LOADED under raw Node, not that downstream callers EXECUTED — so this latent bug surfaced only on the next docker-compose-up. Fix: changed the single seed call to `isValidSeason.safeParse(seasonData)` to match every other caller in the codebase. Verified end-to-end with a full local `docker compose -f docker-compose.ci.yml up --build` run that brought the stack to healthy (the exact verification step the v0.47.1 hotfix should have done).
+
 ## 0.47.1
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.1",
+    "version": "0.47.3",
     "private": true,
     "type": "module",
     "scripts": {

--- a/prisma/seed/seed.mjs
+++ b/prisma/seed/seed.mjs
@@ -48,7 +48,10 @@ async function seedSeason(db, file) {
 
     // Validate against the same schema the worker pipeline uses. Wire format:
     // snapshots[].data is a stringified JSON array of 3 faction status objects.
-    const check = isValidSeason(seasonData);
+    // isValidSeason is a raw Zod schema (post-v0.46.4 protocol unification),
+    // not a callable wrapper — invoke via .safeParse(). The src/update/*.mjs
+    // callers were migrated in v0.46.4 but this seed caller was missed.
+    const check = isValidSeason.safeParse(seasonData);
     if (!check.success) {
         console.warn(`Skipping ${file}: validation failed.`);
         for (const issue of check.error?.issues ?? []) {


### PR DESCRIPTION
## Summary

Second hotfix from the same v0.46.4 cleanup window. **v0.47.1 fixed the `@/shared` alias import** that was masking this bug — once the validator module actually loaded under raw Node, the next failure was right behind it: `prisma/seed/seed.mjs` calls `isValidSeason(seasonData)` as a function, but post-v0.46.4 it's a raw Zod schema, not a callable wrapper.

### Failure (reported from production with v0.47.1 deployed)
```
helldiversbot-migrate  | Found 156 season file(s) to seed (concurrency: 10).
helldiversbot-migrate  | Seed failed: TypeError: isValidSeason is not a function
helldiversbot-migrate  |     at seedSeason (file:///app/prisma/seed/seed.mjs:51:19)
Container helldiversbot-migrate Error
service "migrate" didn't complete successfully: exit 1
```

### Root cause
v0.46.4's "Validator protocol unified to raw-schema exports" change replaced `export const isValidSeason = (data) => rootSchema.safeParse(data)` (callable) with `export const isValidSeason = rootSchema` (Zod schema). The CHANGELOG entry called out updating callers in `src/update/season.mjs`, `src/update/status.mjs`, and the unit tests — but the `prisma/seed/seed.mjs` caller was missed. v0.47.1 then fixed the alias import that was masking this caller from ever executing, so the latent bug surfaced on the next deploy.

### Fix
Single character-for-character change: `isValidSeason(seasonData)` → `isValidSeason.safeParse(seasonData)`. Matches every other caller in the codebase. Added a comment on the call site so a future edit can't silently revert it.

Grep'd the codebase for `isValidSeason\|isValidStatus` — this was the only stale caller. All others (`src/update/*.mjs`, all unit tests) already use `.safeParse()`.

### Verification (and why this time it's actually verified)
**The new verification rule** (per the user's directive after this same class of bug shipped twice): for any Docker-runtime fix, the local `docker compose -f docker-compose.ci.yml up --build` stack must reach healthy before the hotfix PR is opened.

- ✅ `docker compose -f docker-compose.ci.yml up --build --wait` — exit 0 in 1m 54s
- ✅ migrate seeded all 156 season files, printed `Seed complete.`, exited 0 (the exact path that crashed in production)
- ✅ helldiversbot reached healthy, `curl /api/healthcheck` → `{"alive":true,"performanceTime":50}`
- ✅ Tore down cleanly
- ✅ The four JS gates: lint, typecheck, 1320 unit tests, build — all green

The `docker-compose.ci.yml` file is on `develop` (added in v0.47.2) but not yet on `main` — I pulled it into the working tree from develop for the verification step only and did not include it in the commit. Reviewers wanting to reproduce can do the same: `git checkout develop -- docker-compose.ci.yml` then run the command above.

### Why v0.47.1 didn't catch this
My v0.47.1 verification was `node --input-type=module -e "import('./src/validators/isValidSeason.mjs')"` — that confirmed the file LOADED under raw Node but not that downstream callers EXECUTED. The seed never ran. I now know better; the rule above prevents the same miss from happening again.

### Post-merge actions
1. Tag the merge commit on `main` as `v0.47.3`, push tag → triggers production Docker build.
2. Merge `main` back into `develop`.

## Test plan

- [ ] CI green
- [ ] After merge: `v0.47.3` tag pushed, `release.docker.yml` produces new images
- [ ] On production host: `sudo docker compose pull && sudo docker compose up` — migrate completes, app reaches healthy
- [ ] `main` merged back into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)