### PR TITLE
Release v0.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Setup Node.js
               uses: actions/setup-node@v6.4.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,17 +29,17 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4.35.5
+              uses: github/codeql-action/init@v4.36.2
               with:
                   languages: ${{ matrix.language }}
 
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v4.35.5
+              uses: github/codeql-action/autobuild@v4.36.2
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4.35.5
+              uses: github/codeql-action/analyze@v4.36.2
               with:
                   category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Dependency Review
               uses: actions/dependency-review-action@v5.0.0

--- a/.github/workflows/main-pr-docker-smoke.yml
+++ b/.github/workflows/main-pr-docker-smoke.yml
@@ -33,14 +33,14 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Set up Docker Buildx
               # Buildx is needed for the BuildKit features Dockerfile.app uses:
               # `# syntax=docker/dockerfile:1`, `RUN --mount=type=cache,...`,
               # and `RUN --mount=type=secret,...`. Without buildx, those parse
               # as ordinary RUNs and break the build.
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@v4.1.0
 
             - name: Build images
               # `docker compose build` invokes buildx per service. No GHA cache

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -19,7 +19,9 @@ jobs:
         steps:
             # https://github.com/lowlighter/metrics/tree/master/source/plugins/pagespeed
             - name: 'metrics: pagespeed'
-              uses: lowlighter/metrics@v4
+              # pinned to v3.34 (latest release tag); @v4 is an unreleased
+              # dev branch, not a tag — a group bump silently moved it there.
+              uses: lowlighter/metrics@v3.34
               with:
                   token: NOT_NEEDED
                   committer_branch: metrics

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -19,7 +19,7 @@ jobs:
         steps:
             # https://github.com/lowlighter/metrics/tree/master/source/plugins/pagespeed
             - name: 'metrics: pagespeed'
-              uses: lowlighter/metrics@v3.34
+              uses: lowlighter/metrics@v4
               with:
                   token: NOT_NEEDED
                   committer_branch: metrics

--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -15,20 +15,20 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@v4.1.0
 
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4.1.0
+              uses: docker/login-action@v4.2.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push Docker image
-              uses: docker/build-push-action@v7.1.0
+              uses: docker/build-push-action@v7.2.0
               with:
                   context: .
                   file: ./Dockerfile.app
@@ -60,20 +60,20 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@v4.1.0
 
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4.1.0
+              uses: docker/login-action@v4.2.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push MIGRATE image
-              uses: docker/build-push-action@v7.1.0
+              uses: docker/build-push-action@v7.2.0
               with:
                   context: .
                   file: ./Dockerfile.migrate
@@ -91,7 +91,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Extract changelog for this version
               id: changelog

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -17,7 +17,7 @@ jobs:
             image_missing: ${{ steps.check.outputs.missing }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Detect migration-related changes
               id: filter
@@ -46,20 +46,20 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@v4.1.0
 
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4.1.0
+              uses: docker/login-action@v4.2.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push MIGRATE
-              uses: docker/build-push-action@v7.1.0
+              uses: docker/build-push-action@v7.2.0
               with:
                   context: .
                   file: ./Dockerfile.migrate
@@ -72,20 +72,20 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@v7.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@v4.1.0
 
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4.1.0
+              uses: docker/login-action@v4.2.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push APP
-              uses: docker/build-push-action@v7.1.0
+              uses: docker/build-push-action@v7.2.0
               with:
                   context: .
                   file: ./Dockerfile.app

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -113,7 +113,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Cleanup untagged packages
-              uses: snok/container-retention-policy@v3.0.1
+              uses: snok/container-retention-policy@v3.1.0
               with:
                   account: user
                   # Classic PAT with delete:packages — the default GITHUB_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **`/sign-in` now has its own page title** (`Sign In | Helldivers Bot`) via a
+  `sign-in/layout.jsx`, instead of inheriting the generic site-wide default.
+- **Removed the post-login `/dashboard → /profile` redirect hop.** OAuth
+  `callbackURL`s now point straight at `/profile`, and the redirect-only
+  `/dashboard` route (plus its `robots.txt` disallow) is deleted.
+
 ## 0.59.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@
   faction · % held. Restricted to defend fails — the only events with a clean
   margin signal — and hidden when a war had no genuine nail-biters.
 
+### Fixed
+
+- **Lockfile synced to `0.60.0`** — `package-lock.json` still carried `0.59.1`.
+- **`/stats` Combat Telemetry charts deferred via `next/dynamic`** — added
+  `RatioTrendChartLoader` so the Recharts bundle stays out of the initial page
+  JS, matching the `/archives` chart loaders.
+- **`metrics.yml` pinned back to `lowlighter/metrics@v3.34`** — a CI group bump
+  had silently moved it to the unreleased `@v4` dev branch (not a release tag).
+- **`buildEngagementSeries` hardened and unit-tested** — extracted to its own
+  module; the anchor fallback uses `reduce` instead of `Math.min(...spread)` (no
+  `RangeError` on large event arrays), and the telemetry ratios guard missing
+  BigInt fields with `?? 0n`.
+
 ## 0.59.2
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "helldivers.bot",
-    "version": "0.59.1",
+    "version": "0.60.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "helldivers.bot",
-            "version": "0.59.1",
+            "version": "0.60.0",
             "dependencies": {
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@mdx-js/loader": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "react": "^19.2.7",
                 "react-dom": "^19.2.7",
                 "react-slot-counter": "^3.3.3",
-                "recharts": "^3.8.1",
+                "recharts": "^3.9.0",
                 "remark-gfm": "^4.0.1",
                 "serwist": "^9.5.11",
                 "sonner": "^2.0.7",
@@ -14711,9 +14711,9 @@
             }
         },
         "node_modules/recharts": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
-            "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
+            "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
             "license": "MIT",
             "workspaces": [
                 "www"
@@ -14726,7 +14726,7 @@
                 "eventemitter3": "^5.0.1",
                 "immer": "^10.1.1",
                 "react-redux": "8.x.x || 9.x.x",
-                "reselect": "5.1.1",
+                "reselect": "5.2.0",
                 "tiny-invariant": "^1.3.3",
                 "use-sync-external-store": "^1.2.2",
                 "victory-vendor": "^37.0.2"
@@ -14739,12 +14739,6 @@
                 "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
-        },
-        "node_modules/recharts/node_modules/reselect": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-            "license": "MIT"
         },
         "node_modules/recma-build-jsx": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-slot-counter": "^3.3.3",
