### PR TITLE
feat(archives): faction introduction-order markers in the Event Log (#157)

### DIFF
--- a/src/__tests__/unit/features/archives/ArchiveComponentsIntegration.test.jsx
+++ b/src/__tests__/unit/features/archives/ArchiveComponentsIntegration.test.jsx
@@ -456,6 +456,49 @@ describe('Archive Components Integration Tests', () => {
             expect(props.selectedEvent).toEqual(mockEvent);
         });
 
+        test('EventLog receives computed faction intro markers', () => {
+            // getCampaign-shaped data: introduction_order.order is enemy-indexed
+            // reveal slots; status[i].first_seen is per-faction first appearance.
+            const warStart = 1700000000;
+            const introData = {
+                ...allSeeds[0].data,
+                war_start: warStart,
+                introduction_order: { order: [1, 2, 0] }, // illuminate never deployed
+                status: [
+                    { enemy: 0, first_seen: warStart }, // Bugs — Day 1
+                    { enemy: 1, first_seen: warStart + 3 * 86400 }, // Cyborgs — Day 4
+                    { enemy: 2, first_seen: null }, // never seen
+                ],
+            };
+
+            render(<ArchivesClient data={introData} seasons={[1]} currentSeason={1} />);
+
+            const props = JSON.parse(
+                screen.getByTestId('event-log-mock').getAttribute('data-props') || '{}',
+            );
+
+            expect(Array.isArray(props.introMarkers)).toBe(true);
+            expect(props.introMarkers.map((m) => m.enemy)).toEqual([0, 1]);
+            expect(props.introMarkers.map((m) => m.name)).toEqual(['Bugs', 'Cyborgs']);
+            expect(props.introMarkers.map((m) => m.day)).toEqual([1, 4]);
+        });
+
+        test('EventLog receives empty intro markers when intro data is absent', () => {
+            // The default seed lacks a getCampaign `status` array, so no markers.
+            render(
+                <ArchivesClient
+                    data={allSeeds[0].data}
+                    seasons={[1]}
+                    currentSeason={1}
+                />,
+            );
+
+            const props = JSON.parse(
+                screen.getByTestId('event-log-mock').getAttribute('data-props') || '{}',
+            );
+            expect(props.introMarkers).toEqual([]);
+        });
+
         test('Mobile viewport behavior simulation', () => {
             // Simulate mobile viewport
             global.innerWidth = 400;

--- a/src/__tests__/unit/features/archives/buildIntroMarkers.test.mjs
+++ b/src/__tests__/unit/features/archives/buildIntroMarkers.test.mjs
@@ -1,0 +1,112 @@
+import { buildIntroMarkers } from '@/features/archives/buildIntroMarkers.mjs';
+
+const DAY = 86400;
+const WAR_START = 1_700_000_000;
+
+/**
+ * Build a getCampaign-shaped fixture. `order` is enemy-indexed reveal slots;
+ * `firstSeen` is enemy-indexed first-appearance timestamps (null = not seen).
+ */
+function makeData({ order, firstSeen, warStart = WAR_START }) {
+    return {
+        war_start: warStart,
+        introduction_order: { order },
+        status: firstSeen.map((first_seen, enemy) => ({ enemy, first_seen })),
+    };
+}
+
+test('emits one marker per introduced faction with a known first_seen', () => {
+    const data = makeData({
+        order: [1, 2, 3],
+        firstSeen: [WAR_START, WAR_START + 2 * DAY, WAR_START + 5 * DAY],
+    });
+    const markers = buildIntroMarkers(data);
+
+    expect(markers).toHaveLength(3);
+    expect(markers.map((m) => m.enemy)).toEqual([0, 1, 2]);
+    expect(markers.map((m) => m.name)).toEqual(['Bugs', 'Cyborgs', 'Illuminate']);
+    expect(markers.every((m) => m.kind === 'intro')).toBe(true);
+});
+
+test('day is 1-based off war_start', () => {
+    const data = makeData({
+        order: [1, 2, 3],
+        firstSeen: [WAR_START, WAR_START + 2 * DAY, WAR_START + 5 * DAY],
+    });
+    const markers = buildIntroMarkers(data);
+    // war start → Day 1, +2 days → Day 3, +5 days → Day 6.
+    expect(markers.map((m) => m.day)).toEqual([1, 3, 6]);
+});
+
+test('strips the leading article from "The Illuminate"', () => {
+    const data = makeData({
+        order: [0, 0, 1],
+        firstSeen: [null, null, WAR_START + DAY],
+    });
+    const markers = buildIntroMarkers(data);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].name).toBe('Illuminate');
+});
+
+test('skips factions never introduced (order <= 0)', () => {
+    const data = makeData({
+        order: [1, 0, 2], // cyborgs (enemy 1) never deployed
+        firstSeen: [WAR_START, WAR_START + DAY, WAR_START + 2 * DAY],
+    });
+    const markers = buildIntroMarkers(data);
+    expect(markers.map((m) => m.enemy)).toEqual([0, 2]);
+});
+
+test('skips introduced factions with a null first_seen', () => {
+    const data = makeData({
+        order: [1, 2, 3],
+        firstSeen: [WAR_START, null, WAR_START + 3 * DAY], // cyborgs never seen
+    });
+    const markers = buildIntroMarkers(data);
+    expect(markers.map((m) => m.enemy)).toEqual([0, 2]);
+});
+
+test('sorts markers ascending by time even when reveal order differs', () => {
+    const data = makeData({
+        order: [3, 1, 2], // reveal slots out of chronological order
+        firstSeen: [WAR_START + 5 * DAY, WAR_START + DAY, WAR_START + 3 * DAY],
+    });
+    const markers = buildIntroMarkers(data);
+    expect(markers.map((m) => m.enemy)).toEqual([1, 2, 0]);
+    expect(markers.map((m) => m.time)).toEqual([
+        WAR_START + DAY,
+        WAR_START + 3 * DAY,
+        WAR_START + 5 * DAY,
+    ]);
+});
+
+test('falls back to the earliest first_seen when war_start is absent', () => {
+    const data = makeData({
+        order: [1, 2, 0],
+        firstSeen: [WAR_START + 2 * DAY, WAR_START + DAY, null],
+    });
+    // Drop war_start entirely so the reduce-min fallback anchors Day 1.
+    delete data.war_start;
+    const markers = buildIntroMarkers(data);
+    // anchor = earliest candidate first_seen (cyborgs, +1 day) → that is Day 1.
+    const cyborgs = markers.find((m) => m.enemy === 1);
+    const bugs = markers.find((m) => m.enemy === 0);
+    expect(cyborgs.day).toBe(1);
+    expect(bugs.day).toBe(2);
+});
+
+test('returns [] for missing / malformed data', () => {
+    expect(buildIntroMarkers(null)).toEqual([]);
+    expect(buildIntroMarkers(undefined)).toEqual([]);
+    expect(buildIntroMarkers({})).toEqual([]);
+    expect(buildIntroMarkers({ introduction_order: { order: [1, 2, 3] } })).toEqual([]);
+    expect(buildIntroMarkers({ status: [] })).toEqual([]);
+});
+
+test('returns [] when no faction is both introduced and seen', () => {
+    const data = makeData({
+        order: [0, 0, 0],
+        firstSeen: [WAR_START, WAR_START, WAR_START],
+    });
+    expect(buildIntroMarkers(data)).toEqual([]);
+});

--- a/src/__tests__/unit/features/timeline/EventLog.test.jsx
+++ b/src/__tests__/unit/features/timeline/EventLog.test.jsx
@@ -74,4 +74,68 @@ describe('EventLog', () => {
         expect(cards.length).toBeGreaterThan(0);
         expect(cards[0].getAttribute('data-event-key')).toBe('defend-1');
     });
+
+    describe('intro markers (archives opt-in)', () => {
+        const introMarkers = [
+            { kind: 'intro', enemy: 2, name: 'Illuminate', time: NOW - 400, day: 4 },
+        ];
+
+        test('renders an intro marker row when introMarkers is provided', () => {
+            const { container } = render(
+                <EventLog
+                    events={fakeEvents}
+                    timeFormat="absolute"
+                    layout="stack"
+                    introMarkers={introMarkers}
+                />,
+            );
+            const marker = container.querySelector('.event-log-intro');
+            expect(marker).toBeInTheDocument();
+            expect(marker.textContent).toContain('Day 4');
+            expect(marker.textContent).toContain('Illuminate enter the war');
+        });
+
+        test('does NOT render any intro marker when introMarkers is empty', () => {
+            const { container } = render(
+                <EventLog
+                    events={fakeEvents}
+                    timeFormat="absolute"
+                    layout="stack"
+                    introMarkers={[]}
+                />,
+            );
+            expect(container.querySelector('.event-log-intro')).toBeNull();
+        });
+
+        test('output is identical with the default (omitted) introMarkers prop', () => {
+            const withDefault = render(
+                <EventLog events={fakeEvents} timeFormat="absolute" layout="stack" />,
+            ).container.innerHTML;
+            const withEmpty = render(
+                <EventLog
+                    events={fakeEvents}
+                    timeFormat="absolute"
+                    layout="stack"
+                    introMarkers={[]}
+                />,
+            ).container.innerHTML;
+            expect(withEmpty).toBe(withDefault);
+        });
+
+        test('markers are not treated as events (no data-event-key, no W/L count)', () => {
+            const { container } = render(
+                <EventLog
+                    events={[]}
+                    timeFormat="absolute"
+                    layout="stack"
+                    introMarkers={introMarkers}
+                />,
+            );
+            // The marker renders but contributes no event card / scroll-sync key
+            expect(container.querySelector('.event-log-intro')).toBeInTheDocument();
+            expect(container.querySelector('[data-event-key]')).toBeNull();
+            // No outcome summary when the day holds only an intro marker
+            expect(container.querySelector('.event-log-day-summary')).toBeNull();
+        });
+    });
 });

