### PR TITLE
Hotfix 0.47.10 — fix EACCES on /app/.next/cache in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.47.10
+
+### Fixes
+
+- **Fix the `EACCES: permission denied, mkdir '/app/.next/cache'` flood in the production container by chowning the runtime image by numeric uid instead of the unresolvable name `nonroot`.** Root cause: the Chainguard runtime (`cgr.dev/chainguard/node:latest`) has **no `nonroot` entry in `/etc/passwd`** — uid 65532 is named `node` — so the runner-stage `COPY --from=builder --chown=nonroot:nonroot …` lines silently fell back to root (`0:0`). That left `/app/.next` root-owned (mode 755), and since the container runs as uid 65532, the Next.js image optimizer's first remote-avatar optimization (`mkdir('.next/cache/images', { recursive: true })`, triggered by Discord/GitHub/Google/Gravatar avatars) failed with `EACCES` and rejected on every subsequent cacheable image request. `Dockerfile.app` now uses `--chown=65532:65532` (numeric IDs need no passwd lookup) on all three runner COPY lines, so the runtime user owns the standalone tree and creates `.next/cache` on demand. Verified by reproducing the production state (`/app/.next` `uid=0`, `mkdir FAILED:EACCES`) and confirming the numeric-chown image yields `uid=65532` and a successful write. Hotfix off `main`; the same fix is already on `develop` as 0.52.1.
+
 ## 0.47.9
 
 ### Documentation

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -103,9 +103,18 @@ ARG NEXT_PUBLIC_DEPLOY_ENV
 ENV NEXT_PUBLIC_DEPLOY_ENV=$NEXT_PUBLIC_DEPLOY_ENV
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nonroot:nonroot /app/.next/standalone ./
-COPY --from=builder --chown=nonroot:nonroot /app/.next/static ./.next/static
-COPY --from=builder --chown=nonroot:nonroot /app/public ./public
+#
+# Chown by NUMERIC uid:gid, NOT the name `nonroot`. This Chainguard runtime
+# has no `nonroot` entry in /etc/passwd (uid 65532 is named `node`), so
+# `--chown=nonroot:nonroot` silently falls back to root (0:0). That left
+# /app/.next root-owned and made the Next.js image optimizer's runtime
+# `mkdir('.next/cache/images')` fail with EACCES, flooding logs with
+# unhandledRejection on every remote-avatar (Discord/GitHub/Google/Gravatar)
+# optimization. Numeric IDs need no passwd lookup, so 65532 (the runtime
+# user) owns the tree as intended and the cache dir is created on demand.
+COPY --from=builder --chown=65532:65532 /app/.next/standalone ./
+COPY --from=builder --chown=65532:65532 /app/.next/static ./.next/static
+COPY --from=builder --chown=65532:65532 /app/public ./public
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.4",
+    "version": "0.47.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "helldivers.bot",
-            "version": "0.47.4",
+            "version": "0.47.10",
             "dependencies": {
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@mdx-js/loader": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.47.9",
+    "version": "0.47.10",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Problem

The production container floods logs with:

```
Error: EACCES: permission denied, mkdir '/app/.next/cache'
    at async .../next/dist/server/lib/disk-lru-cache.external.js
```

**Root cause:** the Chainguard runtime (`cgr.dev/chainguard/node:latest`) has **no `nonroot` entry in `/etc/passwd`** — uid 65532 is named `node`. So the runner-stage `COPY --from=builder --chown=nonroot:nonroot …` lines silently fall back to root (`0:0`), leaving `/app/.next` root-owned (mode 755). The container runs as uid 65532, so the Next.js **image optimizer**'s first remote-avatar optimization (`mkdir('.next/cache/images')`, triggered by Discord/GitHub/Google/Gravatar avatars) fails with `EACCES` and rejects on every subsequent cacheable image request.

## Fix

Switch the three runner `COPY` lines to numeric `--chown=65532:65532` (numeric IDs need no passwd lookup), so the runtime user owns the standalone tree and creates `.next/cache` on demand.

## Verification

Reproduced the exact production state in a controlled build (`/app/.next` `uid=0`, `mkdir FAILED:EACCES`), then confirmed a real `Dockerfile.app` build with the numeric chown yields `/app/.next` `uid=65532` and a successful `.next/cache/images` write. Probe against the deployed container showed `/app/.next` `uid=0` / process `uid=65532`, matching the repro.

## Scope / notes

- Hotfix off `main` (v0.47.9 → **v0.47.10**); isolates the fix from the unreleased 0.48–0.52 work on `develop`. The same fix is already on `develop` as 0.52.1.
- No application code or schema change. The image cache is ephemeral (Postgres holds all persistence).
- **Deploy note:** after tagging, the server's `docker-compose.yml` must (1) bump the image pin to `v0.47.10` (app + migrate), and (2) replace the `curl` healthcheck with the node-based one — Chainguard ships no `curl`, so the current override marks the container unhealthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)