### PR TITLE
refactor(rebroadcast): extract reconstruction logic; export SEASON_NOT_FOUND; fix 500→404 on missing season

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- **`/api/h1/rebroadcast` reconstruction logic extracted to `src/db/queries/rebroadcast.mjs`; `SEASON_NOT_FOUND` sentinel becomes a named export; rebroadcast snapshots path returns `404` for missing seasons instead of `500`.** The rebroadcast route inlined ~130 LOC of `reconstructCampaignStatus` + `reconstructSnapshots` alongside the POST handler — the same DISTINCT-ON + bucket-merge logic already encapsulated in `db/queries/`, just producing a different wire shape. Moves both functions out into `src/db/queries/rebroadcast.mjs` so the route file becomes pure orchestration (147 LOC → 152 LOC handler kept; ~140 LOC of data-access removed from route layer). The `SEASON_NOT_FOUND` magic string used as `Error.cause` in `src/update/season.mjs` was previously a hand-typed literal duplicated across the throw site and the campaign-route consumer (`fetchError.cause === 'SEASON_NOT_FOUND'`); now exported as a named constant from `src/update/season.mjs` and imported by both campaign and rebroadcast routes — typos fail at `tsc --noEmit` time. **Behavior change:** the rebroadcast `get_snapshots` backfill path previously returned `500` when the requested season didn't exist on the HD1 API; now correctly returns `404`, matching the campaign route's existing behavior. Closes the `rebroadcast-getcampaign-consolidation` cluster + `rebroadcast-churn-hotspot-decoupling` strategic issue from /desloppify (issue #406).
+
 ## 0.51.2
 
 ### Changes

--- a/src/__tests__/unit/routes/campaign.test.mjs
+++ b/src/__tests__/unit/routes/campaign.test.mjs
@@ -4,7 +4,10 @@ import { getCampaign } from '@/db/queries/getCampaign.mjs';
 import { updateSeason } from '@/update/season.mjs';
 
 vi.mock('@/db/queries/getCampaign', () => ({ getCampaign: vi.fn() }));
-vi.mock('@/update/season', () => ({ updateSeason: vi.fn() }));
+vi.mock('@/update/season', () => ({
+    updateSeason: vi.fn(),
+    SEASON_NOT_FOUND: 'SEASON_NOT_FOUND',
+}));
 vi.mock('@/shared/utils/umami', () => ({ umamiTrackEvent: vi.fn() }));
 
 function createRouteRequest(path) {

--- a/src/__tests__/unit/routes/rebroadcast.test.mjs
+++ b/src/__tests__/unit/routes/rebroadcast.test.mjs
@@ -23,7 +23,10 @@ vi.mock('@/db/queries/validateApiKey', () => ({
         DISABLED: 'disabled',
     }),
 }));