--- a/src/features/archives/ArchivesClient.jsx
+++ b/src/features/archives/ArchivesClient.jsx
@@ -10,6 +10,7 @@ import StatGrid from '@/features/stats/StatGrid';
 import EventLog from '@/features/timeline/EventLog';
 import CascadeLog from '@/features/timeline/CascadeLog';
 import { findAllCascades } from '@/shared/utils/game/seasonAnalytics.mjs';
+import { buildIntroMarkers } from '@/features/archives/buildIntroMarkers.mjs';
 import ArchiveMap from '@/features/archives/ArchiveMap';
 import SeasonSelector from '@/features/archives/SeasonSelector';
 import RefreshSeasonButton from '@/features/archives/RefreshSeasonButton';
@@ -85,6 +86,11 @@ export default function ArchivesClient({
         season: data?.season,
         ...c,
     }));
+    // Synthetic "faction enters the war" markers, interleaved chronologically
+    // into the archives Event Log only. Empty when intro/first_seen data is
+    // missing, in which case EventLog renders exactly as it does on the
+    // homepage (which passes no markers at all).
+    const introMarkers = buildIntroMarkers(data);
     // 'global' shows the whole-war overview; bugs/cyborgs/illuminate show a
     // per-faction breakdown. Either way the stats render through the shared
     // StatGrid plus the archives-only ArchiveStats extras. Persisted via
