### PR TITLE
Release v0.65.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.65.3
+
+### Fixed
+
+- **React hydration mismatch (#418) for non-en-US visitors**. `formatNumber`
+  grouped thousands with a bare `toLocaleString()`, so values in the 1K–999K
+  range rendered per the *runtime* locale: the server emitted `"3,522"` while a
+  ru-RU client re-rendered `"3 522"`. The differing text tripped React error
+  #418 on every affected page load (14 events on 0.65.2 in a single day, all
+  from non-en-US locales), forcing React to discard and re-render the
+  server-rendered tree on the client. The locale is now pinned to `en-US`,
+  matching every other formatter in the codebase and the server default.
+
+- **Post-deploy chunk auto-reload never fired.** Two independent faults, both
+  surfaced by ChunkLoadErrors on 0.65.2 from real users on `/archives` and
+  `/sign-in`:
+    - The detection predicate tested `err.message || err.name`, but a real
+      `ChunkLoadError` carries the identifying token in `name` while `message`
+      is `"Failed to load chunk X from module Y"`. The non-empty message
+      short-circuited away the only field that matched, so nothing was ever
+      recognized as a chunk error. Detection now tests name and message
+      together, and the Turbopack message wording is matched explicitly.
+    - The only trigger was an `unhandledrejection` listener, but Next/React
+      catch these internally and report them as *handled* exceptions — every
+      observed production ChunkLoadError arrived that way. A Sentry
+      `beforeSend` hook now covers every reporting path; the listener is kept
+      as the fallback for when no DSN is configured.
+  Detection is extracted to `src/shared/utils/isChunkError.mjs` with unit
+  coverage pinned to the verbatim production error shape.
+
 ## 0.65.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@
   server-rendered tree on the client. The locale is now pinned to `en-US`,
   matching every other formatter in the codebase and the server default.
 
+- **Post-deploy chunk auto-reload never fired.** Two independent faults, both
+  surfaced by ChunkLoadErrors on 0.65.2 from real users on `/archives` and
+  `/sign-in`:
+    - The detection predicate tested `err.message || err.name`, but a real
+      `ChunkLoadError` carries the identifying token in `name` while `message`
+      is `"Failed to load chunk X from module Y"`. The non-empty message
+      short-circuited away the only field that matched, so nothing was ever
+      recognized as a chunk error. Detection now tests name and message
+      together, and the Turbopack message wording is matched explicitly.
+    - The only trigger was an `unhandledrejection` listener, but Next/React
+      catch these internally and report them as *handled* exceptions — every
+      observed production ChunkLoadError arrived that way. A Sentry
+      `beforeSend` hook now covers every reporting path; the listener is kept
+      as the fallback for when no DSN is configured.
+  Detection is extracted to `src/shared/utils/isChunkError.mjs` with unit
+  coverage pinned to the verbatim production error shape.
+
 ## 0.65.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **React hydration mismatch (#418) for non-en-US visitors**. `formatNumber`
