### PR TITLE
chore(desloppify): mechanical cleanup — close #399, #400, #401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- **Desloppify mechanical cleanup** — closes three filed issues in one PR. (1) Adds JSDoc `@param` descriptions to `CascadeLog.jsx` (`props`) and `seasonAnalytics.mjs` (`opts`), clearing the two `jsdoc/require-param-description` lint warnings (#400). (2) Renames the cross-file `makeFactionMap` test helpers — `EventCard.test.jsx` uses `makeSectorMap` (it builds a per-faction sectors map for one event card) and `DashboardClient.test.jsx` uses `makeDashboardMap` (it builds the full mapState shape including region 0/11) — each helper is a genuinely different shape (regions 1-11 vs 1-10 vs 0-11 with different field sets), so renaming is more honest than extracting a fake shared abstraction; the third occurrence in `computeFrontier.test.mjs` is already scoped inside a `describe()` block (#401). (3) Annotates the two intentional empty-`catch` swallows in `MinistryProvider.jsx` (flicker scheduler) and `useLiveData.mjs` (`saveCachedState`) — both now capture `err` and `console.debug` it so the swallow is visible during diagnosis, with the existing rationale promoted from inline comment to a fuller multi-line explanation of why each path is non-critical (#399). No runtime behavior change.
+
 ## 0.51.3
 
 ### Changes