@@ -192,6 +198,7 @@ export default function ArchivesClient({
                         onHoverEvent={undefined}
                         railRef={railRef}
                         layout="stack"
+                        introMarkers={introMarkers}
                     />
                 </div>
 

--- a/src/features/archives/buildIntroMarkers.mjs
+++ b/src/features/archives/buildIntroMarkers.mjs
@@ -1,0 +1,73 @@
+import factions from '@/shared/enums/factions.mjs';
+
+const DAY = 86400;
+
+/**
+ * Build synthetic "a faction enters the war" markers for the archives Event
+ * Log. One marker per faction that (a) has a positive `introduction_order`
+ * slot — `<= 0` means the faction never deployed this season — AND (b) has a
+ * non-null `first_seen` (the earliest non-hidden status bucket). Factions that
+ * are revealed but lack a recorded first appearance are skipped: without a
+ * timestamp there's nowhere to interleave the marker.
+ *
+ * `day` mirrors the war-day convention used elsewhere (1-based): the first day
+ * of the war is Day 1. `warStart` anchors Day 1, falling back to the earliest
+ * `first_seen` across all introduced factions when absent (reduce, not
+ * `Math.min(...spread)`, so a large status array can't trip the engine's
+ * arg-count limit — matching buildEngagementSeries).
+ *
+ * The faction name strips a leading article ("The Illuminate" → "Illuminate")
+ * so it templates cleanly into "<Name> enter the war".
+ *
+ * @param {object} [data] - getCampaign output. Reads `data.introduction_order.order` (enemy-id-indexed reveal slots), `data.status[i].first_seen` / `.enemy`, and `data.war_start`.
+ * @returns {Array<{kind:'intro', enemy:number, name:string, time:number, day:number}>} markers sorted ascending by time. Empty when data is missing.
+ */
+export function buildIntroMarkers(data) {
+    const order = data?.introduction_order?.order;
+    const status = data?.status;
+    if (!Array.isArray(order) || !Array.isArray(status)) return [];
+
+    // Map enemy id → first_seen from the per-faction status rows.
+    const firstSeenByEnemy = new Map();
+    for (const row of status) {
+        if (row && row.enemy != null && row.first_seen != null) {
+            firstSeenByEnemy.set(row.enemy, row.first_seen);
+        }
+    }
+
+    // Collect candidate markers: introduced (order > 0) AND first_seen known.
+    const candidates = [];
+    for (let enemy = 0; enemy < order.length; enemy++) {
+        if ((order[enemy] ?? 0) <= 0) continue;
+        const time = firstSeenByEnemy.get(enemy);
+        if (time == null) continue;
+        candidates.push({ enemy, time });
+    }
+    if (candidates.length === 0) return [];
+
+    // reduce, not Math.min(...spread): a long status array spread as call
+    // arguments can throw RangeError. Mirrors buildEngagementSeries.
+    const anchor =
+        data?.war_start ?? candidates.reduce((m, c) => Math.min(m, c.time), Infinity);
+
+    return candidates
+        .map(({ enemy, time }) => ({
+            kind: /** @type {'intro'} */ ('intro'),
+            enemy,
+            name: stripArticle(factions[enemy]?.name ?? `Faction ${enemy}`),
+            time,
+            day: Math.floor((time - anchor) / DAY) + 1,
+        }))
+        .sort((a, b) => a.time - b.time);
+}
+
+/**
+ * Strip a leading "The " article so a faction name templates into a sentence
+ * fragment ("The Illuminate" → "Illuminate" for "Illuminate enter the war").
+ *
+ * @param {string} name - Faction display name.
+ * @returns {string}
+ */
+function stripArticle(name) {
+    return name.replace(/^the\s+/i, '');
+}

--- a/src/features/timeline/EventLog.css
+++ b/src/features/timeline/EventLog.css
@@ -262,3 +262,38 @@
     color: var(--color-text-muted);
     margin: 0.25rem 0 0.75rem 0;
 }
+
+/* === Faction intro markers (archives only) ===
+ *
+ * Synthetic "a faction enters the war" dividers interleaved among the event
+ * rows on /archives. `--intro-color` is set inline per faction from the
+ * `--color-faction-*` token. Full-width so it reads as a divider even if a
+ * grid layout ever wraps it (the archives log uses the stack layout, so it
+ * naturally spans the single column there). */
+.event-log-intro {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
+    margin: 0.4rem 0;
+    background: color-mix(in srgb, var(--intro-color) 12%, transparent);
+    border-left: 4px solid var(--intro-color);
+    font-family: var(--font-mono, monospace);
+}
+
+.event-log-intro-day {
+    font-size: var(--text-small);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--intro-color);
+    white-space: nowrap;
+}
+
+.event-log-intro-label {
+    font-size: var(--text-small);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+}

