### PR TITLE
feat(types): z.infer exports + tighten widened JSDoc across event pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- **Type-safety: Zod-inferred validator types + shared enum literal typedefs + tightened JSDoc across the event pipeline.** Adds `@typedef {z.infer<typeof Schema>} TypeName` exports to `isValidStatus.mjs` (`StatusPayload`), `isValidSeason.mjs` (`SeasonPayload`), and `isValidFormData.mjs` (`FormDataPayload`) so downstream consumers can reference the real wire-format shape instead of typing as `object`. Adds five literal-union typedefs (`EventType`, `EventStatus`, `CampaignStatus`, `MapStatus`) plus a shared `Event` shape and `EventChangeKind` union (`'event_started'|'event_won'|'event_lost'|'catch_up'`) to `src/shared/enums/events.mjs`. Tightens previously widened JSDoc on `detectChanges.mjs` (return shape now refers to the shared `Event` type instead of `event: object`), `EventToast.jsx` (both `toastLabel` and `showEventToast` now consume `Event` + `EventChangeKind`), and consolidates the duplicate `LiveStatus` typedef declaration between `useLiveData.mjs` and `LiveDataContext.mjs` — the hook is now the single source of truth and the context imports via `@typedef {import('...').LiveStatus} LiveStatus`. Pure refactor — no runtime behavior change; protects momentum on the only improving high-weight desloppify dimension (type_safety 55 → 68 → 71).
+
 ## 0.51.1
 
 ### Changes

--- a/src/features/notifications/EventToast.jsx
+++ b/src/features/notifications/EventToast.jsx
@@ -5,11 +5,14 @@ import { FACTION_COLORS } from '@/shared/enums/colors.mjs';
 import { getEventRegionLabel } from '@/shared/utils/game/getEventRegionLabel.mjs';
 import { EVENT_TYPE } from '@/shared/enums/events.mjs';
 