--- a/src/__tests__/unit/features/dashboard/DashboardClient.test.jsx
+++ b/src/__tests__/unit/features/dashboard/DashboardClient.test.jsx
@@ -65,7 +65,7 @@ vi.mock('@/features/stats/evaluateProgress.mjs', () => ({
 
 import DashboardClient from '@/features/dashboard/DashboardClient';
 
-function makeFactionMap(overrides = {}) {
+function makeDashboardMap(overrides = {}) {
     const map = {};
     for (let r = 0; r <= 11; r++) {
         map[r] = { region: `Region ${r}`, status: 'lost', event: 'idle', percent: 0 };
@@ -77,10 +77,10 @@ function makeFactionMap(overrides = {}) {
 }
 
 const baseMapState = {
-    0: makeFactionMap(),
-    1: makeFactionMap(),
-    2: makeFactionMap(),
-    3: makeFactionMap(), // Super Earth
+    0: makeDashboardMap(),
+    1: makeDashboardMap(),
+    2: makeDashboardMap(),
+    3: makeDashboardMap(), // Super Earth
 };
 
 function getCardProps(testId) {
@@ -306,7 +306,7 @@ describe('DashboardClient — homeworld card suppression', () => {
             },
             mapState: {
                 ...baseMapState,
-                0: makeFactionMap({
+                0: makeDashboardMap({
                     11: {
                         event: 'active',
                         status: 'active',

--- a/src/__tests__/unit/features/galaxy/EventCard.test.jsx
+++ b/src/__tests__/unit/features/galaxy/EventCard.test.jsx
@@ -25,7 +25,7 @@ const baseProps = {
  * Build a mapState[factionIndex] with the given sector statuses.
  * Default: everything lost. Each entry in `overrides` keyed by region 1–11.
  */
-function makeFactionMap(overrides = {}) {
+function makeSectorMap(overrides = {}) {
     const map = {};
     for (let r = 1; r <= 11; r++) map[r] = { status: 'lost', percent: 0 };
     for (const [key, val] of Object.entries(overrides)) {
@@ -258,7 +258,7 @@ describe('EventCard (campaign view)', () => {
     const campaignProps = {
         ...baseProps,
         view: 'campaign',
-        factionMap: makeFactionMap({
+        factionMap: makeSectorMap({
             1: { status: 'captured', percent: 100 },
             2: { status: 'captured', percent: 100 },
             3: { status: 'captured', percent: 100 },
@@ -286,7 +286,7 @@ describe('EventCard (campaign view)', () => {
             <EventCard
                 {...baseProps}
                 view="campaign"
-                factionMap={makeFactionMap({
+                factionMap={makeSectorMap({
                     1: { status: 'captured', percent: 100 },
                     2: { status: 'captured', percent: 100 },
                     3: { status: 'in_progress', percent: 30 },
@@ -319,7 +319,7 @@ describe('EventCard (campaign view)', () => {
             <EventCard
                 {...baseProps}
                 view="campaign"
-                factionMap={makeFactionMap({
+                factionMap={makeSectorMap({
                     11: { status: 'active', percent: 42 },
                 })}
             />,
@@ -355,7 +355,7 @@ describe('EventCard (campaign view)', () => {
             <EventCard
                 {...baseProps}
                 view="campaign"
-                factionMap={makeFactionMap()}
+                factionMap={makeSectorMap()}
                 points={1234567}
                 pointsMax={5000000}
             />,

--- a/src/features/ministry/MinistryProvider.jsx
+++ b/src/features/ministry/MinistryProvider.jsx
@@ -189,8 +189,11 @@ export default function MinistryProvider({ warTone, children }) {
                     ];
                 const dur = randomBetween(FLICKER_DUR_MIN_MS, FLICKER_DUR_MAX_MS, rng);
                 entry.onFlicker(charIdx, dur);
-            } catch {
-                // swallow; reschedule below
+            } catch (err) {
+                // Swallow flicker-scheduling errors and reschedule below.
+                // The flicker animation is a cosmetic non-critical path; we
+                // never want a transient timing issue to crash the provider.
+                console.debug('[MinistryProvider] flicker scheduling failed:', err);
             }
             scheduleNext();
         }

--- a/src/features/timeline/CascadeLog.jsx
+++ b/src/features/timeline/CascadeLog.jsx
@@ -11,7 +11,7 @@ import { groupCascadesBySeason } from '@/features/timeline/groupCascadesBySeason
  * Cross-season cascade log. Same section layout as EventLog, grouped by
  * season instead of by day. Renders nothing when `cascades` is empty.
  *
- * @param {object} props
+ * @param {object} props - Component props.
  * @param {Array<object>} props.cascades - Each cascade includes a `season` field.
  * @param {string} [props.lede] - Optional one-line summary above the groups.
  * @param {string} [props.title] - Optional heading text (defaults to "Cascade Failures").

--- a/src/shared/hooks/useLiveData.mjs
+++ b/src/shared/hooks/useLiveData.mjs
@@ -37,8 +37,10 @@ function saveCachedState(data, mapState) {
             CACHE_KEY,
             JSON.stringify({ data, mapState, ts: Date.now() }),
         );
-    } catch {
-        // localStorage full or unavailable — ignore
+    } catch (err) {
+        // localStorage full / unavailable / disabled in private mode — ignore.
+        // The cache is an offline-fallback nicety, never a correctness path.
+        console.debug('[useLiveData] saveCachedState skipped:', err);
     }
 }
 

--- a/src/shared/utils/game/seasonAnalytics.mjs
+++ b/src/shared/utils/game/seasonAnalytics.mjs
@@ -10,8 +10,8 @@ const MAX_GAP_SEC = 3600; // 1 hour
  * and consecutive events within `MAX_GAP_SEC` (1 hour).
  *
  * @param {Array} events - h1_event records (any type, any status)
- * @param {object} [opts]
- * @param {number} [opts.minLength=3] - Inclusive minimum cascade length
+ * @param {object} [opts] - Optional configuration.
+ * @param {number} [opts.minLength=3] - Inclusive minimum cascade length.
  * @returns {Array<{
  *   length: number,
  *   faction: string,


### PR DESCRIPTION
## Summary

Three small fixes bundled into one PR — closes three filed desloppify issues from the initial scan.

| Issue | Fix |
|-------|-----|
| **#399** — review 2 empty catch clauses | Annotated both intentional swallows with captured `err` + `console.debug` log. Promoted inline comments to fuller multi-line rationale. |
| **#400** — fix 4 ESLint warnings (JSDoc subset) | Added `@param` descriptions to `CascadeLog.jsx` (`props`) and `seasonAnalytics.mjs` (`opts`). Drops the 2 \`jsdoc/require-param-description\` warnings. The 2 React Compiler warnings in `Hijackable.jsx` are a separate concern. |
| **#401** — reconcile 3 function signatures drifting | Renamed `makeFactionMap` test helpers per-file to reflect their genuinely different shapes (regions 1-11 vs 1-10 vs 0-11; different field sets). |

## What changed

| File | Change |
|------|--------|
| `src/features/timeline/CascadeLog.jsx` | `@param {object} props` → `@param {object} props - Component props.` |
| `src/shared/utils/game/seasonAnalytics.mjs` | `@param {object} [opts]` → `@param {object} [opts] - Optional configuration.` |
| `src/__tests__/unit/features/galaxy/EventCard.test.jsx` | `makeFactionMap` → `makeSectorMap` (5 sites) |
| `src/__tests__/unit/features/dashboard/DashboardClient.test.jsx` | `makeFactionMap` → `makeDashboardMap` (6 sites) |
| `src/features/ministry/MinistryProvider.jsx` | Empty catch → `catch (err)` + `console.debug(...)`; multi-line comment explaining why a swallow is correct here |
| `src/shared/hooks/useLiveData.mjs` | Same treatment for `saveCachedState`'s empty catch |
| `CHANGELOG.md` | Recorded under `## Unreleased` |

## Why this design

- **Rename instead of dedupe** on `makeFactionMap`: the three test fixtures take genuinely different region ranges and field shapes; extracting a shared helper would force a fake abstraction. The signature_variance detector flagged a name collision, not a real abstraction opportunity. Renaming makes the test intent clearer and dissolves the cross-file variance (the third occurrence in `computeFrontier.test.mjs` is already scoped inside its `describe()` so it doesn't conflict).
- **`console.debug` instead of `eslint-disable`** on the empty catches: ESLint isn't currently flagging the empty bodies (the project doesn't enable `no-empty`); the desloppify smells detector did. Switching from a bare comment to a logged-and-explained swallow makes the failure mode discoverable during diagnosis without changing behavior.

## Verification

- `npm run lint` ✅ — 0 errors, 2 warnings remaining (both React Compiler in `Hijackable.jsx`, tracked separately in #400)
- `npm run typecheck` ✅
- `npm run test:unit` ✅ — 1416 tests pass (133 files)
- `npm run build` ✅

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`

## Closes

- Closes #399
- Closes #400 — partial. The 2 React Compiler warnings in `Hijackable.jsx:66,106` are a separate enable-React-rules investigation; this PR resolves the 2 JSDoc warnings only. Reopen #400 with reduced scope on merge.
- Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)