--- a/src/features/timeline/EventLog.jsx
+++ b/src/features/timeline/EventLog.jsx
@@ -8,6 +8,7 @@ import { useEventLogSort } from '@/features/timeline/useEventLogSort.mjs';
 import { groupEventsByDay } from '@/features/timeline/groupEventsByDay.mjs';
 import { countOutcomes } from '@/shared/utils/game/eventFilters.mjs';
 import { eventKey } from '@/shared/utils/game/eventKey.mjs';
+import { FACTION_SLUG_BY_ID } from '@/shared/enums/factions.mjs';
 
 /**
  * Unified event log, shared between the homepage (`/`) and the archives
@@ -31,6 +32,24 @@ import { eventKey } from '@/shared/utils/game/eventKey.mjs';
  *   vertical column regardless of viewport width — required by the
  *   archives scrollytelling flow because `useScrollEvent`'s DOM-order
  *   optimization only works on a single column.
+ * - `introMarkers` (optional, default `[]`): archives-only synthetic
+ *   "faction enters the war" rows (`buildIntroMarkers`). They're
+ *   interleaved chronologically with the event rows and rendered as a
+ *   distinct faction-colored divider. The homepage passes nothing, so
+ *   with the default empty array the output is byte-for-byte identical
+ *   to before — the live dashboard is unaffected.
+ *
+ * @param {object} props - Component props.
+ * @param {Array} [props.events] - Full event list, unsorted.
+ * @param {'live' | 'absolute'} [props.timeFormat] - Time display mode.
+ * @param {string} [props.title] - Heading text.
+ * @param {string} [props.id] - DOM id on the section wrapper.
+ * @param {string} [props.initialSortOrder] - Initial sort preference (`'desc'` or `'asc'`).
+ * @param {string | null} [props.selectedEventKey] - Highlight the card matching this key.
+ * @param {(event: object) => void} [props.onHoverEvent] - Called on card hover.
+ * @param {object} [props.railRef] - Forwarded to the scrolling container.
+ * @param {string} [props.layout] - Layout mode (`'grid'` or `'stack'`).
+ * @param {Array<{kind:'intro', enemy:number, name:string, time:number, day:number}>} [props.introMarkers] - Archives-only intro markers.
  */
 export default function EventLog({
     events,
@@ -42,9 +61,21 @@ export default function EventLog({
     onHoverEvent,
     railRef,
     layout = 'grid',
+    introMarkers = [],
 }) {
     const [sortOrder, toggleSortOrder] = useEventLogSort(initialSortOrder);
-    const groups = groupEventsByDay(events ?? [], {
+    // Tag intro markers with `start_time` (their `time`) so they flow through
+    // the same day-grouping/sort path as events; `__intro` distinguishes them
+    // at render time. Empty `introMarkers` → the rows array is just `events`,
+    // preserving the homepage's exact output.
+    const rows =
+        introMarkers.length === 0 ?
+            (events ?? [])
+        :   [
+                ...(events ?? []),
+                ...introMarkers.map((m) => ({ ...m, __intro: true, start_time: m.time })),
+            ];
+    const groups = groupEventsByDay(rows, {
         // useEventLogSort constrains sortOrder to 'desc' | 'asc'
         sortOrder: /** @type {'desc' | 'asc'} */ (sortOrder),
     });
@@ -77,7 +108,11 @@ export default function EventLog({
                         ref={railRef}
                     >
                         {groups.map((group) => {
-                            const { wins, losses } = countOutcomes(group.events);
+                            // Intro markers carry no win/loss outcome; count
+                            // only real events for the day summary.
+                            const { wins, losses } = countOutcomes(
+                                group.events.filter((row) => !row.__intro),
+                            );
                             return (
                                 <Fragment key={group.date}>
                                     <div className="event-log-day">
@@ -92,7 +127,16 @@ export default function EventLog({
                                             )}
                                         </div>
                                         <div className="event-log-day-grid">
-                                            {group.events.map((event) => {
+                                            {group.events.map((row) => {
+                                                if (row.__intro) {
+                                                    return (
+                                                        <IntroMarker
+                                                            key={`intro-${row.enemy}`}
+                                                            marker={row}
+                                                        />
+                                                    );
+                                                }
+                                                const event = row;
                                                 const key = eventKey(event);
                                                 return (
                                                     <div
@@ -126,5 +170,32 @@ export default function EventLog({
                 }
             </div>
         </section>
+    );
+}
+
+/**
+ * A synthetic "faction enters the war" divider, interleaved among the event
+ * rows on /archives only. Faction-colored via the `--color-faction-*` theme
+ * tokens (resolved from the enemy id's slug). Static — no interactivity, so no
+ * umami tracking is needed.
+ *
+ * @param {object} props - Component props.
+ * @param {{enemy:number, name:string, day:number}} props.marker - One `buildIntroMarkers` entry.
+ */
+function IntroMarker({ marker }) {
+    const slug = FACTION_SLUG_BY_ID[marker.enemy] ?? 'bugs';
+    return (
+        <div
+            className="event-log-intro"
+            style={
+                // CSS custom property — cast past React.CSSProperties' typed keys.
+                /** @type {React.CSSProperties} */ ({
+                    '--intro-color': `var(--color-faction-${slug})`,
+                })
+            }
+        >
+            <span className="event-log-intro-day">Day {marker.day}</span>
+            <span className="event-log-intro-label">{marker.name} enter the war</span>
+        </div>
     );
 }


### PR DESCRIPTION
Closes #157.

## What
Surfaces **when each faction entered the war** on the `/archives` Event Log — synthetic "*\<Faction\> enter the war*" markers interleaved chronologically with the event rows. Archives-only; the live dashboard is untouched. (The map-reveal half of #157 already works via `computeMapStateAtEvent`; this adds the timeline half.)

## How
- **`buildIntroMarkers(data)`** — pure helper → one marker per faction with a positive `introduction_order` slot **and** a non-null `first_seen`. Day math + article-strip mirror `buildWarNarrative`; reduce-min `war_start` fallback; missing data → `[]`.
- **`EventLog`** — opt-in `introMarkers` prop (default `[]`). Markers flow through the same day-group/sort path (tagged `start_time`), render as a faction-colored `IntroMarker` divider (`--color-faction-*`), keyed `intro-${enemy}`, excluded from the day W/L count.
- **`ArchivesClient`** computes + passes the markers.

## Live-dashboard safety (the key risk)
`EventLog` has two call sites: `HomeClient` (live) and `ArchivesClient` (archives). **HomeClient passes no `introMarkers`** → defaults to `[]` → `rows = events ?? []` and no row carries `__intro`, so grouping, outcome-counting, and rendering are all byte-identical to before. A new `EventLog` test asserts default-vs-empty render produces identical `innerHTML`.

## Sample marker
```html
<div class="event-log-intro" style="--intro-color:var(--color-faction-illuminate)">
  <span class="event-log-intro-day">Day 4</span>
  <span class="event-log-intro-label">Illuminate enter the war</span>
</div>
```

## Verification
✅ lint · typecheck · test:unit (**1518**, +16) · build — all pass (node 24). Reviewed: confirmed `FACTION_SLUG_BY_ID` resolves and the 2 EventLog call sites keep the live view unaffected.

## ⚠️ Hold before merge
- **No DevTools visual check** — the worktree has no running dev server; the marker-divider styling should be eyeballed on `/archives` once merged (or I can run a visual pass).
- Both this and #274 (PR #446) touch `ArchivesClient.jsx` in nearby spots — trivial/auto-mergeable, but merge order may need a glance.
- Merge after v0.60.0 dust settles; bumps the next version on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)