-vi.mock('@/update/season', () => ({ updateSeason: vi.fn() }));
+vi.mock('@/update/season', () => ({
+    updateSeason: vi.fn(),
+    SEASON_NOT_FOUND: 'SEASON_NOT_FOUND',
+}));
 vi.mock('@/shared/utils/umami', () => ({ umamiTrackEvent: vi.fn() }));
 vi.mock('@/shared/enums/events.mjs', () => ({
     EVENT_TYPE: { DEFEND: 'defend', ATTACK: 'attack' },

--- a/src/app/api/h1/campaign/route.js
+++ b/src/app/api/h1/campaign/route.js
@@ -10,7 +10,7 @@ import { after } from 'next/server';
 import { isValidNumber } from '@/validators/isValidNumber.mjs';
 //db and fetch
 import { getCampaign } from '@/db/queries/getCampaign.mjs';
-import { updateSeason } from '@/update/season.mjs';
+import { updateSeason, SEASON_NOT_FOUND } from '@/update/season.mjs';
 //track
 import { umamiTrackEvent } from '@/shared/utils/umami.mjs';
 
@@ -50,7 +50,7 @@ export async function GET(request) {
     if (!campaignData) {
         const { error: fetchError } = await tryCatch(updateSeason(season));
         if (fetchError) {
-            if (fetchError.cause === 'SEASON_NOT_FOUND') {
+            if (fetchError.cause === SEASON_NOT_FOUND) {
                 return errorResponse(404, start, fetchError.message);
             }
             reportError(fetchError, {

--- a/src/app/api/h1/rebroadcast/route.js
+++ b/src/app/api/h1/rebroadcast/route.js
@@ -1,4 +1,3 @@
-import db from '@/db/db';
 import { tryCatch } from '@/shared/utils/tryCatch.mjs';
 import { performance } from 'perf_hooks';
 import { roundedPerformanceTime } from '@/shared/utils/time.mjs';
@@ -10,14 +9,15 @@ import { reportError } from '@/shared/utils/observability.mjs';
 import { isValidContentType } from '@/validators/isValidContentType.mjs';
 import { isValidFormData } from '@/validators/isValidFormData.mjs';
 //db
-import { updateSeason } from '@/update/season.mjs';
+import {
+    reconstructCampaignStatus,
+    reconstructSnapshots,
+} from '@/db/queries/rebroadcast.mjs';
+import { updateSeason, SEASON_NOT_FOUND } from '@/update/season.mjs';
 //auth
 import { validateApiKey, API_KEY_ERROR } from '@/db/queries/validateApiKey.mjs';
 //track
 import { umamiTrackEvent } from '@/shared/utils/umami.mjs';
-//enums
-import { EVENT_TYPE, EVENT_STATUS } from '@/shared/enums/events.mjs';
-import { groupStatusByBucket } from '@/shared/utils/bucketing.mjs';
 
 export async function POST(request) {
     const start = performance.now();
@@ -113,6 +113,9 @@ export async function POST(request) {
                     updateSeason(formValues.season),
                 );
                 if (seasonFetchError) {
+                    if (seasonFetchError.cause === SEASON_NOT_FOUND) {
+                        return errorResponse(404, start, seasonFetchError.message);
+                    }
                     reportError(seasonFetchError, {
                         route: '/api/h1/rebroadcast',
                         stage: 'backfill-season',
@@ -143,150 +146,6 @@ export async function POST(request) {
         return errorResponse(404, start, 'Not found');
     }
     return successResponse(200, start, data);
-}
-
-/**
- * Reconstruct the `get_campaign_status` wire format from the normalized
- * tables (h1_season + h1_status + h1_statistic + h1_event). Uses the latest
- * season with data. Returns null when no season has been populated yet.
- *
- * Partial loss of fidelity vs the HD1 wire format: the 4 event-count
- * fields on each statistics[] entry (defend_events, successful_defend_events,
- * attack_events, successful_attack_events) are omitted — they are derivable
- * from h1_event with COUNT(*) WHERE type=... AND status=... AND season=X.
- */
-async function reconstructCampaignStatus() {
-    // Latest season that has been populated.
-    const seasonRow = await db.h1_season.findFirst({
-        where: { last_updated: { not: null } },
-        orderBy: { season: 'desc' },
-        select: {
-            season: true,
-            introduction_order: true,
-            points_max: true,
-            season_duration: true,
-        },
-    });
-    if (!seasonRow) return null;
-
-    const targetSeason = seasonRow.season;
-
-    // latestStatus / latestStats / activeEvents are mutually independent —
-    // each keyed only on targetSeason — so they run in parallel, collapsing
-    // three sequential round-trips into one. (The DISTINCT ON $queryRaw is
-    // used like getCampaign.mjs; Prisma can't express DISTINCT ON natively.)
-    const [latestStatus, latestStats, activeEvents] = await Promise.all([
-        db.$queryRaw`
-            SELECT DISTINCT ON (enemy) *
-            FROM h1_status
-            WHERE season = ${targetSeason}
-            ORDER BY enemy ASC, bucket DESC
-        `,
-        db.$queryRaw`
-            SELECT DISTINCT ON (enemy) *
-            FROM h1_statistic
-            WHERE season = ${targetSeason}
-            ORDER BY enemy ASC, bucket DESC
-        `,
-        db.h1_event.findMany({
-            where: { season: targetSeason, status: EVENT_STATUS.ACTIVE },
-        }),
-    ]);
-
-    const statByEnemy = new Map(latestStats.map((r) => [r.enemy, r]));
-
-    const latestTime = Math.max(
-        0,
-        ...latestStatus.map((r) => r.time),
-        ...latestStats.map((r) => r.time),
-    );
-
-    return {
-        time: latestTime,
-        error_code: 0,
-        campaign_status: latestStatus.map((r) => ({
-            enemy: r.enemy,
-            points: r.points,
-            points_taken: r.points_taken,
-            points_max: seasonRow.points_max?.[r.enemy] ?? 0,
-            status: r.status,
-            introduction_order: seasonRow.introduction_order?.[r.enemy] ?? 0,
-        })),
-        statistics: [0, 1, 2].map((enemy) => {
-            const s = statByEnemy.get(enemy);
-            return {
-                enemy,
-                season_duration: seasonRow.season_duration ?? 0,
-                players: s?.players ?? 0,
-                total_unique_players: s?.total_unique_players ?? 0,
-                missions: s?.missions ?? 0,
-                successful_missions: s?.successful_missions ?? 0,
-                total_mission_difficulty: s?.total_mission_difficulty ?? 0,
-                completed_planets: s?.completed_planets ?? 0,
-                // 4 fields intentionally omitted (derivable from h1_event):
-                //   defend_events, successful_defend_events,
-                //   attack_events, successful_attack_events
-                kills: s?.kills != null ? Number(s.kills) : 0,
-                deaths: s?.deaths != null ? Number(s.deaths) : 0,
-                accidentals: s?.accidentals != null ? Number(s.accidentals) : 0,
-                shots: s?.shots != null ? Number(s.shots) : 0,
-                hits: s?.hits != null ? Number(s.hits) : 0,
-            };
-        }),
-        defend_event: activeEvents.find((e) => e.type === EVENT_TYPE.DEFEND) ?? null,
-        attack_events: activeEvents.filter((e) => e.type === EVENT_TYPE.ATTACK),
-        introduction_order: seasonRow.introduction_order ?? [],
-        points_max: seasonRow.points_max ?? [],
-    };
-}
-
-/**
- * Reconstruct the `get_snapshots` wire format for a given season from the
- * normalized tables (h1_season + h1_status + h1_event). Returns null when
- * the season has no h1_season row yet (caller may then trigger an on-demand
- * updateSeason() fetch from the official API).
- *
- * Sparse buckets (missing one or more factions) are filtered out of the
- * snapshot array for consumer safety — matches getCampaign.mjs's behavior.
- */
-async function reconstructSnapshots(season) {
-    if (!season) return null;
-
-    const seasonRow = await db.h1_season.findUnique({
-        where: { season },
-        select: {
-            season: true,
-            introduction_order: true,
-            points_max: true,
-        },
-    });
-    if (!seasonRow) return null;
-
-    // allStatus / allEvents are independent — run in parallel to collapse
-    // two sequential round-trips into one.
-    const [allStatus, allEvents] = await Promise.all([
-        db.h1_status.findMany({
-            where: { season },
-            orderBy: [{ bucket: 'asc' }, { enemy: 'asc' }],
-        }),
-        db.h1_event.findMany({ where: { season } }),
-    ]);
-
-    const snapshots = groupStatusByBucket(allStatus).map(({ time, factions }) => ({
-        season,
-        time,
-        data: JSON.stringify(factions),
-    }));
-
-    return {
-        time: Math.floor(Date.now() / 1000),
-        error_code: 0,
-        introduction_order: seasonRow.introduction_order ?? [],
-        points_max: seasonRow.points_max ?? [],
-        snapshots,
-        defend_events: allEvents.filter((e) => e.type === EVENT_TYPE.DEFEND),
-        attack_events: allEvents.filter((e) => e.type === EVENT_TYPE.ATTACK),
-    };
 }
 
 export const GET = methodNotAllowed;

--- a/src/db/queries/rebroadcast.mjs
+++ b/src/db/queries/rebroadcast.mjs
@@ -1,0 +1,153 @@
+'use server';
+import db from '@/db/db';
+import { EVENT_TYPE, EVENT_STATUS } from '@/shared/enums/events.mjs';
+import { groupStatusByBucket } from '@/shared/utils/bucketing.mjs';
+
+/**
+ * Reconstruct the `get_campaign_status` wire format from the normalized
+ * tables (h1_season + h1_status + h1_statistic + h1_event). Uses the latest
+ * season with data. Returns `null` when no season has been populated yet.
+ *
+ * Partial loss of fidelity vs the HD1 wire format: the 4 event-count
+ * fields on each statistics[] entry (defend_events, successful_defend_events,
+ * attack_events, successful_attack_events) are omitted — they are derivable
+ * from h1_event with COUNT(*) WHERE type=... AND status=... AND season=X.
+ *
+ * @returns {Promise<object | null>}
+ */
+export async function reconstructCampaignStatus() {
+    // Latest season that has been populated.
+    const seasonRow = await db.h1_season.findFirst({
+        where: { last_updated: { not: null } },
+        orderBy: { season: 'desc' },
+        select: {
+            season: true,
+            introduction_order: true,
+            points_max: true,
+            season_duration: true,
+        },
+    });
+    if (!seasonRow) return null;
+
+    const targetSeason = seasonRow.season;
+
+    // latestStatus / latestStats / activeEvents are mutually independent —
+    // each keyed only on targetSeason — so they run in parallel, collapsing
+    // three sequential round-trips into one. (The DISTINCT ON $queryRaw is
+    // used like getCampaign.mjs; Prisma can't express DISTINCT ON natively.)
+    const [latestStatus, latestStats, activeEvents] = await Promise.all([
+        db.$queryRaw`
+            SELECT DISTINCT ON (enemy) *
+            FROM h1_status
+            WHERE season = ${targetSeason}
+            ORDER BY enemy ASC, bucket DESC
+        `,
+        db.$queryRaw`
+            SELECT DISTINCT ON (enemy) *
+            FROM h1_statistic
+            WHERE season = ${targetSeason}
+            ORDER BY enemy ASC, bucket DESC
+        `,
+        db.h1_event.findMany({
+            where: { season: targetSeason, status: EVENT_STATUS.ACTIVE },
+        }),
+    ]);
+
+    const statByEnemy = new Map(latestStats.map((r) => [r.enemy, r]));
+
+    const latestTime = Math.max(
+        0,
+        ...latestStatus.map((r) => r.time),
+        ...latestStats.map((r) => r.time),
+    );
+
+    return {
+        time: latestTime,
+        error_code: 0,
+        campaign_status: latestStatus.map((r) => ({
+            enemy: r.enemy,
+            points: r.points,
+            points_taken: r.points_taken,
+            points_max: seasonRow.points_max?.[r.enemy] ?? 0,
+            status: r.status,
+            introduction_order: seasonRow.introduction_order?.[r.enemy] ?? 0,
+        })),
+        statistics: [0, 1, 2].map((enemy) => {
+            const s = statByEnemy.get(enemy);
+            return {
+                enemy,
+                season_duration: seasonRow.season_duration ?? 0,
+                players: s?.players ?? 0,
+                total_unique_players: s?.total_unique_players ?? 0,
+                missions: s?.missions ?? 0,
+                successful_missions: s?.successful_missions ?? 0,
+                total_mission_difficulty: s?.total_mission_difficulty ?? 0,
+                completed_planets: s?.completed_planets ?? 0,
+                // 4 fields intentionally omitted (derivable from h1_event):
+                //   defend_events, successful_defend_events,
+                //   attack_events, successful_attack_events
+                kills: s?.kills != null ? Number(s.kills) : 0,
+                deaths: s?.deaths != null ? Number(s.deaths) : 0,
+                accidentals: s?.accidentals != null ? Number(s.accidentals) : 0,
+                shots: s?.shots != null ? Number(s.shots) : 0,
+                hits: s?.hits != null ? Number(s.hits) : 0,
+            };
+        }),
+        defend_event: activeEvents.find((e) => e.type === EVENT_TYPE.DEFEND) ?? null,
+        attack_events: activeEvents.filter((e) => e.type === EVENT_TYPE.ATTACK),
+        introduction_order: seasonRow.introduction_order ?? [],
+        points_max: seasonRow.points_max ?? [],
+    };
+}
+
+/**
+ * Reconstruct the `get_snapshots` wire format for a given season from the
+ * normalized tables (h1_season + h1_status + h1_event). Returns `null` when
+ * the season has no h1_season row yet (caller may then trigger an on-demand
+ * `updateSeason()` fetch from the official API).
+ *
+ * Sparse buckets (missing one or more factions) are filtered out of the
+ * snapshot array for consumer safety — matches `getCampaign.mjs`'s behavior.
+ *
+ * @param {number} season - Season number to reconstruct.
+ * @returns {Promise<object | null>}
+ */
+export async function reconstructSnapshots(season) {
+    if (!season) return null;
+
+    const seasonRow = await db.h1_season.findUnique({
+        where: { season },
+        select: {
+            season: true,
+            introduction_order: true,
+            points_max: true,
+        },
+    });
+    if (!seasonRow) return null;
+
+    // allStatus / allEvents are independent — run in parallel to collapse
+    // two sequential round-trips into one.
+    const [allStatus, allEvents] = await Promise.all([
+        db.h1_status.findMany({
+            where: { season },
+            orderBy: [{ bucket: 'asc' }, { enemy: 'asc' }],
+        }),
+        db.h1_event.findMany({ where: { season } }),
+    ]);
+
+    const snapshots = groupStatusByBucket(allStatus).map(({ time, factions }) => ({
+        season,
+        time,
+        data: JSON.stringify(factions),
+    }));
+
+    return {
+        time: Math.floor(Date.now() / 1000),
+        error_code: 0,
+        introduction_order: seasonRow.introduction_order ?? [],
+        points_max: seasonRow.points_max ?? [],
+        snapshots,
+        defend_events: allEvents.filter((e) => e.type === EVENT_TYPE.DEFEND),
+        attack_events: allEvents.filter((e) => e.type === EVENT_TYPE.ATTACK),
+    };
+}

--- a/src/update/season.mjs
+++ b/src/update/season.mjs
@@ -12,6 +12,13 @@ import { upsertEvent } from '@/db/queries/upsertEvent.mjs';
 import { upsertStatus } from '@/db/queries/upsertStatus.mjs';
 
 /**
+ * Sentinel value used as the `cause` on errors thrown by `updateSeason` when
+ * the requested season doesn't exist on the HD1 API. Callers should compare
+ * `err.cause === SEASON_NOT_FOUND` to return 404 instead of 500.
+ */
+export const SEASON_NOT_FOUND = 'SEASON_NOT_FOUND';
+
+/**
  * @param {number} season - Season number to fetch and persist
  * @param {{ protectedBucket?: number }} opts  When set, skip writing h1_status
  *   rows whose bucket >= this value. The worker poll passes this to prevent
@@ -53,7 +60,7 @@ export async function updateSeason(season, opts = {}) {
     try {
         fetchedSeason = getSeasonFromSnapshot(fetchedData);
     } catch {
-        throw new Error(`Season ${season} not found`, { cause: 'SEASON_NOT_FOUND' });
+        throw new Error(`Season ${season} not found`, { cause: SEASON_NOT_FOUND });
     }
     if (season !== fetchedSeason) throw new Error('Invalid season');
 


### PR DESCRIPTION
## Summary

- **Extracts ~140 LOC** of inlined `reconstructCampaignStatus` + `reconstructSnapshots` out of `src/app/api/h1/rebroadcast/route.js` into a new `src/db/queries/rebroadcast.mjs` module. The route file now does pure POST orchestration; the data-access lives where data-access lives.
- **Promotes the `SEASON_NOT_FOUND` magic-string** used as `Error.cause` in `src/update/season.mjs` to a named export. Both `campaign/route.js` (existing consumer) and `rebroadcast/route.js` (new consumer) import it, so typos fail at `tsc --noEmit` time.
- **Behavior fix:** `POST /api/h1/rebroadcast { action: 'get_snapshots', season: <nonexistent> }` previously returned `500` for "season doesn't exist on the HD1 API"; now correctly returns `404` with the upstream error message — matching `GET /api/h1/campaign?season=<nonexistent>`'s existing 404 behavior.

Closes the **`rebroadcast-churn-hotspot-decoupling`** strategic issue from /desloppify (issue #406, cluster `rebroadcast-getcampaign-consolidation`). This route appeared in **5 desloppify detector channels** (structural, high/mid/low elegance, cross-module-arch); the structural decoupling stops surface edits to either side from regenerating findings.

## What changed

| File | Change |
|------|--------|
| `src/db/queries/rebroadcast.mjs` | **New module.** `reconstructCampaignStatus()` + `reconstructSnapshots(season)` — moved verbatim from the route handler. |
| `src/app/api/h1/rebroadcast/route.js` | Drops the two inlined functions (-140 LOC); imports them from the new query module. Adds `SEASON_NOT_FOUND` → 404 branch on the snapshots-backfill failure path. |
| `src/update/season.mjs` | `+export const SEASON_NOT_FOUND = 'SEASON_NOT_FOUND'`; throw site uses the constant. |
| `src/app/api/h1/campaign/route.js` | Imports the constant instead of comparing against the literal string. |
| `src/__tests__/unit/routes/campaign.test.mjs` | Mock exposes `SEASON_NOT_FOUND` (route now imports it). |
| `src/__tests__/unit/routes/rebroadcast.test.mjs` | Same mock update. |
| `CHANGELOG.md` | Recorded under `## Unreleased`. |

## Verification

- `npm run lint` ✅ (0 errors, 4 pre-existing warnings tracked in #400)
- `npm run typecheck` ✅
- `npm run test:unit` ✅ — 1416 tests pass (133 files)
- `npm run build` ✅

## Behavior changes

| Endpoint | Scenario | Before | After |
|----------|----------|--------|-------|
| `POST /api/h1/rebroadcast` | `get_snapshots` for nonexistent season | `500 Internal server error` | `404 Season N not found` |
| `POST /api/h1/rebroadcast` | All other paths | unchanged | unchanged |
| `GET /api/h1/campaign` | All paths | unchanged | unchanged (constant import only) |

The reconstruction return shapes, error envelopes for *real* failures, and the `404 Not found` fallback when DB returns empty data are byte-for-byte preserved.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [ ] Manual smoke: `curl -X POST /api/h1/rebroadcast -F 'action=get_snapshots' -F 'season=999'` (should return 404 now instead of 500)

## Related

- Refs #406 (Desloppify subjective review backlog — strategic issue `rebroadcast-churn-hotspot-decoupling`)
- Refs #403 (large/complex files — rebroadcast/route.js was at complexity 145, now significantly slimmer)
- Refs #402 (boilerplate duplication — rebroadcast cluster, partially addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)