### PR TITLE
release: v0.47.4 — postcss security override + Docker smoke CI

### DIFF
--- a/.github/workflows/main-pr-docker-smoke.yml
+++ b/.github/workflows/main-pr-docker-smoke.yml
@@ -1,0 +1,87 @@
+name: Main PR Docker Smoke
+
+# Catches the class of bugs that only manifest when the production-shaped
+# Docker stack actually builds and runs — image-level dependency issues,
+# missing COPY lines in Dockerfiles, raw-Node module resolution (the v0.47.0
+# `@/shared` regression), runtime env-var requirements, etc. These all pass
+# `npm run lint/typecheck/test:unit/build` locally because the local tooling
+# resolves jsconfig aliases and provides full env mocking.
+#
+# Scoped to `pull_request: branches: [main]` only — runs on release PRs from
+# develop → main and on hotfix PRs to main. Not on develop PRs (too slow for
+# the integration loop) and not on pushes (by then the merge already happened).
+
+on:
+    pull_request:
+        branches: [main]
+
+concurrency:
+    group: docker-smoke-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    smoke:
+        name: Docker Compose smoke test
+        runs-on: ubuntu-latest
+        # The Next.js image build takes ~5-7 minutes from a cold cache; the
+        # migrate image ~1 minute; postgres start + migrate run + app boot ~30s.
+        # 20 minutes leaves comfortable headroom for runner variability.
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - name: Set up Docker Buildx
+              # Buildx is needed for the BuildKit features Dockerfile.app uses:
+              # `# syntax=docker/dockerfile:1`, `RUN --mount=type=cache,...`,
+              # and `RUN --mount=type=secret,...`. Without buildx, those parse
+              # as ordinary RUNs and break the build.
+              uses: docker/setup-buildx-action@v4.0.0
+
+            - name: Build images
+              # `docker compose build` invokes buildx per service. No GHA cache
+              # configured here — adding it requires the `x-bake` extension or
+              # rewriting as standalone `docker buildx build` calls per image.
+              # Cold-cache cost is ~7 minutes total which is acceptable for the
+              # main-PR cadence; revisit if it becomes painful.
+              run: docker compose -f docker-compose.ci.yml build
+
+            - name: Start the stack
+              # `--wait` (compose >= 2.17) blocks until every service reaches
+              # `healthy` (per `healthcheck:`) or `completed_successfully`
+              # (for one-shot containers like migrate), then exits 0.
+              # On any service failure or healthcheck timeout it exits non-zero
+              # — which is precisely the assertion we want.
+              run: docker compose -f docker-compose.ci.yml up -d --wait
+
+            - name: HTTP sanity check from runner host
+              # Compose reported all services healthy via the in-container
+              # probe. This step verifies the host port mapping works end-to-end
+              # and that the response body is sensible JSON, not just a 200.
+              run: |
+                  set -euo pipefail
+                  curl -sf --max-time 10 http://127.0.0.1:3000/api/healthcheck | tee /dev/stderr | grep -q '"data"'
+
+            - name: Dump container logs on failure
+              if: failure()
+              run: |
+                  echo "::group::postgres logs"
+                  docker compose -f docker-compose.ci.yml logs postgres || true
+                  echo "::endgroup::"
+                  echo "::group::migrate logs"
+                  docker compose -f docker-compose.ci.yml logs migrate || true
+                  echo "::endgroup::"
+                  echo "::group::helldiversbot logs"
+                  docker compose -f docker-compose.ci.yml logs helldiversbot || true
+                  echo "::endgroup::"
+                  echo "::group::compose ps"
+                  docker compose -f docker-compose.ci.yml ps || true
+                  echo "::endgroup::"
+
+            - name: Tear down
+              if: always()
+              run: docker compose -f docker-compose.ci.yml down -v --remove-orphans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Chores
+
+- **Docker smoke CI for main PRs.** New `.github/workflows/main-pr-docker-smoke.yml` (scoped to `pull_request: branches: [main]` only) brings up the full production-shaped stack — postgres + migrate + helldiversbot, all built from the working-tree Dockerfiles — and asserts both that migrate exits 0 and that the app's `/api/healthcheck` returns a sensible payload. Backed by a new `docker-compose.ci.yml` (standalone, not an override) that swaps `image: ghcr.io/...` for `build:` and replaces `env_file: .env.development` with inline `environment:` blocks so CI can inject stub credentials. Closes the gap exposed by the v0.47.1 hotfix, where `npm run lint`/`typecheck`/`test:unit`/`build` all passed locally while the production migrate container crashed on a jsconfig-alias import (`@/shared/...`) that only fails under raw Node. The compose file is also usable locally — `docker compose -f docker-compose.ci.yml up --build` reproduces the exact CI check before pushing. Cold-cache cost is ~7 minutes per main PR; no GHA build cache configured yet (revisit if it becomes painful).
+
 ## 0.47.1
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.47.4
+
+### Chores
+
+- **`postcss` pinned to `^8.5.10` via `package.json#overrides`** to remediate the GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 advisory (PostCSS XSS via unescaped `</style>` in stringified CSS output, < 8.5.10). The vulnerable copy came in transitively via `next@16.2.6 → postcss@8.4.31`; Tailwind 4's own `@tailwindcss/postcss` dependency already pulled `postcss@8.5.14`, proving the 8.5.x line works in our build pipeline. Real-world exploit risk for this app is essentially zero (the vuln requires processing **user-submitted CSS** through PostCSS's stringifier and embedding the output in an HTML `<style>` tag — we author all our own CSS via Tailwind utilities and design tokens), but the override is a one-line hygiene fix that drops us from 1 moderate dependabot alert to 0. After install all three postcss consumers (Tailwind, Next, Vite) dedupe onto `8.5.15`. Verified end-to-end with the local `docker compose -f docker-compose.ci.yml up --build` stack.
+
 ## 0.47.3
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.47.2
+
 ### Chores
 
 - **Docker smoke CI for main PRs.** New `.github/workflows/main-pr-docker-smoke.yml` (scoped to `pull_request: branches: [main]` only) brings up the full production-shaped stack — postgres + migrate + helldiversbot, all built from the working-tree Dockerfiles — and asserts both that migrate exits 0 and that the app's `/api/healthcheck` returns a sensible payload. Backed by a new `docker-compose.ci.yml` (standalone, not an override) that swaps `image: ghcr.io/...` for `build:` and replaces `env_file: .env.development` with inline `environment:` blocks so CI can inject stub credentials. Closes the gap exposed by the v0.47.1 hotfix, where `npm run lint`/`typecheck`/`test:unit`/`build` all passed locally while the production migrate container crashed on a jsconfig-alias import (`@/shared/...`) that only fails under raw Node. The compose file is also usable locally — `docker compose -f docker-compose.ci.yml up --build` reproduces the exact CI check before pushing. Cold-cache cost is ~7 minutes per main PR; no GHA build cache configured yet (revisit if it becomes painful).

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,113 @@
+# =============================================================================
+# docker-compose.ci.yml — Local-build smoke test for main PRs
+# =============================================================================
+#
+# WHAT THIS FILE DOES
+#
+# Spins up the full production-shaped stack (postgres + migrate + app) using
+# images built from the local working tree, NOT pulled from GHCR. Used by
+# .github/workflows/main-pr-docker-smoke.yml to catch the class of bugs that
+# only manifest at image build / container runtime — e.g. the v0.47.0 migrate
+# crash where `isValidSeason.mjs` imported `@/shared/...` and raw Node could
+# not resolve the jsconfig alias. That regression passed `npm run build`,
+# `npm run typecheck`, and `npm run test:unit` locally because every one of
+# those tools honors the jsconfig path alias. Only running the actual migrate
+# container caught it.
+#
+# WHY A SEPARATE COMPOSE FILE (not an override of docker-compose.yml)
+#
+# docker-compose.yml is the production-shaped file: `image: ghcr.io/...` (pulls
+# pre-built images), `env_file: .env.development` (uses a host-side env file).
+# CI needs the opposite: `build:` (build from local source), `environment:`
+# (inject vars from the workflow). Override files can flip these, but the diff
+# would be larger than the inheritance saves. A standalone file is also
+# trivially runnable by developers locally — `docker compose -f docker-compose.ci.yml up --build`
+# reproduces the exact CI check before pushing.
+#
+# WHY POSTGRES IS BUNDLED IN HERE (and not a GHA service container)
+#
+# Compose service-name DNS — the migrate and app containers reach the database
+# at `postgres:5432`. That keeps the connection string identical to what
+# .env.development would use locally with docker compose, and avoids the
+# host-port-mapping dance of GHA services (which expose on localhost:5432 of
+# the runner host, not the container network).
+# =============================================================================
+
+services:
+    postgres:
+        image: postgres:17-alpine
+        environment:
+            POSTGRES_USER: ci
+            POSTGRES_PASSWORD: ci
+            POSTGRES_DB: ci
+        # No published ports — the migrate and app containers reach postgres
+        # via compose's internal network DNS. Keeping postgres unpublished
+        # avoids port conflicts on the CI runner and reduces the attack surface.
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U ci -d ci']
+            interval: 2s
+            timeout: 3s
+            retries: 20
+            start_period: 5s
+
+    migrate:
+        build:
+            context: .
+            dockerfile: Dockerfile.migrate
+        environment:
+            POSTGRES_URL: postgresql://ci:ci@postgres:5432/ci?sslmode=disable
+        depends_on:
+            postgres:
+                condition: service_healthy
+        # No restart policy — this is a one-shot container that runs
+        # `prisma migrate deploy && node prisma/seed/seed.mjs`, exits 0 on
+        # success, non-zero on failure. The app's depends_on gate uses
+        # service_completed_successfully to wait for exit 0.
+
+    helldiversbot:
+        build:
+            context: .
+            dockerfile: Dockerfile.app
+            args:
+                # Tag CI builds distinctly from staging/production so any
+                # accidental Sentry events from a smoke-test run are
+                # identifiable. The SDK still no-ops without SENTRY_DSN
+                # (gated at runtime per the v0.47.0 observability work).
+                NEXT_PUBLIC_DEPLOY_ENV: ci
+        ports:
+            # Published on localhost only so the workflow can curl the
+            # healthcheck from the runner host as a final HTTP sanity check
+            # after `compose up --wait` reports healthy.
+            - '127.0.0.1:3000:3000'
+        environment:
+            POSTGRES_URL: postgresql://ci:ci@postgres:5432/ci?sslmode=disable
+            POSTGRES_SSL: 'false'
+            UPDATE_KEY: ci-smoke-stub-key
+            UPDATE_INTERVAL: '60'
+            NODE_ENV: production
+            # Intentionally NOT set: BETTER_AUTH_SECRET, SENTRY_DSN,
+            # UMAMI_SITE_ID, VAPID_*. Each of those features gates itself
+            # to a graceful no-op when its required env var is absent —
+            # exactly what we want for a smoke test that exercises the boot
+            # path without depending on external services.
+        depends_on:
+            postgres:
+                condition: service_healthy
+            migrate:
+                condition: service_completed_successfully
+        healthcheck:
+            # Same probe shape as docker-compose.yml's production config,
+            # but with tighter intervals because CI doesn't need a 60s
+            # production cadence — we want to know within seconds whether
+            # the app booted.
+            test:
+                [
+                    'CMD',
+                    'node',
+                    '-e',
+                    "fetch('http://127.0.0.1:3000/api/healthcheck').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+                ]
+            interval: 5s
+            timeout: 5s
+            retries: 30
+            start_period: 10s

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.3",
+    "version": "0.47.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "helldivers.bot",
-            "version": "0.47.3",
+            "version": "0.47.4",
             "dependencies": {
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@mdx-js/loader": "^3.1.1",
@@ -13708,9 +13708,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "funding": [
                 {
                     "type": "github",
@@ -13805,34 +13805,6 @@
                 "sass": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/next/node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/node-exports-info": {
@@ -14489,10 +14461,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-            "devOptional": true,
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -14509,7 +14480,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.3",
+    "version": "0.47.4",
     "private": true,
     "type": "module",
     "scripts": {
@@ -74,6 +74,7 @@
         "vitest": "^4.1.6"
     },
     "overrides": {
+        "postcss": "^8.5.10",
         "prisma": {
             "hono": ">=4.12.18",
             "@hono/node-server": ">=1.19.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.1",
+    "version": "0.47.2",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Summary

Release **v0.47.4** to production. Rolls up two changes since `v0.47.3`:

### 0.47.4 — `postcss` pinned via `package.json#overrides` (security)
Remediates **GHSA-qx2v-qp2m-jg93 / CVE-2026-41305** (PostCSS XSS via unescaped `</style>` in stringified CSS, < 8.5.10). The vulnerable copy came in transitively via `next@16.2.6 → postcss@8.4.31`; Tailwind 4 already pulled `postcss@8.5.14` independently, proving the 8.5.x line works in our pipeline.

After install all three postcss consumers (Tailwind, Next, Vite) dedupe to `8.5.15`. `npm install` reports **0 vulnerabilities**. Real-world exploit risk for this app is essentially zero (the vuln requires processing **user-submitted CSS** through PostCSS's stringifier — we author all our own CSS via Tailwind utilities and design tokens), but the override drops us from 1 moderate dependabot alert to 0.

Also picks up a stray dependabot bump that landed on main directly (PR #382): `brace-expansion 5.0.5 → 5.0.6` (CVE-flagged ReDoS, also low real-world risk for us).

### 0.47.2 — Docker smoke CI for main PRs
New `.github/workflows/main-pr-docker-smoke.yml` (scoped to `pull_request: branches: [main]`) brings up the full production-shaped stack (postgres + migrate + helldiversbot, all built from working-tree Dockerfiles) and asserts both that migrate exits 0 and that the app's `/api/healthcheck` returns sensible JSON. Backed by a standalone `docker-compose.ci.yml`. Cold-cache cost ~7 minutes per main PR.

**This PR should be the first one where that workflow actually runs in CI** — assuming GitHub's PR workflow resolution picks up the file from the head ref. If it doesn't trigger here (because main doesn't yet have the workflow file), it'll start working on the next main PR.

### Verification (local, on develop @ HEAD)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:unit` — 1320 tests pass
- `npm run build` — succeeds
- `docker compose -f docker-compose.ci.yml up --build --wait` — exit 0 in 1m 11s; migrate seeded all 156 seasons, app reached healthy, curl `/api/healthcheck` → `{"alive":true,...}`

### Post-merge actions
1. Tag the merge commit on `main` as `v0.47.4` and push the tag — triggers production Docker build via `release.docker.yml`.
2. Merge `main` back into `develop` so `develop` carries the merge commit.

## Test plan

- [ ] Existing CI (Test & Build, CodeQL, Dependency Review) green
- [ ] Docker smoke workflow — observe whether it triggers (it's new). If it does, expect ~7 min and a healthy stack.
- [ ] After merge: `v0.47.4` tag pushed, `release.docker.yml` produces new images
- [ ] On production host: `sudo docker compose pull && sudo docker compose up` — migrate completes, app reaches healthy
- [ ] Dependabot alert #98 (postcss) closes once GitHub re-scans the default branch
- [ ] `main` merged back into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)