### PR TITLE
refactor(validators): unify on direct-export shape across all 5 isValid* files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- **Drop the redundant `rootSchema` intermediate from `isValidStatus.mjs` and `isValidSeason.mjs` — all 5 Zod validators now export their schema directly.** Three of the five `src/validators/isValid*.mjs` files (`isValidContentType`, `isValidNumber`, `isValidFormData`) wrote `export const isValidX = z.<schema>(...)` directly. The other two bound the root schema to a local `const rootSchema = ...` first and re-exported it on the next line — an unused indirection (the name was never referenced elsewhere in the file). Converged on the direct-export form. The `@typedef {z.infer<typeof isValidStatus>} StatusPayload` / `@typedef {z.infer<typeof isValidSeason>} SeasonPayload` annotations continue to work unchanged because they reference the exported name. Pure refactor — no runtime behavior change. Closes the `validator-protocol-unification` cluster and 3 `contract_coherence` findings from /desloppify (issue #406).
+
 ## 0.51.5
 
 ### Changes

--- a/src/validators/isValidSeason.mjs
+++ b/src/validators/isValidSeason.mjs
@@ -53,8 +53,7 @@ const eventSchema = z.object({
     region: z.number().optional(),
 });
 
-// The main schema
-const rootSchema = z.object({
+export const isValidSeason = z.object({
     time: z.number(),
     error_code: z.number(),
     introduction_order: z.array(z.number()).nullable(),
@@ -75,8 +74,6 @@ const rootSchema = z.object({
         }),
     ),
 });
-
-export const isValidSeason = rootSchema;
 
 /**
  * Inferred shape of a validated `get_snapshots` payload from HD1.

--- a/src/validators/isValidStatus.mjs
+++ b/src/validators/isValidStatus.mjs
@@ -56,7 +56,7 @@ const statisticsSchema = z.object({
     hits: z.number(),
 });
 
-const rootSchema = z.object({
+export const isValidStatus = z.object({
     time: z.number().int().min(1000000000).max(2000000000),
     error_code: z.number(),
     // campaign_status and statistics must be non-empty — the real HD1 API always
@@ -68,8 +68,6 @@ const rootSchema = z.object({
     attack_events: z.array(attackEventSchema),
     statistics: z.array(statisticsSchema).min(1),
 });
-
-export const isValidStatus = rootSchema;
 
 /**
  * Inferred shape of a validated `get_campaign_status` payload from HD1.


### PR DESCRIPTION
## Summary

Two of the five Zod validators bound their root schema to a local `const rootSchema = ...` and then re-exported it on the next line — an unused indirection. The other three already used the direct-export form. Converged on the direct-export form across all five.

## What changed

| File | Before | After |
|------|--------|-------|
| \`src/validators/isValidStatus.mjs\` | \`const rootSchema = z.object({...}); export const isValidStatus = rootSchema;\` | \`export const isValidStatus = z.object({...});\` |
| \`src/validators/isValidSeason.mjs\` | \`const rootSchema = z.object({...}); export const isValidSeason = rootSchema;\` | \`export const isValidSeason = z.object({...});\` |
| \`src/validators/isValidContentType.mjs\` | (unchanged — already direct) | — |
| \`src/validators/isValidNumber.mjs\` | (unchanged — already direct) | — |
| \`src/validators/isValidFormData.mjs\` | (unchanged — already direct) | — |
| \`CHANGELOG.md\` | — | recorded under \`## Unreleased\` |

The `@typedef {z.infer<typeof isValidStatus>} StatusPayload` and `@typedef {z.infer<typeof isValidSeason>} SeasonPayload` annotations continue to work — they reference the exported name, not the dropped intermediate.

## Behavior changes

**None.** Pure JS-level refactor. No public API surface change, no test updates required, no runtime path affected.

## Verification

- \`npm run lint\` ✅ (0 errors, 2 pre-existing React Compiler warnings)
- \`npm run typecheck\` ✅
- \`npm run test:unit\` ✅ — 1416 tests pass (133 files)
- \`npm run build\` ✅

## Net change

5 line deletions, 2 line additions across 2 source files. Smallest cluster of the entire grind series.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm run test:unit\`
- [x] \`npm run build\`

## Related

- Refs #406 (Desloppify subjective review backlog — cluster \`validator-protocol-unification\`)
- Closes 3 \`contract_coherence\` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)