-        "recharts": "^3.8.1",
+        "recharts": "^3.9.0",
         "remark-gfm": "^4.0.1",
         "serwist": "^9.5.11",
         "sonner": "^2.0.7",

--- a/src/__tests__/unit/features/archives/buildEngagementSeries.test.mjs
+++ b/src/__tests__/unit/features/archives/buildEngagementSeries.test.mjs
@@ -1,0 +1,84 @@
+import { buildEngagementSeries } from '@/features/archives/buildEngagementSeries.mjs';
+
+const DAY = 86400;
+
+test('anchors day 0 to warStart and groups points per faction', () => {
+    const warStart = 1000;
+    const events = [
+        { enemy: 0, start_time: 1000, players_at_start: 100, region: 1, type: 'defend' },
+        {
+            enemy: 0,
+            start_time: 1000 + DAY,
+            players_at_start: 200,
+            region: 2,
+            type: 'attack',
+        },
+        {
+            enemy: 1,
+            start_time: 1000 + 2 * DAY,
+            players_at_start: 300,
+            region: 3,
+            type: 'defend',
+        },
+    ];
+    const series = buildEngagementSeries(events, warStart);
+
+    const bugs = series.find((s) => s.enemy === 0);
+    const cyborgs = series.find((s) => s.enemy === 1);
+    expect(bugs.points.map((p) => p.x)).toEqual([0, 1]);
+    expect(bugs.points.map((p) => p.y)).toEqual([100, 200]);
+    expect(cyborgs.points.map((p) => p.x)).toEqual([2]);
+    // Illuminate had no events — its empty series is dropped entirely.
+    expect(series.find((s) => s.enemy === 2)).toBeUndefined();
+});
+
+test('falls back to the earliest event when warStart is absent', () => {
+    const events = [
+        {
+            enemy: 0,
+            start_time: 5000 + DAY,
+            players_at_start: 200,
+            region: 1,
+            type: 'defend',
+        },
+        { enemy: 0, start_time: 5000, players_at_start: 100, region: 1, type: 'defend' },
+    ];
+    const series = buildEngagementSeries(events, null);
+    // anchor = earliest start_time (5000) → that point is day 0.
+    expect(series[0].points.map((p) => p.x).sort()).toEqual([0, 1]);
+});
+
+test('drops events with no positive player count', () => {
+    const events = [
+        { enemy: 0, start_time: 0, players_at_start: 0, region: 1, type: 'defend' },
+        {
+            enemy: 0,
+            start_time: 0,
+            players_at_start: undefined,
+            region: 1,
+            type: 'defend',
+        },
+    ];
+    expect(buildEngagementSeries(events, 0)).toEqual([]);
+});
+
+test('returns empty for null/undefined input', () => {
+    expect(buildEngagementSeries(null, 0)).toEqual([]);
+    expect(buildEngagementSeries(undefined)).toEqual([]);
+});
+
+test('handles a large event array without RangeError (reduce, not spread)', () => {
+    const n = 200000;
+    // start_time increases with i, so the earliest event is index 0 → anchor.
+    const events = Array.from({ length: n }, (_, i) => ({
+        enemy: 0,
+        start_time: 1_000_000 + i,
+        players_at_start: 1,
+        region: 1,
+        type: 'defend',
+    }));
+    // The old Math.min(...spread) would throw RangeError at this size; reduce must not.
+    const series = buildEngagementSeries(events, null);
+    expect(series[0].points.length).toBe(n);
+    expect(series[0].points[0].x).toBe(0);
+});

--- a/src/__tests__/unit/features/archives/selectClosestCalls.test.mjs
+++ b/src/__tests__/unit/features/archives/selectClosestCalls.test.mjs
@@ -1,0 +1,42 @@
+import { selectClosestCalls } from '@/features/archives/selectClosestCalls.mjs';
+
+const ev = (o) => ({ type: 'defend', status: 'fail', points_max: 100, ...o });
+
+test('returns narrowest defend losses, closest to holding first', () => {
+    const events = [
+        ev({ region: 1, enemy: 0, points: 95 }), // 0.95
+        ev({ region: 2, enemy: 1, points: 99 }), // 0.99 — narrowest
+        ev({ region: 3, enemy: 2, points: 92 }), // 0.92
+    ];
+    const calls = selectClosestCalls(events);
+    expect(calls.map((c) => c.region)).toEqual([2, 1, 3]);
+    expect(calls[0].ratio).toBeCloseTo(0.99);
+});
+
+test('excludes wins, actives, attacks, and blowout losses below minRatio', () => {
+    const events = [
+        ev({ region: 1, enemy: 0, points: 100, status: 'success' }), // win
+        ev({ region: 2, enemy: 0, points: 99, status: 'active' }), // in progress
+        ev({ region: 3, enemy: 0, points: 99, type: 'attack' }), // attack (unreliable)
+        ev({ region: 4, enemy: 0, points: 50 }), // 0.50 blowout, below 0.9
+        ev({ region: 5, enemy: 1, points: 91 }), // 0.91 — the only qualifier
+    ];
+    const calls = selectClosestCalls(events);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].region).toBe(5);
+});
+
+test('caps at limit (default 3) and respects an override', () => {
+    const events = Array.from({ length: 6 }, (_, i) =>
+        ev({ region: i, enemy: 0, points: 90 + i }),
+    );
+    expect(selectClosestCalls(events)).toHaveLength(3);
+    expect(selectClosestCalls(events, { limit: 5 })).toHaveLength(5);
+});
+
+test('guards points_max = 0 (no divide-by-zero) and null input', () => {
+    expect(
+        selectClosestCalls([ev({ region: 1, enemy: 0, points: 0, points_max: 0 })]),
+    ).toEqual([]);
+    expect(selectClosestCalls(null)).toEqual([]);
+});

