### PR TITLE
Release v0.90.5

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -84,7 +84,22 @@ jobs:
               with:
                   context: .
                   file: ./Dockerfile.migrate
-                  platforms: linux/amd64,linux/arm64
+                  # amd64 only — NOT an oversight. `prisma generate` dies under
+                  # QEMU aarch64 emulation with `qemu: uncaught target signal 4
+                  # (Illegal instruction)`, exit 132: Prisma's engine binary uses
+                  # instructions QEMU doesn't implement. The amd64 leg of the same
+                  # build succeeds. Adding arm64 here (8b5b2058, two hours after
+                  # v0.67.1 was tagged) was speculative prep for the Pi swarm and
+                  # broke the first release that tried it — v0.90.4, where the app
+                  # image published fine and this one failed, leaving no migrate
+                  # image for the tag.
+                  #
+                  # The app image (Dockerfile.app) still builds both arches; only
+                  # Prisma is affected. To restore arm64 here, the QEMU problem has
+                  # to be solved first — newer binfmt (`docker/setup-qemu-action`
+                  # with `image: tonistiigi/binfmt:latest`) or a native arm64
+                  # runner — and verified on a real tag, not assumed.
+                  platforms: linux/amd64
                   push: true
                   tags: |
                       ghcr.io/${{ github.repository_owner }}/helldiversbot-migrate:${{ github.ref_name }}

--- a/.github/workflows/staging.docker.yml
+++ b/.github/workflows/staging.docker.yml
@@ -66,7 +66,9 @@ jobs:
               with:
                   context: .
                   file: ./Dockerfile.migrate
-                  platforms: linux/amd64,linux/arm64
+                  # amd64 only — see the matching comment in release.docker.yml.
+                  # `prisma generate` SIGILLs under QEMU aarch64 (exit 132).
+                  platforms: linux/amd64
                   push: true
                   tags: |
                       ghcr.io/${{ github.repository_owner }}/helldiversbot-migrate:staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.90.5
+
+### Fixed
+
+- **The migrate image is built for amd64 only again — v0.90.4's release build
+  failed without it.** `prisma generate` dies under QEMU aarch64 emulation with
+  `qemu: uncaught target signal 4 (Illegal instruction)` (exit 132); Prisma's
+  engine binary uses instructions QEMU does not implement. The amd64 leg of the
+  same build succeeds and generates the client fine.
+
+  arm64 was added to `build-migrate` in 8b5b2058, two hours after v0.67.1 was
+  tagged, as prep for the Pi swarm — so **v0.90.4 was the first release that
+  ever attempted it**, and it broke: the app image published for both arches,
+  the migrate image published for none, and `github-release` was skipped. Every
+  previously published migrate image (v0.67.1, v0.65.3, v0.65.2) is amd64-only,
+  so this restores the configuration that has shipped every release to date
+  rather than inventing a new one.
+
+  The app image still builds amd64 + arm64 — only Prisma is affected. Restoring
+  arm64 for migrate needs the QEMU problem solved first (newer binfmt via
+  `tonistiigi/binfmt:latest`, or a native arm64 runner) and verified on a real
+  tag.
+
 ## 0.90.4
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The migrate image is built for amd64 only again — v0.90.4's release build
+  failed without it.** `prisma generate` dies under QEMU aarch64 emulation with
+  `qemu: uncaught target signal 4 (Illegal instruction)` (exit 132); Prisma's
+  engine binary uses instructions QEMU does not implement. The amd64 leg of the
+  same build succeeds and generates the client fine.
+
+  arm64 was added to `build-migrate` in 8b5b2058, two hours after v0.67.1 was
+  tagged, as prep for the Pi swarm — so **v0.90.4 was the first release that
+  ever attempted it**, and it broke: the app image published for both arches,
+  the migrate image published for none, and `github-release` was skipped. Every
+  previously published migrate image (v0.67.1, v0.65.3, v0.65.2) is amd64-only,
+  so this restores the configuration that has shipped every release to date
+  rather than inventing a new one.
+
+  The app image still builds amd64 + arm64 — only Prisma is affected. Restoring
+  arm64 for migrate needs the QEMU problem solved first (newer binfmt via
+  `tonistiigi/binfmt:latest`, or a native arm64 runner) and verified on a real
+  tag.
+
 ## 0.90.4
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.90.4",
+    "version": "0.90.5",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Follow-up to [#498](https://github.com/elfensky/helldivers.bot/pull/498). v0.90.4 tagged but did **not** produce a complete release.

## What went wrong with v0.90.4

`build-app` succeeded and pushed `ghcr.io/elfensky/helldiversbot:v0.90.4` for both amd64 and arm64. `build-migrate` failed, so no migrate image exists for that tag and `github-release` was skipped.

Cause: `prisma generate` dies under QEMU aarch64 emulation —

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
exit code: 132
```

The amd64 leg of the same build succeeds (`✔ Generated Prisma Client (7.9.1) in 142ms`). Prisma's engine binary uses instructions QEMU does not implement.

arm64 was added to `build-migrate` in 8b5b2058 — two hours *after* v0.67.1 was tagged — as Pi-swarm prep, so **v0.90.4 was the first release that ever exercised it**. Every migrate image previously published (v0.67.1, v0.65.3, v0.65.2) is amd64-only. This restores that configuration rather than inventing a new one.

The app image keeps amd64 + arm64. Only Prisma is affected.

## Verification

`npm run lint`, `npm run typecheck`, `npm run test:unit` (1930 tests), `npm run build` — pass. The build uploads sourcemaps cleanly (`Successfully uploaded source maps to Sentry`).

One caveat reported honestly: during one run a single test failed, but I did not capture which one, and it has not reproduced across 8 subsequent full runs. Worth watching CI here.

## After merge

Tag `v0.90.5` — that build should produce **both** images plus the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)