+  grouped thousands with a bare `toLocaleString()`, so values in the 1K–999K
+  range rendered per the *runtime* locale: the server emitted `"3,522"` while a
+  ru-RU client re-rendered `"3 522"`. The differing text tripped React error
+  #418 on every affected page load (14 events on 0.65.2 in a single day, all
+  from non-en-US locales), forcing React to discard and re-render the
+  server-rendered tree on the client. The locale is now pinned to `en-US`,
+  matching every other formatter in the codebase and the server default.
+
 ## 0.65.2
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.65.2",
+    "version": "0.65.3",
     "private": true,
     "type": "module",
     "scripts": {

--- a/src/__tests__/unit/features/stats/StatGrid.test.jsx
+++ b/src/__tests__/unit/features/stats/StatGrid.test.jsx
@@ -75,13 +75,12 @@ describe('StatGrid', () => {
             expect(screen.getByText('35')).toBeInTheDocument();
         });
 
-        // formatNumber uses num.toLocaleString() without a locale argument for
-        // values 1K-999K, so the thousands separator is locale-dependent.
-        // Use a tolerant regex so this test survives non-en-US CI environments.
-        test('shows kills total with locale-tolerant separator', () => {
+        // formatNumber pins en-US grouping (a comma) for values 1K-999K so SSR
+        // and client render identical text \u2014 see formatNumber.mjs.
+        test('shows kills total with en-US thousands separator', () => {
             render(<StatGrid live={mockLive} faction="global" events={mockEvents} />);
-            // 500+1000+750 = 2,250 / 2.250 / 2 250 / 2\u202f250 depending on locale
-            expect(screen.getByText(/2[,.\s\u202f\u00a0]250/)).toBeInTheDocument();
+            // 500+1000+750 = 2,250
+            expect(screen.getByText('2,250')).toBeInTheDocument();
         });
 
         test('shows win/loss counts on the merged EVENTS card', () => {

--- a/src/__tests__/unit/shared/utils/isChunkError.test.mjs
+++ b/src/__tests__/unit/shared/utils/isChunkError.test.mjs
@@ -1,0 +1,44 @@
+import { isChunkError } from '@/shared/utils/isChunkError.mjs';
+
+describe('isChunkError', () => {
+    test('matches the ChunkLoadError shape seen in production', () => {
+        // Verbatim from GlitchTip HELLDIVERSBOT-2K (0.65.2).
+        const err = new Error(
+            'Failed to load chunk /_next/static/chunks/2avgbxs8eufgs.js?dpl=0-65-2 from module 964893',
+        );
+        err.name = 'ChunkLoadError';
+        expect(isChunkError(err)).toBe(true);
+    });
+
+    test('matches the other post-deploy import failure shapes', () => {
+        expect(isChunkError('Failed to fetch dynamically imported module: /x.js')).toBe(
+            true,
+        );
+        expect(isChunkError(new Error('error loading dynamically imported module'))).toBe(
+            true,
+        );
+        expect(isChunkError(new Error('Importing a module script failed.'))).toBe(true);
+    });
+
+    test('matches on name even when message is non-empty and non-matching', () => {
+        // Regression: the predicate used `message || name`, so a non-empty
+        // message short-circuited away the `name` that actually identified the
+        // error — the auto-reload never fired for real production chunk errors.
+        const err = new Error('totally unrelated wording');
+        err.name = 'ChunkLoadError';
+        expect(isChunkError(err)).toBe(true);
+    });
+
+    test('ignores unrelated errors', () => {
+        expect(isChunkError(new Error('Minified React error #418'))).toBe(false);
+        expect(isChunkError(new TypeError('x is not a function'))).toBe(false);
+        expect(isChunkError('POSTGRES_URL is not set')).toBe(false);
+    });
+
+    test('tolerates empty and non-error values', () => {
+        expect(isChunkError(null)).toBe(false);
+        expect(isChunkError(undefined)).toBe(false);
+        expect(isChunkError('')).toBe(false);
+        expect(isChunkError({})).toBe(false);
+    });
+});

--- a/src/__tests__/unit/shared/utils/utils.test.mjs
+++ b/src/__tests__/unit/shared/utils/utils.test.mjs
@@ -7,10 +7,10 @@ describe('formatNumber', () => {
         expect(formatNumber(999)).toBe('999');
     });
 
-    test('thousands use locale string', () => {
-        expect(formatNumber(1000)).toBe(Number(1000).toLocaleString());
-        expect(formatNumber(1500)).toBe(Number(1500).toLocaleString());
-        expect(formatNumber(999999)).toBe(Number(999999).toLocaleString());
+    test('thousands use en-US grouping (pinned to avoid SSR hydration mismatch)', () => {
+        expect(formatNumber(1000)).toBe('1,000');
+        expect(formatNumber(1500)).toBe('1,500');
+        expect(formatNumber(999999)).toBe('999,999');
     });
 
     test('values from 1M up use the M suffix with one decimal', () => {

--- a/src/instrumentation-client.js
+++ b/src/instrumentation-client.js
@@ -4,6 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { guardedReload } from '@/shared/utils/reloadGuard.mjs';
+import { isChunkError } from '@/shared/utils/isChunkError.mjs';
 import { registerSwErrorBridge } from '@/shared/utils/swErrorBridge.mjs';
 
 Sentry.init({
@@ -19,6 +20,20 @@ Sentry.init({
     tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
     tunnel: '/api/glitchtip',
     debug: false,
+    // A client that outlived a deploy requests chunk URLs the new build no longer
+    // serves. Next/React catch most of those internally and report them as
+    // *handled* exceptions (mechanism `generic`), so they never reach the
+    // `unhandledrejection` listener below — every observed production
+    // ChunkLoadError arrived this way, meaning the auto-reload never fired.
+    // beforeSend is the one place every reporting path passes through.
+    // Deferred a tick so the event is queued for transport before we navigate;
+    // guardedReload's circuit breaker (3 reloads / 30s) bounds the retry.
+    beforeSend(event, hint) {
+        if (isChunkError(hint?.originalException)) {
+            setTimeout(() => guardedReload('chunk'), 0);
+        }
+        return event;
+    },
 });
 
 // Forward errors postMessage'd from the service worker (push handler etc.)
@@ -27,14 +42,10 @@ registerSwErrorBridge();
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
 
-const CHUNK_ERROR_RE =
-    /ChunkLoadError|Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i;
-
+// Retained as the fallback path: with no DSN configured Sentry never runs
+// beforeSend, and genuinely unhandled chunk rejections still need the reload.
 window.addEventListener('unhandledrejection', (event) => {
-    const reason = event.reason;
-    const msg =
-        typeof reason === 'string' ? reason : reason?.message || reason?.name || '';
-    if (CHUNK_ERROR_RE.test(msg)) {
+    if (isChunkError(event.reason)) {
         guardedReload('chunk');
     }
 });

--- a/src/shared/utils/format/formatNumber.mjs
+++ b/src/shared/utils/format/formatNumber.mjs
@@ -12,6 +12,10 @@ export function formatNumber(n) {
     // M suffix from 1M up — a 7-digit grouped number ("3,522,088") overflows
     // the stat cards, so anything >= 1M collapses to "X.XM".
     if (num >= 1_000_000) return (num / 1_000_000).toFixed(1) + 'M';
-    if (num >= 1_000) return num.toLocaleString();
+    // Pin the locale: a bare toLocaleString() groups per the runtime locale, so
+    // the server (en-US) and a non-en-US client (e.g. ru-RU → "3 522") produce
+    // different text, causing a React hydration mismatch (#418). en-US matches
+    // every other formatter in the codebase and the server default.
+    if (num >= 1_000) return num.toLocaleString('en-US');
     return String(num);
 }

--- a/src/shared/utils/isChunkError.mjs
+++ b/src/shared/utils/isChunkError.mjs
@@ -1,0 +1,25 @@
+// Matches the several shapes a "stale client requested a chunk the new build no
+// longer serves" failure takes across bundlers and browsers. `Failed to load
+// chunk` is Turbopack's wording and is listed explicitly so a serialized error
+// that lost its `name` (e.g. one relayed over the service-worker bridge) still
+// matches on message alone.
+const CHUNK_ERROR_RE =
+    /ChunkLoadError|Failed to load chunk|Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i;
+
+/**
+ * True when the given thrown value looks like a post-deploy chunk load failure.
+ * @param {unknown} err - Thrown value, rejection reason, or message string
+ * @returns {boolean}
+ */
+export function isChunkError(err) {
+    if (!err) return false;
+    if (typeof err === 'string') return CHUNK_ERROR_RE.test(err);
+    // Test name AND message, never `message || name`: a real ChunkLoadError
+    // carries the identifying token in `name` while `message` is the
+    // non-matching "Failed to load chunk X from module Y", so short-circuiting
+    // on a non-empty message silently skipped the only field that matched.
+    const { name = '', message = '' } = /** @type {{name?: string, message?: string}} */ (
+        err
+    );
+    return CHUNK_ERROR_RE.test(`${name} ${message}`);
+}


### PR DESCRIPTION
Release **v0.65.3** — two production bugfixes surfaced by GlitchTip now that browser-side error reporting works (fixed in 0.65.2).

## Fixed

### React #418 hydration mismatch for all non-en-US visitors
`formatNumber` grouped thousands with a bare `toLocaleString()`, so values in the 1K–999K range rendered per the *runtime* locale — the server emitted `"3,522"` while a ru-RU client re-rendered `"3 522"`. The differing text tripped React error #418 on every affected page load, forcing React to discard and re-render the server-rendered tree on the client.

14 events in a single day on 0.65.2, all from non-en-US locales, all on `/`. Locale is now pinned to `en-US`, matching every other formatter in the codebase and the server default.

### Post-deploy chunk auto-reload never fired
Two independent faults, both surfaced by ChunkLoadErrors from real users on `/archives` and `/sign-in`:

- The detection predicate tested `err.message || err.name`, but a real `ChunkLoadError` carries the identifying token in `name` while `message` is `"Failed to load chunk X from module Y"`. The non-empty message short-circuited away the only field that matched, so nothing was ever recognized as a chunk error.
- The only trigger was an `unhandledrejection` listener, but Next/React catch these internally and report them as *handled* exceptions (mechanism `generic`) — every observed production ChunkLoadError arrived that way. A Sentry `beforeSend` hook now covers every reporting path; the listener is kept as the fallback for when no DSN is configured.

Detection is extracted to `src/shared/utils/isChunkError.mjs` with unit coverage pinned to the verbatim production error shape.

## Verification

All four gates green on the merged tree:

- `npm run lint` — 0 errors (2 pre-existing warnings in untouched files)
- `npm run typecheck` — clean
- `npm run test:unit` — 1598 passed (162 files)
- `npm run build` — compiled successfully

No migrations in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)