--- a/src/__tests__/unit/features/stats/computeTelemetryStats.test.mjs
+++ b/src/__tests__/unit/features/stats/computeTelemetryStats.test.mjs
@@ -1,0 +1,58 @@
+import { computeTelemetryStats } from '@/features/stats/computeTelemetryStats.mjs';
+
+// A historical (pre-telemetry) season carries 0n sums; live-polled seasons
+// carry real BigInt counts. Mirrors getCrossSeasonStats' perSeason shape.
+const seasons = [
+    { season: 10, kills: 0n, accidentals: 0n, shots: 0n, hits: 0n, completed_planets: 0 },
+    {
+        season: 157,
+        kills: 1000n,
+        accidentals: 50n,
+        shots: 2000n,
+        hits: 1000n,
+        completed_planets: 100,
+    },
+    {
+        season: 158,
+        kills: 2000n,
+        accidentals: 40n,
+        shots: 8000n,
+        hits: 2000n,
+        completed_planets: 300,
+    },
+];
+
+test('filters out pre-telemetry (all-zero) seasons', () => {
+    const { friendlyFire, accuracy, seasonsWithTelemetry } =
+        computeTelemetryStats(seasons);
+    expect(seasonsWithTelemetry).toBe(2);
+    expect(friendlyFire.map((r) => r.season)).toEqual([157, 158]);
+    expect(accuracy.map((r) => r.season)).toEqual([157, 158]);
+});
+
+test('computes ratios as percentages from BigInt sums', () => {
+    const { friendlyFire, accuracy } = computeTelemetryStats(seasons);
+    // 50/1000 = 5%, 40/2000 = 2%
+    expect(friendlyFire.map((r) => r.value)).toEqual([5, 2]);
+    // 1000/2000 = 50%, 2000/8000 = 25%
+    expect(accuracy.map((r) => r.value)).toEqual([50, 25]);
+});
+
+test('shots-per-planet aggregates shots/planets across telemetry seasons', () => {
+    const { shotsPerPlanet } = computeTelemetryStats(seasons);
+    // (2000 + 8000) / (100 + 300) = 25
+    expect(shotsPerPlanet).toBe(25);
+});
+
+test('returns empty series and null big-number when no telemetry exists', () => {
+    const result = computeTelemetryStats([seasons[0]]);
+    expect(result.seasonsWithTelemetry).toBe(0);
+    expect(result.friendlyFire).toEqual([]);
+    expect(result.accuracy).toEqual([]);
+    expect(result.shotsPerPlanet).toBeNull();
+});
+
+test('tolerates null/undefined input', () => {
+    expect(computeTelemetryStats(null).seasonsWithTelemetry).toBe(0);
+    expect(computeTelemetryStats(undefined).shotsPerPlanet).toBeNull();
+});

--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Dashboard() {
-    redirect('/profile');
-}

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,4 +1,3 @@
 User-Agent: *
 Allow: /
-Disallow: /dashboard/
 Sitemap: https://helldivers.bot/sitemap.xml

--- a/src/app/sign-in/layout.jsx
+++ b/src/app/sign-in/layout.jsx
@@ -1,0 +1,8 @@
+export const metadata = {
+    title: 'Sign In | Helldivers Bot',
+    description: 'Sign in to Helldivers Bot with Discord, GitHub, or Google.',
+};
+
+export default function SignInLayout({ children }) {
+    return children;
+}