+/** @typedef {import('@/shared/enums/events.mjs').Event} Event */
+/** @typedef {import('@/shared/enums/events.mjs').EventChangeKind} EventChangeKind */
+
 /**
  * Build title + subtitle for a toast based on event kind and type.
  *
- * @param {'event_started'|'event_won'|'event_lost'|'catch_up'} kind - Event lifecycle stage the toast represents
- * @param {{ enemy: number, region: number, type: 'attack'|'defend' }} event - The event the toast describes
+ * @param {EventChangeKind} kind - Event lifecycle stage the toast represents.
+ * @param {Event} event - The event the toast describes.
  * @returns {{ title: string, subtitle: string }}
  */
 export function toastLabel(kind, event) {
@@ -64,13 +67,13 @@ let flashToggle = false;
 /**
  * Show (or replace) an event toast with faction-colored blinking accent border.
  *
- * @param {{ event_id: number, enemy: number, region: number, type: 'attack'|'defend' }} event - The event to show a toast for
- * @param {'event_started'|'event_won'|'event_lost'|'catch_up'} kind - Event lifecycle stage the toast represents
- * @param {object}  [opts] - Optional toast appearance overrides
- * @param {number}  [opts.duration]    - Sonner duration (default Infinity)
- * @param {string}  [opts.alertColor]  - Blink overlay color (default danger)
- * @param {number}  [opts.pulseDelay]  - Animation delay in seconds for per-event offset
- * @param {Function} [opts.onDismiss]  - Called when toast is dismissed
+ * @param {Event} event - The event to show a toast for.
+ * @param {EventChangeKind} kind - Event lifecycle stage the toast represents.
+ * @param {object}  [opts] - Optional toast appearance overrides.
+ * @param {number}  [opts.duration]    - Sonner duration (default Infinity).
+ * @param {string}  [opts.alertColor]  - Blink overlay color (default danger).
+ * @param {number}  [opts.pulseDelay]  - Animation delay in seconds for per-event offset.
+ * @param {Function} [opts.onDismiss]  - Called when toast is dismissed.
  */
 export function showEventToast(
     event,

--- a/src/shared/enums/events.mjs
+++ b/src/shared/enums/events.mjs
@@ -21,3 +21,43 @@ export const MAP_STATUS = {
     LOST: 'lost',
     IDLE: 'idle',
 };
+
+/**
+ * Literal-union typedefs for the enum values above. Use these in JSDoc
+ * `@param` / `@returns` / `@typedef` annotations instead of widening to
+ * `string` — they catch typos at `tsc --noEmit` time and document the
+ * actual contract.
+ *
+ * @typedef {'defend'|'attack'} EventType
+ * @typedef {'active'|'success'|'fail'} EventStatus
+ * @typedef {'active'|'defeated'|'hidden'} CampaignStatus
+ * @typedef {'captured'|'in_progress'|'lost'|'idle'} MapStatus
+ */
+
+/**
+ * Shape of a single event as carried through the runtime (after the worker
+ * pipeline merges defend/attack events into a unified array with the
+ * source `type` field added). Used by `detectChanges`, toast / push
+ * notification code paths, and live data consumers.
+ *
+ * @typedef {object} Event
+ * @property {number} event_id - HD1 event id (stable across status transitions).
+ * @property {number} enemy - Faction id (0=Bugs, 1=Cyborgs, 2=Illuminate).
+ * @property {number} region - Region id (1-10 for sectors, 11 for homeworld; defend events only — attack events typically have region undefined upstream but the merge step backfills 11).
+ * @property {EventType} type - 'defend' or 'attack'.
+ * @property {EventStatus} status - 'active' / 'success' / 'fail'.
+ * @property {number} [season] - Season number; present on records read from the DB.
+ * @property {number} [start_time] - Unix epoch (sec) when the event began.
+ * @property {number} [end_time] - Unix epoch (sec) when the event resolves.
+ * @property {number} [points] - Current points scored.
+ * @property {number} [points_max] - Points required to resolve.
+ */
+
+/**
+ * The four lifecycle stages a toast / push notification represents.
+ * `event_started` / `event_won` / `event_lost` are emitted by `detectChanges`
+ * on a poll-to-poll transition; `catch_up` is emitted by `LiveToasts` on
+ * page load for events that are already active.
+ *
+ * @typedef {'event_started'|'event_won'|'event_lost'|'catch_up'} EventChangeKind
+ */

--- a/src/shared/hooks/useLiveData.mjs
+++ b/src/shared/hooks/useLiveData.mjs
@@ -2,6 +2,19 @@
 import { useState, useEffect } from 'react';
 import { guardedReload, clearReloadGuard } from '@/shared/utils/reloadGuard.mjs';
 
+/**
+ * Tri-state polling status:
+ * - `'polling'` — request in flight (also the SSR-safe default).
+ * - `'live'` — last poll succeeded.
+ * - `'offline'` — last poll failed, or PWA detected offline.
+ *
+ * Hoisted to module level so other files can import it via
+ * `@typedef {import('@/shared/hooks/useLiveData.mjs').LiveStatus} LiveStatus`
+ * instead of redeclaring the union locally.
+ *
+ * @typedef {'polling'|'live'|'offline'} LiveStatus
+ */
+
 // Version-suffixed: bump the `-vN` suffix whenever the cached payload shape
 // changes (new/renamed/retyped fields). Old entries are then never read again
 // and naturally abandoned, avoiding hydration mismatches from stale caches.
@@ -249,10 +262,8 @@ function teardownLeader() {
  *   notifications. Leaders yield on conflicting claims to prevent dupes.
  * - Fallback chain: live poll → server-rendered → localStorage cache → null.
  *
- * @typedef {'polling'|'live'|'offline'} LiveStatus
- *
- * @param {object | null} initialData - Server-rendered campaign data (null if offline)
- * @param {object | null} initialMapState - Server-rendered map state (null if offline)
+ * @param {object | null} initialData - Server-rendered campaign data (null if offline).
+ * @param {object | null} initialMapState - Server-rendered map state (null if offline).
  * @returns {{data: object | null, mapState: object | null, status: LiveStatus, prevData: object | null, isLeader: boolean}}
  */
 export function useLiveData(initialData, initialMapState) {

--- a/src/shared/providers/LiveDataContext.mjs
+++ b/src/shared/providers/LiveDataContext.mjs
@@ -1,13 +1,13 @@
 'use client';
 import { createContext, useContext } from 'react';
 
+/** @typedef {import('@/shared/hooks/useLiveData.mjs').LiveStatus} LiveStatus */
+
 export const LiveDataContext = createContext(null);
 
 /**
  * Read live campaign data from the nearest LiveDataProvider.
  * Throws if called outside a provider — catches wiring bugs early.
- *
- * @typedef {'polling'|'live'|'offline'} LiveStatus
  *
  * @returns {{data: object | null, mapState: object | null, status: LiveStatus, prevData: object | null, isLeader: boolean}}
  */

--- a/src/shared/utils/game/detectChanges.mjs
+++ b/src/shared/utils/game/detectChanges.mjs
@@ -1,11 +1,16 @@
 import { EVENT_STATUS } from '@/shared/enums/events.mjs';
 
+/** @typedef {import('@/shared/enums/events.mjs').Event} Event */
+
 /**
  * Detect event transitions between two campaign states.
  *
- * @param {Array | null} prevEvents - Previous event array (may be null on first call)
- * @param {Array} nextEvents - Current event array
- * @returns {Array<{kind: 'event_started'|'event_won'|'event_lost', event: object}>}
+ * `catch_up` is intentionally not emitted here — that variant belongs to
+ * page-load synthesis in `LiveToasts`, not poll-to-poll diff detection.
+ *
+ * @param {ReadonlyArray<Event> | null} prevEvents - Previous event array (null on first call).
+ * @param {ReadonlyArray<Event>} nextEvents - Current event array.
+ * @returns {Array<{kind: 'event_started'|'event_won'|'event_lost', event: Event}>}
  */
 export function detectChanges(prevEvents, nextEvents) {
     if (!prevEvents || !nextEvents) return [];

--- a/src/validators/isValidFormData.mjs
+++ b/src/validators/isValidFormData.mjs
@@ -43,3 +43,10 @@ export const isValidFormData = z.discriminatedUnion('action', [
     schemaGetLeaderboards,
     schemaGetUsernames,
 ]);
+
+/**
+ * Inferred shape of a validated rebroadcast form-data body. Discriminated
+ * on `action`, so consumers get exhaustive narrowing automatically.
+ *
+ * @typedef {import('zod').infer<typeof isValidFormData>} FormDataPayload
+ */

--- a/src/validators/isValidSeason.mjs
+++ b/src/validators/isValidSeason.mjs
@@ -77,3 +77,10 @@ const rootSchema = z.object({
 });
 
 export const isValidSeason = rootSchema;
+
+/**
+ * Inferred shape of a validated `get_snapshots` payload from HD1.
+ * Use this typedef downstream of Zod validation instead of typing as `object`.
+ *
+ * @typedef {import('zod').infer<typeof isValidSeason>} SeasonPayload
+ */

--- a/src/validators/isValidStatus.mjs
+++ b/src/validators/isValidStatus.mjs
@@ -70,3 +70,10 @@ const rootSchema = z.object({
 });
 
 export const isValidStatus = rootSchema;
+
+/**
+ * Inferred shape of a validated `get_campaign_status` payload from HD1.
+ * Use this typedef downstream of Zod validation instead of typing as `object`.
+ *
+ * @typedef {import('zod').infer<typeof isValidStatus>} StatusPayload
+ */


### PR DESCRIPTION
## Summary

- Adds `@typedef {z.infer<typeof Schema>} TypeName` exports to the three non-trivial Zod validators so consumers can type wire-format data as the real shape instead of widening to `object`.
- Adds five literal-union enum typedefs (`EventType`, `EventStatus`, `CampaignStatus`, `MapStatus`, plus the composite `Event` shape and `EventChangeKind`) to `src/shared/enums/events.mjs` — one source of truth replaces inline `'attack'|'defend'` literals scattered across event-related files.
- Tightens 5 widened JSDoc declarations across the event + live-data pipeline:
  1. `detectChanges.mjs` — `Array → ReadonlyArray<Event>` for params, `event: object → event: Event` in return.
  2. `EventToast.jsx::toastLabel` — inline `{enemy, region, type: 'attack'|'defend'}` → `Event`.
  3. `EventToast.jsx::showEventToast` — same; both `kind` params now use `EventChangeKind`.
  4. `useLiveData.mjs` — `LiveStatus` typedef hoisted from function JSDoc to module level so other files can import it.
  5. `LiveDataContext.mjs` — duplicate `LiveStatus` declaration removed; now imports from `useLiveData.mjs`.

Net effect: a single canonical `Event` / `EventChangeKind` / `LiveStatus` / `*Payload` contract across `detectChanges` → `pushNotifier` → `LiveToasts` → `EventToast` → `LiveDataContext` → worker pipeline. Typos in `event.type` / `event.status` / `kind` / `LiveStatus` values now fail at `tsc --noEmit` time instead of silently flowing through.

Closes the **type-safety-momentum-protection** strategic issue from /desloppify (issue #406 cluster `type-safety-validator-inference` + `type-safety-jsdoc-tightening`). Protects the only improving high-weight subjective dimension (type_safety trajectory: 55 → 68 → 71).

## What changed

| File | Change |
|------|--------|
| `src/validators/isValidStatus.mjs` | `+@typedef StatusPayload` (z.infer<typeof isValidStatus>) |
| `src/validators/isValidSeason.mjs` | `+@typedef SeasonPayload` (z.infer<typeof isValidSeason>) |
| `src/validators/isValidFormData.mjs` | `+@typedef FormDataPayload` (z.infer<typeof isValidFormData>, discriminated on \`action\`) |
| `src/shared/enums/events.mjs` | `+EventType +EventStatus +CampaignStatus +MapStatus +Event +EventChangeKind` typedefs |
| `src/shared/utils/game/detectChanges.mjs` | Param/return shapes use shared `Event` |
| `src/features/notifications/EventToast.jsx` | `toastLabel` + `showEventToast` use `Event` + `EventChangeKind` |
| `src/shared/hooks/useLiveData.mjs` | `LiveStatus` typedef hoisted to module scope (was inside function JSDoc) |
| `src/shared/providers/LiveDataContext.mjs` | Duplicate `LiveStatus` removed; imports from `useLiveData.mjs` |
| `CHANGELOG.md` | Records the change under \`## Unreleased\` |

## Behavior changes

**None.** Pure JSDoc / type-annotation refactor. Zod schemas, exports, runtime values, and function signatures are byte-for-byte unchanged. No tests needed updating.

## Verification

- `npm run lint` ✅ (0 errors, 4 pre-existing warnings tracked in #400)
- `npm run typecheck` ✅ — tsc validates every new `@typedef` import resolves correctly
- `npm run test:unit` ✅ — 1416 tests pass (all 133 files)
- `npm run build` ✅ — Next.js + Serwist build clean

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`

## Related

- Refs #406 (Desloppify subjective review backlog — strategic issue \`type-safety-momentum-protection\`)
- Refs #408 (PR #407 merged in 0.51.1 — auth helpers — same desloppify cluster wave)

🤖 Generated with [Claude Code](https://claude.com/claude-code)