### PR TITLE
feat(archives): auto-generated war narrative (#274)

### DIFF
--- a/src/__tests__/unit/features/archives/buildWarNarrative.test.mjs
+++ b/src/__tests__/unit/features/archives/buildWarNarrative.test.mjs
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { buildWarNarrative } from '@/features/archives/buildWarNarrative.mjs';
+
+const DAY = 86400;
+const HOUR = 3600;
+const WAR_START = 1_000_000;
+
+/**
+ * A season fixture covering every beat path:
+ *  - war start (opening beat)
+ *  - a faction (Illuminate) introduced mid-war → arrival beat
+ *  - a standalone resolved defend + attack → field-report beats
+ *  - a 4-event failed-defense cascade for the Bugs → one collapsed beat
+ *  - a defeat outcome (Super Earth region-0 defend fails)
+ */
+function fixture() {
+    // Bugs cascade: 4 failed defends, strictly decreasing regions, <1h gaps.
+    const cascadeStart = WAR_START + 12 * DAY;
+    const cascade = [4, 3, 2, 1].map((region, i) => ({
+        type: 'defend',
+        status: 'fail',
+        enemy: 0,
+        region,
+        start_time: cascadeStart + i * 30 * 60, // 30 min apart
+        end_time: cascadeStart + i * 30 * 60 + 20 * 60,
+        season: 200,
+    }));
+
+    return {
+        season: 200,
+        war_start: WAR_START,
+        introduction_order: { order: [1, 0, 2] }, // Bugs first, Illuminate second, Cyborgs absent
+        status: [
+            { enemy: 0, first_seen: WAR_START, status: 'active' },
+            { enemy: 1, first_seen: null, status: 'hidden' },
+            { enemy: 2, first_seen: WAR_START + 5 * DAY, status: 'active' },
+        ],
+        snapshots: [],
+        events: [
+            // Standalone resolved defend (Cyborgs) on day 1.
+            {
+                type: 'defend',
+                status: 'success',
+                enemy: 1,
+                region: 6,
+                start_time: WAR_START,
+                end_time: WAR_START + HOUR,
+                season: 200,
+            },
+            // Illuminate attack captured on day 6.
+            {
+                type: 'attack',
+                status: 'success',
+                enemy: 2,
+                region: 11,
+                start_time: WAR_START + 5 * DAY,
+                end_time: WAR_START + 5 * DAY + HOUR,
+                season: 200,
+            },
+            ...cascade,
+            // Super Earth falls — region-0 defend fails on day 47 (defeat).
+            {
+                type: 'defend',
+                status: 'fail',
+                enemy: 2,
+                region: 0,
+                start_time: WAR_START + 46 * DAY,
+                end_time: WAR_START + 47 * DAY,
+                season: 200,
+            },
+        ],
+    };
+}
+
+describe('buildWarNarrative', () => {
+    it('returns [] for empty/missing event data', () => {
+        expect(buildWarNarrative(null)).toEqual([]);
+        expect(buildWarNarrative(undefined)).toEqual([]);
+        expect(buildWarNarrative({})).toEqual([]);
+        expect(buildWarNarrative({ events: [] })).toEqual([]);
+    });
+
+    it('opens with a day-1 war-begins beat', () => {
+        const beats = buildWarNarrative(fixture());
+        expect(beats[0].day).toBe(1);
+        expect(beats[0].text).toContain('The war begins');
+    });
+
+    it('emits beats in chronological (non-decreasing day) order', () => {
+        const beats = buildWarNarrative(fixture());
+        for (let i = 1; i < beats.length; i++) {
+            expect(beats[i].day).toBeGreaterThanOrEqual(beats[i - 1].day);
+        }
+    });
+
+    it('computes day offsets as floor((t - war_start)/86400) + 1', () => {
+        const beats = buildWarNarrative(fixture());
+        // Illuminate arrival is anchored to first_seen = war_start + 5 days → day 6.
+        const arrival = beats.find((b) => b.text.includes('Illuminate'));
+        expect(arrival).toBeDefined();
+        expect(arrival.day).toBe(6);
+    });
+
+    it('splices a faction-arrival beat for mid-war introductions', () => {
+        const beats = buildWarNarrative(fixture());
+        const arrival = beats.find(
+            (b) => b.text.includes('Illuminate') && b.text.includes('enter the war'),
+        );
+        expect(arrival).toBeDefined();
+    });
+
+    it('does not emit an arrival beat for the first-introduced faction', () => {
+        const beats = buildWarNarrative(fixture());
+        // Bugs are introduced first → already on the field at war start, so no
+        // separate "Bugs enter the war" arrival beat.
+        const bugsArrival = beats.find(
+            (b) => b.text.includes('Bugs') && b.text.includes('enter the war'),
+        );
+        expect(bugsArrival).toBeUndefined();
+    });
+
+    it('collapses a cascade run into one dramatic beat', () => {
+        const beats = buildWarNarrative(fixture());
+        const cascadeBeats = beats.filter((b) => b.text.includes('devastating cascade'));
+        // The 4 failed Bugs defends collapse into exactly one beat.
+        expect(cascadeBeats).toHaveLength(1);
+        expect(cascadeBeats[0].text).toContain('4 regions');
+        // Cascade starts on day 13 (war_start + 12 days).
+        expect(cascadeBeats[0].day).toBe(13);
+        // The cascade's individual failed-defend events are NOT also narrated
+        // as separate field reports.
+        const bugsRegionFalls = beats.filter((b) => b.text.includes('falls to the Bugs'));
+        expect(bugsRegionFalls).toHaveLength(0);
+    });
+
+    it('caps the chronicle with the war outcome beat', () => {
+        const beats = buildWarNarrative(fixture());
+        const last = beats[beats.length - 1];
+        // Region-0 defend failed → defeat, attributed to the Illuminate.
+        expect(last.text).toContain('Super Earth falls');
+        expect(last.text).toContain('Illuminate');
+    });
+
+    it('caps a victory with a triumphant, faction-attributed beat', () => {
+        // All 3 homeworlds captured → victory; no region-0 failure.
+        const data = {
+            season: 201,
+            war_start: WAR_START,
+            introduction_order: { order: [1, 2, 3] },
+            status: [],
+            snapshots: [],
+            events: [0, 1, 2].map((enemy, i) => ({
+                type: 'attack',
+                status: 'success',
+                enemy,
+                region: 11,
+                start_time: WAR_START + i * DAY,
+                end_time: WAR_START + i * DAY + HOUR,
+                season: 201,
+            })),
+        };
+        const beats = buildWarNarrative(data);
+        const last = beats[beats.length - 1];
+        expect(last.text).toContain('The war is won');
+    });
+
+    it('falls back to the earliest event when war_start is absent', () => {
+        const data = fixture();
+        delete data.war_start;
+        const beats = buildWarNarrative(data);
+        // Opening beat anchored to the earliest event (which equals the old
+        // WAR_START) → still day 1, no negative or zero days anywhere.
+        expect(beats[0].day).toBe(1);
+        for (const b of beats) expect(b.day).toBeGreaterThanOrEqual(1);
+    });
+
+    it('strips the leading article from cascade faction names (no "The The Illuminate")', () => {
+        // Illuminate is "The Illuminate" in the factions enum; emit() carries
+        // that full name on cascade.faction, so the beat must resolve the name
+        // from cascade.factionIndex through factionName() to avoid doubling.
+        const start = WAR_START + 3 * DAY;
+        const data = {
+            season: 202,
+            war_start: WAR_START,
+            introduction_order: { order: [1, 0, 2] },
+            status: [],
+            snapshots: [],
+            events: [8, 6, 4, 2].map((region, i) => ({
+                type: 'defend',
+                status: 'fail',
+                enemy: 2,
+                region,
+                start_time: start + i * 30 * 60,
+                end_time: start + i * 30 * 60 + 20 * 60,
+                season: 202,
+            })),
+        };
+        const beats = buildWarNarrative(data);
+        const cascade = beats.find((b) => b.text.includes('devastating cascade'));
+        expect(cascade).toBeDefined();
+        expect(cascade.text).toContain('The Illuminate push through');
+        // No beat should ever contain a doubled article from an unstripped name.
+        for (const b of beats) expect(b.text).not.toMatch(/\bthe the\b/i);
+    });
+
+    it('produces no NaN days and every beat carries text', () => {
+        const beats = buildWarNarrative(fixture());
+        for (const b of beats) {
+            expect(Number.isNaN(b.day)).toBe(false);
+            expect(typeof b.text).toBe('string');
+            expect(b.text.length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/src/features/archives/ArchivesClient.jsx
+++ b/src/features/archives/ArchivesClient.jsx
@@ -5,6 +5,7 @@ import ArchiveStats from '@/features/archives/ArchiveStats';
 import ArchivesHeader from '@/features/archives/ArchivesHeader';
 import FactionHealthChart from '@/features/archives/FactionHealthChartLoader';
 import PlayerEngagementChart from '@/features/archives/PlayerEngagementChartLoader';
+import NarrativeSection from '@/features/archives/NarrativeSection';
 import FactionTabs from '@/shared/components/FactionTabs';
 import StatGrid from '@/features/stats/StatGrid';
 import EventLog from '@/features/timeline/EventLog';
@@ -166,6 +167,8 @@ export default function ArchivesClient({
                         />
                     </section>
                 )}
+
+                <NarrativeSection data={data} />
             </div>
 
             {cascades.length > 0 && (

--- a/src/features/archives/NarrativeSection.jsx
+++ b/src/features/archives/NarrativeSection.jsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { buildWarNarrative } from '@/features/archives/buildWarNarrative.mjs';
+
+/**
+ * War Narrative — a collapsible, in-world chronicle of a season's campaign,
+ * generated chronologically from event data in the Ministry of Truth's
+ * propaganda voice. Renders nothing when there is no narrative to tell
+ * (hide-when-empty, matching the player-engagement section).
+ *
+ * Uses the native `<details>`/`<summary>` collapsible idiom established by the
+ * docs `EndpointCard` — no JS toggle state, keyboard-accessible for free. The
+ * heading reuses the `.event-log-section` visual language so it reads as one
+ * archives section alongside the Event Log and Cascade Failures.
+ *
+ * @param {object} props - Component props.
+ * @param {object} props.data - Campaign data (the getCampaign shape).
+ * @param {boolean} [props.defaultOpen] - Whether the section starts expanded.
+ */
+export default function NarrativeSection({ data, defaultOpen = false }) {
+    const beats = buildWarNarrative(data);
+    if (beats.length === 0) return null;
+
+    return (
+        <section className="mt-4 flex flex-col gap-2">
+            <details className="group" open={defaultOpen}>
+                <summary
+                    className="flex cursor-pointer list-none items-center justify-between gap-2"
+                    data-umami-event="archive-narrative-toggle"
+                >
+                    <h2 className="m-0">War Narrative</h2>
+                    <span
+                        aria-hidden="true"
+                        className="font-mono text-small text-text-muted transition-transform group-open:rotate-90"
+                    >
+                        ▸
+                    </span>
+                </summary>
+
+                <p className="mt-2 text-small text-text-muted">
+                    The official record of the campaign, as approved for citizen
+                    consumption by the Ministry of Truth.
+                </p>
+
+                <ol className="mt-3 flex flex-col gap-2">
+                    {beats.map((beat, i) => (
+                        <li
+                            key={i}
+                            className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 border-l-4 border-ghost bg-surface-1 px-3 py-2"
+                        >
+                            <span className="font-mono text-small font-bold tracking-wide text-text-muted uppercase">
+                                Day {beat.day}
+                            </span>
+                            <span className="text-body text-text">{beat.text}</span>
+                        </li>
+                    ))}
+                </ol>
+            </details>
+        </section>
+    );
+}

--- a/src/features/archives/buildWarNarrative.mjs
+++ b/src/features/archives/buildWarNarrative.mjs
@@ -1,0 +1,236 @@
+import { EVENT_TYPE, EVENT_STATUS } from '@/shared/enums/events.mjs';
+import factions from '@/shared/enums/factions.mjs';
+import { findAllCascades } from '@/shared/utils/game/seasonAnalytics.mjs';
+import { getWarOutcome } from '@/features/archives/getWarOutcome.mjs';
+import { getEventRegionLabel } from '@/shared/utils/game/getEventRegionLabel.mjs';
+
+const SECONDS_PER_DAY = 86400;
+
+/**
+ * Resolve a faction's display name from its enemy id, stripped of any leading
+ * definite article. "The Illuminate" in the enum becomes "Illuminate" so the
+ * templates — which all supply their own "the ${name}" — never read "the The
+ * Illuminate". Bugs / Cyborgs are unaffected.
+ *
+ * @param {number} enemy - Faction id (0=Bugs, 1=Cyborgs, 2=Illuminate).
+ * @returns {string}
+ */
+function factionName(enemy) {
+    const name = factions[enemy]?.name ?? 'Unknown forces';
+    return name.replace(/^The\s+/i, '');
+}
+
+/**
+ * Day-into-war for a unix-seconds timestamp, 1-indexed. Day 1 is the war's
+ * opening day. Guards a missing/late anchor by clamping to a minimum of 1 so
+ * no beat ever reads "Day 0" or negative.
+ *
+ * @param {number} time - Event unix-seconds timestamp.
+ * @param {number} warStart - Unix-seconds anchor for day 1.
+ * @returns {number}
+ */
+function dayOf(time, warStart) {
+    const day = Math.floor((time - warStart) / SECONDS_PER_DAY) + 1;
+    return day < 1 ? 1 : day;
+}
+
+/**
+ * Build an ordered, in-world "war narrative" for a season from its campaign
+ * data. Each beat is a day-stamped sentence in the Ministry of Truth's
+ * propaganda voice — the opening of the war, each faction's arrival, the
+ * dramatic cascade runs collapsed into a single beat, and the war's outcome
+ * capping the chronicle.
+ *
+ * Generated, not pooled: the strings are season-specific (region names,
+ * faction names, day offsets), so they are templated from the data rather than
+ * drawn from a static content pool. Voice conventions mirror
+ * `src/features/ministry/ministryContent.mjs` and `generateCascadeLede.mjs`:
+ * dark-comedy military tone, franchise-only, no real-world politics.
+ *
+ * @param {object} data - Campaign data (the getCampaign shape): `events[]`,
+ *   `status[]`, `snapshots[]`, `introduction_order.order`, `war_start`.
+ * @returns {Array<{ day: number, text: string }>} Beats in chronological order.
+ *   Empty array when there is no event data to narrate.
+ */
+export function buildWarNarrative(data) {
+    const events = data?.events ?? [];
+    if (events.length === 0) return [];
+
+    // Anchor day 1 to war_start, falling back to the earliest event start_time.
+    // reduce, not Math.min(...spread): a large event array spread as call
+    // arguments can throw RangeError — mirror buildEngagementSeries.mjs.
+    const warStart =
+        data?.war_start ??
+        events.reduce((m, e) => Math.min(m, e.start_time ?? Infinity), Infinity);
+    if (!Number.isFinite(warStart)) return [];
+
+    /** @type {Array<{ time: number, day: number, order: number, text: string }>} */
+    const beats = [];
+    // `order` is a stable tiebreaker for same-timestamp beats so the opening,
+    // faction arrivals, and field reports stay in a sensible reading order.
+    let seq = 0;
+
+    // --- Opening beat -------------------------------------------------------
+    beats.push({
+        time: warStart,
+        day: 1,
+        order: seq++,
+        text: 'The war begins. By order of the Ministry of Truth, every citizen is a soldier and every soldier is a statistic.',
+    });
+
+    // --- Faction-arrival beats ---------------------------------------------
+    // introduction_order.order is enemy-id-indexed: order[enemy] = the 1-based
+    // slot in which that faction was revealed. status[i].first_seen is the
+    // earliest non-hidden bucket for that faction — the moment it entered the
+    // war. Splice one arrival beat per faction, anchored at first_seen so it
+    // interleaves with the field reports by timestamp.
+    const introOrder = data?.introduction_order?.order ?? [];
+    const firstSeenByEnemy = new Map(
+        (data?.status ?? [])
+            .filter((s) => s?.first_seen != null)
+            .map((s) => [s.enemy, s.first_seen]),
+    );
+    // Skip the first-introduced faction: it is already on the field at war
+    // start, so its "arrival" would duplicate the opening beat.
+    const firstIntroducedEnemy = introOrder.reduce(
+        (best, ord, enemy) =>
+            ord > 0 && (best === -1 || ord < introOrder[best]) ? enemy : best,
+        -1,
+    );
+    for (let enemy = 0; enemy < introOrder.length; enemy++) {
+        if (introOrder[enemy] <= 0) continue; // never introduced this season
+        if (enemy === firstIntroducedEnemy) continue;
+        const seen = firstSeenByEnemy.get(enemy);
+        if (seen == null) continue;
+        beats.push({
+            time: seen,
+            day: dayOf(seen, warStart),
+            order: seq++,
+            text: `The ${factionName(enemy)} enter the war. The Ministry assures all citizens this was anticipated, scheduled, and is going entirely according to plan.`,
+        });
+    }
+
+    // --- Cascade beats (collapse a run into one dramatic line) -------------
+    // Each cascade is a chain of failed defenses for one faction marching
+    // toward the home region. Replace the whole run with a single beat and
+    // suppress its constituent events from the per-event pass below.
+    const cascades = findAllCascades(events);
+    /** @type {Set<object>} */
+    const cascadeEvents = new Set();
+    for (const cascade of cascades) {
+        for (const e of cascade.events) cascadeEvents.add(e);
+        const reachedHome = cascade.regions[cascade.regions.length - 1] <= 0;
+        const span = Math.max(1, Math.round(cascade.durationSec / SECONDS_PER_DAY));
+        const dayPhrase = span === 1 ? 'in a single day' : `over ${span} days`;
+        const home =
+            reachedHome ?
+                ' The breach reached the inner regions; the Ministry calls this a controlled withdrawal.'
+            :   '';
+        beats.push({
+            time: cascade.startTime,
+            day: dayOf(cascade.startTime, warStart),
+            order: seq++,
+            text: `A devastating cascade. The ${factionName(cascade.factionIndex)} push through ${cascade.length} regions ${dayPhrase}.${home} Reports of panic have been reclassified as enthusiasm.`,
+        });
+    }
+
+    // --- Per-event field reports -------------------------------------------
+    // One beat per notable resolved event (excluding those folded into a
+    // cascade). Active/unresolved events carry no outcome to narrate, so skip
+    // them. Sort ascending by start_time first so day offsets read in order.
+    const sorted = [...events].sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
+    for (const e of sorted) {
+        if (cascadeEvents.has(e)) continue;
+        if (e.start_time == null) continue;
+        const text = describeEvent(e);
+        if (!text) continue;
+        beats.push({
+            time: e.start_time,
+            day: dayOf(e.start_time, warStart),
+            order: seq++,
+            text,
+        });
+    }
+
+    // --- Outcome beat (caps the chronicle) ---------------------------------
+    const outcome = getWarOutcome(data);
+    if (outcome) {
+        // Anchor the final beat to the last event so it always reads last.
+        const lastTime = sorted.reduce(
+            (m, e) => Math.max(m, e.end_time ?? e.start_time ?? warStart),
+            warStart,
+        );
+        beats.push({
+            time: lastTime,
+            day: dayOf(lastTime, warStart),
+            order: seq++,
+            text: describeOutcome(outcome),
+        });
+    }
+
+    // Chronological order, with the per-beat `order` breaking timestamp ties
+    // so the opening leads and the outcome trails within the same day.
+    beats.sort((a, b) => a.time - b.time || a.order - b.order);
+
+    return beats.map(({ day, text }) => ({ day, text }));
+}
+
+/**
+ * Render a single resolved event as one Ministry-voice field report. Returns
+ * '' for events that carry no narratable outcome (active/unknown), so the
+ * caller can skip them.
+ *
+ * @param {object} e - An h1_event record.
+ * @returns {string}
+ */
+function describeEvent(e) {
+    const region = getEventRegionLabel(e);
+    const enemy = factionName(e.enemy);
+
+    if (e.type === EVENT_TYPE.ATTACK) {
+        if (e.status === EVENT_STATUS.SUCCESS) {
+            return `Helldivers storm the ${enemy} homeworld and raise the flag over ${region}. The Ministry declares the celebration mandatory.`;
+        }
+        if (e.status === EVENT_STATUS.FAIL) {
+            return `The assault on the ${enemy} at ${region} falters. The Ministry has retroactively scheduled this setback as a morale exercise.`;
+        }
+        return '';
+    }
+
+    if (e.type === EVENT_TYPE.DEFEND) {
+        if (e.status === EVENT_STATUS.SUCCESS) {
+            return `${region} holds against the ${enemy}. The Ministry credits its own foresight and nothing else.`;
+        }
+        if (e.status === EVENT_STATUS.FAIL) {
+            return `${region} falls to the ${enemy}. The Ministry reminds citizens that a region lost is merely a region awaiting glorious recapture.`;
+        }
+        return '';
+    }
+
+    return '';
+}
+
+/**
+ * Render the war's final outcome beat. Victory and defeat each get a
+ * faction-attributed line; the faction may be null when attribution is
+ * unavailable, in which case the line stays generic.
+ *
+ * @param {{ outcome: string, faction: number|null }} outcome - The resolved war
+ *   outcome from getWarOutcome (outcome + faction attribution). `outcome` is
+ *   one of 'victory' | 'defeat'; typed loosely as `string` to match the value
+ *   tsc infers from getWarOutcome's object-literal returns.
+ * @returns {string}
+ */
+function describeOutcome(outcome) {
+    if (outcome.outcome === 'victory') {
+        const enemy = outcome.faction != null ? factionName(outcome.faction) : null;
+        const attribution = enemy ? ` The ${enemy} were the last to fall.` : '';
+        return `The war is won. Super Earth stands victorious — managed democracy prevails, exactly as the Ministry always knew it would.${attribution}`;
+    }
+
+    const enemy = outcome.faction != null ? factionName(outcome.faction) : null;
+    if (enemy) {
+        return `Super Earth falls. The ${enemy} have won. The Ministry assures surviving citizens that this defeat was both temporary and, in hindsight, inspirational.`;
+    }
+    return 'The war is lost. The Ministry has classified the outcome as a strategic reposition and recommends citizens look forward, never back.';
+}


### PR DESCRIPTION
Closes #274.

## What

A collapsible **War Narrative** on each season's `/archives` page — a chronological, in-world chronicle generated in the Ministry of Truth propaganda voice. Pure frontend: a transform over data already supplied by `getCampaign`, **no schema/DB/query changes**.

## How

- **`buildWarNarrative(data)`** — pure helper → ordered `[{day, text}]` beats: opening → faction arrivals (`introduction_order` + per-faction `first_seen`) → cascade runs collapsed via `findAllCascades` → per-event field reports → a `getWarOutcome` cap. Defensive (`empty → []`, reduce-min `war_start` fallback).
- **`NarrativeSection.jsx`** — native `<details>/<summary>` collapsible, hide-when-empty (like Player Engagement), `data-umami-event="archive-narrative-toggle"`. Wired into `ArchivesClient`.
- **12 unit tests**, incl. an Illuminate-cascade regression.

## Sample (from the test fixture)

> **Day 1:** The war begins. By order of the Ministry of Truth, every citizen is a soldier and every soldier is a statistic.
> **Day 6:** The Illuminate enter the war. The Ministry assures all citizens this was anticipated, scheduled, and is going entirely according to plan.
> **Day 13:** A devastating cascade. The Bugs push through 4 regions in a single day. Reports of panic have been reclassified as enthusiasm.
> **Day 48:** Super Earth falls. The Illuminate have won. The Ministry assures surviving citizens that this defeat was both temporary and, in hindsight, inspirational.

## Review verification

Built by an implementation agent; reviewed + an integration bug caught and fixed during review: the cascade beat bypassed the article-stripping helper, so an **Illuminate** cascade rendered "The **The Illuminate** push through" (the enum name is "The Illuminate"). Fixed to resolve via `factionName(cascade.factionIndex)` + added a regression test.

✅ lint · typecheck · test:unit (1515) · build — all pass (node 24).

## ⚠️ Hold before merge
- **Voice/tone is subjective** — please eyeball the Ministry phrasing; easy to tweak in `buildWarNarrative.mjs`.
- **Sequencing:** merging to `develop` bumps to the next version and folds into the open v0.60.0 release PR #445. Recommend merging this **after** v0.60.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)