--- a/src/app/sign-in/page.jsx
+++ b/src/app/sign-in/page.jsx
@@ -17,7 +17,7 @@ export default function SignInPage() {
                     className="flex w-64 cursor-pointer items-center justify-center gap-3 px-6 py-3 text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary active:scale-[0.98]"
                     style={{ backgroundColor: '#5865F2' }}
                     data-umami-event="auth-signin-discord"
-                    onClick={() => signIn('discord', { callbackURL: '/dashboard' })}
+                    onClick={() => signIn('discord', { callbackURL: '/profile' })}
                 >
                     <svg
                         width="20"
@@ -37,7 +37,7 @@ export default function SignInPage() {
                     className="flex w-64 cursor-pointer items-center justify-center gap-3 px-6 py-3 text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary active:scale-[0.98]"
                     style={{ backgroundColor: '#24292e' }}
                     data-umami-event="auth-signin-github"
-                    onClick={() => signIn('github', { callbackURL: '/dashboard' })}
+                    onClick={() => signIn('github', { callbackURL: '/profile' })}
                 >
                     <svg
                         width="20"
@@ -59,7 +59,7 @@ export default function SignInPage() {
                     className="flex w-64 cursor-pointer items-center justify-center gap-3 border border-ghost px-6 py-3 transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary active:scale-[0.98]"
                     style={{ backgroundColor: '#fff', color: '#3c4043' }}
                     data-umami-event="auth-signin-google"
-                    onClick={() => signIn('google', { callbackURL: '/dashboard' })}
+                    onClick={() => signIn('google', { callbackURL: '/profile' })}
                 >
                     <svg
                         width="20"

--- a/src/app/stats/page.jsx
+++ b/src/app/stats/page.jsx
@@ -2,7 +2,7 @@ import { getCrossSeasonStats } from '@/db/queries/getCrossSeasonStats.mjs';
 import FactionThreatRanking from '@/features/stats/FactionThreatRanking';
 import WarOutcomes from '@/features/stats/WarOutcomes';
 import SeasonRecords from '@/features/stats/SeasonRecords';
-import RatioTrendChart from '@/features/stats/RatioTrendChart';
+import RatioTrendChart from '@/features/stats/RatioTrendChartLoader';
 import { computeTelemetryStats } from '@/features/stats/computeTelemetryStats.mjs';
 import { StatCard } from '@/features/stats/StatGrid';
 import { formatNumber } from '@/shared/utils/format/formatNumber.mjs';

--- a/src/app/stats/page.jsx
+++ b/src/app/stats/page.jsx
@@ -2,6 +2,10 @@ import { getCrossSeasonStats } from '@/db/queries/getCrossSeasonStats.mjs';
 import FactionThreatRanking from '@/features/stats/FactionThreatRanking';
 import WarOutcomes from '@/features/stats/WarOutcomes';
 import SeasonRecords from '@/features/stats/SeasonRecords';
+import RatioTrendChart from '@/features/stats/RatioTrendChart';
+import { computeTelemetryStats } from '@/features/stats/computeTelemetryStats.mjs';
+import { StatCard } from '@/features/stats/StatGrid';
+import { formatNumber } from '@/shared/utils/format/formatNumber.mjs';
 import Hijackable from '@/features/ministry/Hijackable';
 import CascadeLog from '@/features/timeline/CascadeLog';
 import { getCascadeLeaderboard } from '@/db/queries/getCascadeLeaderboard.mjs';
@@ -35,6 +39,7 @@ export const metadata = {
 export default async function StatsPage() {
     const data = await getCrossSeasonStats();
     const seasonsCount = data.perSeason.length;
+    const telemetry = computeTelemetryStats(data.perSeason);
     const cascades = await getCascadeLeaderboard();
     const lede = generateCascadeLede(cascades, data.perSeason.length);
     const c = await cookies();
@@ -71,6 +76,55 @@ export default async function StatsPage() {
                 <Hijackable as="h2" category="heading" text="All-Time Records" />
                 <SeasonRecords perSeason={data.perSeason} />
             </section>
+
+            {telemetry.seasonsWithTelemetry > 0 && (
+                <section className="flex flex-col gap-2">
+                    <Hijackable as="h2" category="heading" text="Combat Telemetry" />
+                    <p className="text-small text-text-muted">
+                        Live combat stats from the {telemetry.seasonsWithTelemetry}{' '}
+                        {telemetry.seasonsWithTelemetry === 1 ? 'season' : 'seasons'} the
+                        bot has polled directly — earlier wars predate telemetry
+                        collection, so the trend grows as new wars are recorded.
+                    </p>
+                    <div className="grid gap-6 md:grid-cols-2">
+                        {telemetry.friendlyFire.length > 0 && (
+                            <div className="flex flex-col gap-1">
+                                <h3 className="text-small text-text-muted">
+                                    Friendly Fire Index — accidentals per kill
+                                </h3>
+                                <RatioTrendChart
+                                    data={telemetry.friendlyFire}
+                                    label="Friendly fire"
+                                    color="#8b2d2d"
+                                    decimals={2}
+                                />
+                            </div>
+                        )}
+                        {telemetry.accuracy.length > 0 && (
+                            <div className="flex flex-col gap-1">
+                                <h3 className="text-small text-text-muted">
+                                    Accuracy Trend — hits per shot
+                                </h3>
+                                <RatioTrendChart
+                                    data={telemetry.accuracy}
+                                    label="Accuracy"
+                                    color="#7ec8e3"
+                                    decimals={1}
+                                />
+                            </div>
+                        )}
+                    </div>
+                    {telemetry.shotsPerPlanet != null && (
+                        <div className="stat-grid">
+                            <StatCard
+                                label="Shots per Planet"
+                                value={formatNumber(Math.round(telemetry.shotsPerPlanet))}
+                                subtitle="rounds fired per planet liberated"
+                            />
+                        </div>
+                    )}
+                </section>
+            )}
 
             <CascadeLog
                 cascades={cascades}

--- a/src/features/archives/ArchiveStats.jsx
+++ b/src/features/archives/ArchiveStats.jsx
@@ -7,6 +7,7 @@ import Hijackable from '@/features/ministry/Hijackable';
 import factions, { FACTION_INDEX } from '@/shared/enums/factions.mjs';
 import { EVENT_TYPE, EVENT_STATUS } from '@/shared/enums/events.mjs';
 import map from '@/shared/enums/map.mjs';
+import { selectClosestCalls } from '@/features/archives/selectClosestCalls.mjs';
 
 /**
  * A DEFENSE_RATE / ATTACK_RATE card for one event type — the success rate
@@ -93,37 +94,68 @@ export default function ArchiveStats({ faction, events, data, live }) {
             { difficulty: 0, successful: 0 },
         );
 
+        // The defends that came within a hair of holding — narrowest losses
+        // first. Hidden entirely when the war had no genuine nail-biters.
+        const closestCalls = selectClosestCalls(events);
+
         return (
-            <div className="stat-grid">
-                <StatCard
-                    label="OUTCOME"
-                    value={
-                        outcome === 'victory' || outcome === 'defeat' ?
-                            <Hijackable
-                                category="value"
-                                scope="archives"
-                                text={outcome.toUpperCase()}
-                                altText={outcome === 'victory' ? 'DEFEAT' : 'VICTORY'}
-                                className={
-                                    outcome === 'defeat' ? 'text-danger' : 'text-success'
-                                }
-                                altClassName={
-                                    outcome === 'defeat' ? 'text-success' : 'text-danger'
-                                }
-                            />
-                        :   outcome.toUpperCase()
-                    }
-                    subtitle={outcomeFaction ?? undefined}
-                    accentColor={outcomeColor}
-                    valueColor={
-                        outcome !== 'victory' && outcome !== 'defeat' ?
-                            outcomeColor
-                        :   undefined
-                    }
-                />
-                {rateCards(events)}
-                {difficultyCard(diff.difficulty, diff.successful)}
-            </div>
+            <>
+                <div className="stat-grid">
+                    <StatCard
+                        label="OUTCOME"
+                        value={
+                            outcome === 'victory' || outcome === 'defeat' ?
+                                <Hijackable
+                                    category="value"
+                                    scope="archives"
+                                    text={outcome.toUpperCase()}
+                                    altText={outcome === 'victory' ? 'DEFEAT' : 'VICTORY'}
+                                    className={
+                                        outcome === 'defeat' ? 'text-danger' : (
+                                            'text-success'
+                                        )
+                                    }
+                                    altClassName={
+                                        outcome === 'defeat' ? 'text-success' : (
+                                            'text-danger'
+                                        )
+                                    }
+                                />
+                            :   outcome.toUpperCase()
+                        }
+                        subtitle={outcomeFaction ?? undefined}
+                        accentColor={outcomeColor}
+                        valueColor={
+                            outcome !== 'victory' && outcome !== 'defeat' ?
+                                outcomeColor
+                            :   undefined
+                        }
+                    />
+                    {rateCards(events)}
+                    {difficultyCard(diff.difficulty, diff.successful)}
+                </div>
+                {closestCalls.length > 0 && (
+                    <div className="flex flex-col gap-2">
+                        <h3 className="text-small text-text-muted">
+                            Closest Calls — defends that came nearest to holding
+                        </h3>
+                        <div className="stat-grid">
+                            {closestCalls.map((c, i) => (
+                                <StatCard
+                                    key={`${c.enemy}-${c.region}-${i}`}
+                                    label={
+                                        map[c.enemy]?.[c.region]?.region ??
+                                        `Region ${c.region}`
+                                    }
+                                    value={`${(c.ratio * 100).toFixed(1)}%`}
+                                    subtitle={factions[c.enemy]?.name}
+                                    accentColor="danger"
+                                />
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </>
         );
     }
 

--- a/src/features/archives/ArchivesClient.jsx
+++ b/src/features/archives/ArchivesClient.jsx
@@ -4,6 +4,7 @@ import { useMapPin } from '@/shared/hooks/useMapPin.mjs';
 import ArchiveStats from '@/features/archives/ArchiveStats';
 import ArchivesHeader from '@/features/archives/ArchivesHeader';
 import FactionHealthChart from '@/features/archives/FactionHealthChartLoader';
+import PlayerEngagementChart from '@/features/archives/PlayerEngagementChartLoader';
 import FactionTabs from '@/shared/components/FactionTabs';
 import StatGrid from '@/features/stats/StatGrid';
 import EventLog from '@/features/timeline/EventLog';
@@ -76,6 +77,10 @@ export default function ArchivesClient({
     initialCascadeSort,
 }) {
     const events = data?.events ?? [];
+    // Player-engagement data is snapshot-derived, so it exists for historical
+    // seasons too — but guard the section anyway so a season with no event
+    // player counts hides it entirely rather than showing an empty chart.
+    const hasPlayerData = events.some((e) => (e.players_at_start ?? 0) > 0);
     const cascades = findAllCascades(events).map((c) => ({
         season: data?.season,
         ...c,
@@ -146,6 +151,21 @@ export default function ArchivesClient({
                         pointsMax={data?.points_max}
                     />
                 </section>
+
+                {hasPlayerData && (
+                    <section className="mt-4 flex flex-col gap-2">
+                        <h2>Player Engagement</h2>
+                        <p className="text-small text-text-muted">
+                            Helldivers mobilized at the start of each event, over the
+                            course of the war — did the community rally for the final
+                            battles?
+                        </p>
+                        <PlayerEngagementChart
+                            events={events}
+                            warStart={data?.war_start}
+                        />
+                    </section>
+                )}
             </div>
 
             {cascades.length > 0 && (

--- a/src/features/archives/PlayerEngagementChart.jsx
+++ b/src/features/archives/PlayerEngagementChart.jsx
@@ -1,0 +1,136 @@
+'use client';
+import {
+    ScatterChart,
+    Scatter,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    Legend,
+} from 'recharts';
+import { formatNumber } from '@/shared/utils/format/formatNumber.mjs';
+
+// Faction palette mirrors FactionHealthChart so /archives reads as one visual
+// language. Each faction's events become one colored scatter series.
+const FACTIONS = [
+    { enemy: 0, name: 'Bugs', color: '#e8822a' },
+    { enemy: 1, name: 'Cyborgs', color: '#8b2d2d' },
+    { enemy: 2, name: 'Illuminate', color: '#7ec8e3' },
+];
+
+/**
+ * Build `{ x: day-into-war, y: players_at_start }` scatter points grouped per
+ * faction. `warStart` anchors day 0, falling back to the earliest event when
+ * absent. Events with no positive player count carry no engagement signal and
+ * are dropped — so a season without player data yields an empty series and the
+ * chart (and its section) hides.
+ *
+ * @param {Array<{enemy:number, start_time:number, players_at_start:number, region:number, type:string}>} events - The season's events.
+ * @param {number|null|undefined} warStart - Unix-seconds anchor for day 0.
+ * @returns {Array<{enemy:number, name:string, color:string, points:Array<object>}>}
+ */
+function buildEngagementSeries(events, warStart) {
+    const withPlayers = (events ?? []).filter((e) => (e.players_at_start ?? 0) > 0);
+    if (withPlayers.length === 0) return [];
+
+    const anchor = warStart ?? Math.min(...withPlayers.map((e) => e.start_time));
+
+    return FACTIONS.map(({ enemy, name, color }) => ({
+        enemy,
+        name,
+        color,
+        points: withPlayers
+            .filter((e) => e.enemy === enemy)
+            .map((e) => ({
+                x: (e.start_time - anchor) / 86400,
+                y: e.players_at_start,
+                region: e.region,
+                type: e.type,
+            })),
+    })).filter((s) => s.points.length > 0);
+}
+
+/**
+ * Recharts-injected tooltip props.
+ *
+ * @param {{ active?: boolean, payload?: Array<{ payload?: {x:number, y:number, region:number, type:string} }> }} props - Tooltip props.
+ */
+function EngagementTooltip({ active, payload }) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    if (!d) return null;
+
+    return (
+        <div
+            style={{
+                background: 'var(--color-surface-1)',
+                border: '1px solid var(--color-surface-3)',
+                padding: '0.5rem 0.75rem',
+                fontSize: '0.75rem',
+                fontFamily: 'var(--font-mono)',
+            }}
+        >
+            <div style={{ color: 'var(--color-text-muted)', marginBottom: 4 }}>
+                Day {Math.round(d.x)}
+            </div>
+            <div>{formatNumber(d.y)} players</div>
+            <div style={{ color: 'var(--color-text-muted)' }}>
+                {d.type} · region {d.region}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Player Engagement — a scatter of player mobilization per event over the
+ * course of one war. X is the day the event started; Y is `players_at_start`;
+ * each faction is a colored series. Shows whether engagement grew, declined, or
+ * surged for the final battles. Renders nothing when the season has no player
+ * data (the caller hides the section in turn).
+ *
+ * @param {object} props - Component props.
+ * @param {Array<object>} props.events - The season's events (with players_at_start).
+ * @param {number|null|undefined} props.warStart - Unix-seconds anchor for day 0.
+ */
+export default function PlayerEngagementChart({ events, warStart }) {
+    const series = buildEngagementSeries(events, warStart);
+    if (series.length === 0) return null;
+
+    return (
+        <ResponsiveContainer width="100%" height={260}>
+            <ScatterChart margin={{ top: 8, right: 24, bottom: 24, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-ghost)" />
+                <XAxis
+                    type="number"
+                    dataKey="x"
+                    name="Day"
+                    tickFormatter={(d) => `D${Math.round(d)}`}
+                    tick={{ fill: 'var(--color-text-muted)' }}
+                    label={{
+                        value: 'Day into war',
+                        position: 'insideBottom',
+                        offset: -12,
+                        fill: 'var(--color-text-muted)',
+                    }}
+                />
+                <YAxis
+                    type="number"
+                    dataKey="y"
+                    name="Players"
+                    width={56}
+                    tickFormatter={formatNumber}
+                    tick={{ fill: 'var(--color-text-muted)' }}
+                />
+                <Tooltip
+                    cursor={{ strokeDasharray: '3 3' }}
+                    content={<EngagementTooltip />}
+                />
+                <Legend />
+                {series.map((s) => (
+                    <Scatter key={s.enemy} name={s.name} data={s.points} fill={s.color} />
+                ))}
+            </ScatterChart>
+        </ResponsiveContainer>
+    );
+}

--- a/src/features/archives/PlayerEngagementChart.jsx
+++ b/src/features/archives/PlayerEngagementChart.jsx
@@ -10,46 +10,7 @@ import {
     Legend,
 } from 'recharts';
 import { formatNumber } from '@/shared/utils/format/formatNumber.mjs';
-
-// Faction palette mirrors FactionHealthChart so /archives reads as one visual
-// language. Each faction's events become one colored scatter series.
-const FACTIONS = [
-    { enemy: 0, name: 'Bugs', color: '#e8822a' },
-    { enemy: 1, name: 'Cyborgs', color: '#8b2d2d' },
-    { enemy: 2, name: 'Illuminate', color: '#7ec8e3' },
-];
-
-/**
- * Build `{ x: day-into-war, y: players_at_start }` scatter points grouped per
- * faction. `warStart` anchors day 0, falling back to the earliest event when
- * absent. Events with no positive player count carry no engagement signal and
- * are dropped — so a season without player data yields an empty series and the
- * chart (and its section) hides.
- *
- * @param {Array<{enemy:number, start_time:number, players_at_start:number, region:number, type:string}>} events - The season's events.
- * @param {number|null|undefined} warStart - Unix-seconds anchor for day 0.
- * @returns {Array<{enemy:number, name:string, color:string, points:Array<object>}>}
- */
-function buildEngagementSeries(events, warStart) {
-    const withPlayers = (events ?? []).filter((e) => (e.players_at_start ?? 0) > 0);
-    if (withPlayers.length === 0) return [];
-
-    const anchor = warStart ?? Math.min(...withPlayers.map((e) => e.start_time));
-
-    return FACTIONS.map(({ enemy, name, color }) => ({
-        enemy,
-        name,
-        color,
-        points: withPlayers
-            .filter((e) => e.enemy === enemy)
-            .map((e) => ({
-                x: (e.start_time - anchor) / 86400,
-                y: e.players_at_start,
-                region: e.region,
-                type: e.type,
-            })),
-    })).filter((s) => s.points.length > 0);
-}
+import { buildEngagementSeries } from './buildEngagementSeries.mjs';
 
 /**
  * Recharts-injected tooltip props.

--- a/src/features/archives/PlayerEngagementChartLoader.jsx
+++ b/src/features/archives/PlayerEngagementChartLoader.jsx
@@ -1,0 +1,13 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// Lazy-loads the recharts-backed PlayerEngagementChart so its chart code stays
+// out of the /archives initial bundle — it only matters once a season has event
+// player data. Mirrors FactionHealthChartLoader. Exporting the dynamic
+// component directly forwards `events`/`warStart`.
+const PlayerEngagementChart = dynamic(() => import('./PlayerEngagementChart'), {
+    ssr: false,
+});
+
+export default PlayerEngagementChart;

--- a/src/features/archives/buildEngagementSeries.mjs
+++ b/src/features/archives/buildEngagementSeries.mjs
@@ -1,0 +1,42 @@
+// Faction palette mirrors FactionHealthChart so /archives reads as one visual
+// language. Each faction's events become one colored scatter series.
+const FACTIONS = [
+    { enemy: 0, name: 'Bugs', color: '#e8822a' },
+    { enemy: 1, name: 'Cyborgs', color: '#8b2d2d' },
+    { enemy: 2, name: 'Illuminate', color: '#7ec8e3' },
+];
+
+/**
+ * Build `{ x: day-into-war, y: players_at_start }` scatter points grouped per
+ * faction. `warStart` anchors day 0, falling back to the earliest event when
+ * absent. Events with no positive player count carry no engagement signal and
+ * are dropped — so a season without player data yields an empty series and the
+ * chart (and its section) hides.
+ *
+ * @param {Array<{enemy:number, start_time:number, players_at_start:number, region:number, type:string}>} events - The season's events.
+ * @param {number|null|undefined} warStart - Unix-seconds anchor for day 0.
+ * @returns {Array<{enemy:number, name:string, color:string, points:Array<object>}>}
+ */
+export function buildEngagementSeries(events, warStart) {
+    const withPlayers = (events ?? []).filter((e) => (e.players_at_start ?? 0) > 0);
+    if (withPlayers.length === 0) return [];
+
+    // reduce, not Math.min(...spread): spreading a large array as call arguments
+    // can throw RangeError once it exceeds the engine's arg-count limit.
+    const anchor =
+        warStart ?? withPlayers.reduce((m, e) => Math.min(m, e.start_time), Infinity);
+
+    return FACTIONS.map(({ enemy, name, color }) => ({
+        enemy,
+        name,
+        color,
+        points: withPlayers
+            .filter((e) => e.enemy === enemy)
+            .map((e) => ({
+                x: (e.start_time - anchor) / 86400,
+                y: e.players_at_start,
+                region: e.region,
+                type: e.type,
+            })),
+    })).filter((s) => s.points.length > 0);
+}

--- a/src/features/archives/selectClosestCalls.mjs
+++ b/src/features/archives/selectClosestCalls.mjs
@@ -1,0 +1,34 @@
+import { EVENT_TYPE, EVENT_STATUS } from '@/shared/enums/events.mjs';
+
+/**
+ * Select a season's "closest calls" — the defend events that came nearest to
+ * flipping outcome.
+ *
+ * Only DEFEND fails carry a clean margin signal: `points / points_max` is the
+ * fraction of the defense bar filled before the planet fell, so a fail near 1.0
+ * is a heartbreaking near-hold. Wins all sit at ~1.0 with no sub-threshold
+ * signal, and attack point semantics are unreliable (some "successes" record a
+ * ~0 ratio), so both are excluded. Returns up to `limit` events with
+ * `ratio >= minRatio`, narrowest loss first.
+ *
+ * @param {Array<{type:string, status:string, region:number, enemy:number, points:number, points_max:number}>} events - The season's events.
+ * @param {{limit?:number, minRatio?:number}} [opts] - `limit` (default 3) and `minRatio` (default 0.9) tuning.
+ * @returns {Array<{region:number, enemy:number, ratio:number}>} Narrowest defend losses, closest first.
+ */
+export function selectClosestCalls(events, { limit = 3, minRatio = 0.9 } = {}) {
+    return (events ?? [])
+        .filter(
+            (e) =>
+                e.type === EVENT_TYPE.DEFEND &&
+                e.status === EVENT_STATUS.FAIL &&
+                e.points_max > 0,
+        )
+        .map((e) => ({
+            region: e.region,
+            enemy: e.enemy,
+            ratio: e.points / e.points_max,
+        }))
+        .filter((e) => e.ratio >= minRatio && e.ratio < 1)
+        .sort((a, b) => b.ratio - a.ratio)
+        .slice(0, limit);
+}

--- a/src/features/stats/RatioTrendChart.jsx
+++ b/src/features/stats/RatioTrendChart.jsx
@@ -1,0 +1,62 @@
+'use client';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+} from 'recharts';
+
+/**
+ * A small cross-season trend line for a single derived ratio (Friendly Fire,
+ * Accuracy — see computeTelemetryStats). One point per telemetry-bearing
+ * season; the X axis is the season number. Values arrive pre-computed as
+ * percentages. The caller guards the empty state, so an absent/empty series
+ * renders nothing.
+ *
+ * @param {object} props - Component props.
+ * @param {Array<{season:number, value:number}>} props.data - Pre-computed {season, percentage} points.
+ * @param {string} props.label - Tooltip series label.
+ * @param {string} props.color - Line/dot color (faction hex, matches FactionHealthChart).
+ * @param {number} [props.decimals] - Decimal places for the % formatter.
+ */
+export default function RatioTrendChart({ data, label, color, decimals = 1 }) {
+    if (!data?.length) return null;
+    const fmt = (v) => `${Number(v).toFixed(decimals)}%`;
+
+    return (
+        <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={data} margin={{ top: 8, right: 32, bottom: 8, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-ghost)" />
+                <XAxis
+                    dataKey="season"
+                    tickFormatter={(s) => `S${s}`}
+                    tick={{ fill: 'var(--color-text-muted)' }}
+                />
+                <YAxis
+                    tickFormatter={fmt}
+                    width={56}
+                    tick={{ fill: 'var(--color-text-muted)' }}
+                />
+                <Tooltip
+                    cursor={{ stroke: 'var(--color-ghost)' }}
+                    contentStyle={{
+                        backgroundColor: 'var(--color-surface-1)',
+                        border: '1px solid var(--color-ghost)',
+                    }}
+                    labelFormatter={(s) => `Season ${s}`}
+                    formatter={(value) => [fmt(value), label]}
+                />
+                <Line
+                    type="monotone"
+                    dataKey="value"
+                    stroke={color}
+                    strokeWidth={2}
+                    dot={{ fill: color, r: 3 }}
+                />
+            </LineChart>
+        </ResponsiveContainer>
+    );
+}

--- a/src/features/stats/RatioTrendChartLoader.jsx
+++ b/src/features/stats/RatioTrendChartLoader.jsx
@@ -1,0 +1,13 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// Lazy-loads the recharts-backed RatioTrendChart so its chart code stays out of
+// the /stats initial bundle — the Combat Telemetry section only renders once a
+// season carries live telemetry. Mirrors FactionHealthChartLoader. Exporting
+// the dynamic component directly forwards `data`/`label`/`color`/`decimals`.
+const RatioTrendChart = dynamic(() => import('./RatioTrendChart'), {
+    ssr: false,
+});
+
+export default RatioTrendChart;

--- a/src/features/stats/computeTelemetryStats.mjs
+++ b/src/features/stats/computeTelemetryStats.mjs
@@ -1,0 +1,50 @@
+/**
+ * Derive the combat-telemetry vizzes (#178 — Friendly Fire, Accuracy,
+ * Shots-per-Planet) from `getCrossSeasonStats`' `perSeason` rows.
+ *
+ * Telemetry (kills/shots/hits/accidentals) only exists for seasons the bot has
+ * polled live — historical wars predate collection and carry `0n` — so every
+ * series filters to telemetry-bearing seasons. That set grows as the worker
+ * keeps polling.
+ *
+ * BigInt sums are narrowed to `Number` here (magnitudes are well under 2^53) so
+ * the result is plain and safe to pass across the server→client boundary to the
+ * chart components — BigInt can't be serialized as a client-component prop.
+ *
+ * @param {Array<{season:number, kills:bigint, accidentals:bigint, shots:bigint, hits:bigint, completed_planets:number}>} perSeason - Per-season aggregates from getCrossSeasonStats.
+ * @returns {{ friendlyFire: Array<{season:number, value:number}>, accuracy: Array<{season:number, value:number}>, shotsPerPlanet: number|null, seasonsWithTelemetry: number }}
+ */
+export function computeTelemetryStats(perSeason) {
+    const rows = (perSeason ?? []).filter(
+        (s) => Number(s.shots) > 0 || Number(s.kills) > 0,
+    );
+
+    // Friendly Fire Index — accidentals as a percentage of total kills.
+    const friendlyFire = rows
+        .filter((s) => Number(s.kills) > 0)
+        .map((s) => ({
+            season: s.season,
+            value: (Number(s.accidentals) / Number(s.kills)) * 100,
+        }));
+
+    // Accuracy Trend — hits as a percentage of shots fired.
+    const accuracy = rows
+        .filter((s) => Number(s.shots) > 0)
+        .map((s) => ({
+            season: s.season,
+            value: (Number(s.hits) / Number(s.shots)) * 100,
+        }));
+
+    // Shots per Planet — one all-time "big number", aggregated across telemetry
+    // seasons so a single contributing season still yields a stable figure.
+    const totalShots = rows.reduce((sum, s) => sum + Number(s.shots), 0);
+    const totalPlanets = rows.reduce((sum, s) => sum + Number(s.completed_planets), 0);
+    const shotsPerPlanet = totalPlanets > 0 ? totalShots / totalPlanets : null;
+
+    return {
+        friendlyFire,
+        accuracy,
+        shotsPerPlanet,
+        seasonsWithTelemetry: rows.length,
+    };
+}

--- a/src/features/stats/computeTelemetryStats.mjs
+++ b/src/features/stats/computeTelemetryStats.mjs
@@ -24,7 +24,7 @@ export function computeTelemetryStats(perSeason) {
         .filter((s) => Number(s.kills) > 0)
         .map((s) => ({
             season: s.season,
-            value: (Number(s.accidentals) / Number(s.kills)) * 100,
+            value: (Number(s.accidentals ?? 0n) / Number(s.kills)) * 100,
         }));
 
     // Accuracy Trend — hits as a percentage of shots fired.
@@ -32,7 +32,7 @@ export function computeTelemetryStats(perSeason) {
         .filter((s) => Number(s.shots) > 0)
         .map((s) => ({
             season: s.season,
-            value: (Number(s.hits) / Number(s.shots)) * 100,
+            value: (Number(s.hits ?? 0n) / Number(s.shots)) * 100,
         }));
 
     // Shots per Planet — one all-time "big number", aggregated across telemetry

--- a/src/shared/components/ProgressExplainer/ProgressExplainer.jsx
+++ b/src/shared/components/ProgressExplainer/ProgressExplainer.jsx
@@ -88,10 +88,14 @@ export default function ProgressExplainer() {
         const points = [];
         for (let pct = 0; pct <= 100; pct += 2) {
             const expected = (pct / 100) * pointsMax;
+            const bufferCeiling = expected * 1.1;
             points.push({
                 pct,
                 expected,
-                bufferCeiling: expected * 1.1,
+                bufferCeiling,
+                // [low, high] tuple → ranged Area. recharts 3.9 removed
+                // <Area baseLine>; a tuple dataKey is the supported replacement.
+                band: [expected, bufferCeiling],
             });
         }
         return points;
@@ -158,22 +162,14 @@ export default function ProgressExplainer() {
                         />
                         <Tooltip content={<CustomTooltip />} />
 
-                        {/* Buffer zone fill between expected and buffer ceiling */}
+                        {/* Buffer zone: ranged area between expected (low) and
+                            bufferCeiling (high). recharts 3.9 removed <Area baseLine>;
+                            a [low, high] tuple dataKey renders the band. */}
                         <Area
-                            dataKey="bufferCeiling"
-                            stroke={COLORS.bufferStroke}
-                            strokeWidth={1}
-                            strokeDasharray="4 4"
+                            dataKey="band"
+                            stroke="none"
                             fill={COLORS.buffer}
                             fillOpacity={1}
-                            // recharts accepts a plain y-value array for the Area
-                            // lower edge at runtime; its `BaseLineType` only models
-                            // the {x,y}[] form, so a `number[]` cast is rejected —
-                            // `any` is the only type that bridges the value-only array.
-                            baseLine={
-                                // eslint-disable-next-line jsdoc/reject-any-type -- recharts BaseLineType rejects the runtime-valid number[] form
-                                /** @type {any} */ (chartData.map((d) => d.expected))
-                            }
                             isAnimationActive={false}
                         />
                         <Area
@@ -181,6 +177,16 @@ export default function ProgressExplainer() {
                             stroke="none"
                             fill="var(--color-surface-1)"
                             fillOpacity={1}
+                            isAnimationActive={false}
+                        />
+                        {/* Dashed upper edge of the buffer band (the +10% ceiling) —
+                            a separate Line so only the top edge is stroked, as before. */}
+                        <Line
+                            dataKey="bufferCeiling"
+                            stroke={COLORS.bufferStroke}
+                            strokeWidth={1}
+                            strokeDasharray="4 4"
+                            dot={false}
                             isAnimationActive={false}
                         />
 


### PR DESCRIPTION
Production release of everything on `develop` since **v0.59.0** → bundles **v0.59.1, v0.59.2, v0.60.0**.

## v0.60.0 — Archive Analytics quick-wins (features)
- **Combat Telemetry on `/stats`** (#178) — Friendly Fire Index + Accuracy Trend (cross-season % line charts) and a Shots-per-Planet "big number", fed by telemetry sums already in `getCrossSeasonStats`. Hides when no telemetry exists (currently S157–S159).
- **Player Engagement on `/archives`** (#275) — lazy-loaded per-faction scatter of `players_at_start` vs. day-into-war.
- **Closest Calls on `/archives`** (#273) — top-3 narrowest defend losses (region · faction · % held), hidden when a war had no nail-biters.

## v0.59.2 — routing
- `/sign-in` gets its own page title; removed the post-login `/dashboard → /profile` redirect hop (OAuth callbacks point straight at `/profile`).

## v0.59.1 — chart upkeep
- recharts 3.8.1 → 3.9.0; reworked `ProgressExplainer`'s buffer band off the removed `<Area baseLine>` (visual unchanged).

## Verification
- `lint` · `typecheck` · `test:unit` (1498 passed) · `build` all green on `develop`.
- v0.60.0 vizzes DevTools-verified with real data, 0 console errors.

## No DB migrations
This release adds no Prisma migrations.

## Post-merge steps (per CLAUDE.md §Git Workflow rule 3)
1. Tag **`v0.60.0`** on the merge commit on `main` and push it — the production Docker build only triggers on version tags.
2. Merge `main` back into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)