### PR TITLE
chore(deploy): point staging at its own database

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,9 +15,14 @@
 
 - Swarm stack `helldiversbot`, services `helldiversbot_app` / `helldiversbot_cloudflared`, 1 replica, `:staging` image (multi-arch, pulls
   anonymously from GHCR — the packages are public, no registry auth needed).
-- Connected to the **dev** Postgres on huginn (`10.0.0.40:5432/helldiversbot`) via the
-  `staging_postgres_url` Swarm secret. Schema was already current (52/52 migrations).
-- `worker: true` — the poller runs and writes `worker_heartbeat` in that DB.
+- Connected to the **staging** Postgres on huginn (`10.0.0.40:5433/helldiversbot_staging` on the
+  `db-staging` cluster) via the `helldiversbot_database_url` Swarm secret — no longer the dev
+  instance on `:5432`. Loaded from a filtered production dump: all 52 migrations plus the `h1_*`
+  game tables, with `User`/`Account`/`Session`/`ApiKey` deliberately restored **empty** (the dump
+  carried real users' plaintext Google and Discord OAuth tokens).
+- `worker: true` — the poller runs and writes `worker_heartbeat` in that DB. After the cutover this
+  is the thing to check: laptop and swarm no longer share that row, so if the swarm is still writing
+  to the dev database the secret did not take.
 - Auth/Umami/Sentry unset on purpose: the app degrades gracefully and OAuth callbacks need a
   real hostname anyway.
 
@@ -45,7 +50,7 @@ The repo is **public**, so Git Sync needs no token — and nothing secret may en
 ## Swarm secrets (external — create once, on a manager, out of band)
 
 ```sh
-printf '%s' "$POSTGRES_URL"     | docker secret create helldiversbot_postgres_url -
+printf '%s' "$POSTGRES_URL"     | docker secret create helldiversbot_database_url -
 printf '%s' "$UPDATE_KEY"       | docker secret create helldiversbot_update_key -
 printf '%s' "$CF_TUNNEL_TOKEN"  | docker secret create helldiversbot_cloudflared -
 ```

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -13,7 +13,7 @@
 #   docker stack deploy -c deploy/staging/compose.yaml helldiversbot
 #
 # Prereqs — external Swarm secrets, created once on a manager (see deploy/README.md):
-#   helldiversbot_postgres_url    secret   Postgres connection string
+#   helldiversbot_database_url    secret   Postgres connection string
 #   helldiversbot_update_key      secret   API key for the update endpoint
 #   helldiversbot_cloudflared     secret   Cloudflare Tunnel token (remotely-managed)
 #
@@ -40,7 +40,7 @@ networks:
         driver: overlay
 
 secrets:
-    helldiversbot_postgres_url:
+    helldiversbot_database_url:
         external: true
     helldiversbot_update_key:
         external: true
@@ -63,10 +63,15 @@ services:
             # The app reads secrets from files via the `*_FILE` convention
             # (src/shared/utils/hydrateFileSecrets.mjs): if POSTGRES_URL_FILE is set,
             # it populates POSTGRES_URL from that file before Prisma reads it.
-            POSTGRES_URL_FILE: /run/secrets/helldiversbot_postgres_url
+            # Points at the STAGING database (db-staging on huginn,
+            # 10.0.0.40:5433/helldiversbot_staging) — no longer the dev
+            # instance on :5432. The secret is named *_database_url to match
+            # the [appname]_[secretName] convention; the env var stays
+            # POSTGRES_URL_FILE because that is what the app reads.
+            POSTGRES_URL_FILE: /run/secrets/helldiversbot_database_url
             UPDATE_KEY_FILE: /run/secrets/helldiversbot_update_key
         secrets:
-            - helldiversbot_postgres_url
+            - helldiversbot_database_url
             - helldiversbot_update_key
         # Auth is deliberately unconfigured: initializeEnv treats a missing
         # BETTER_AUTH_SECRET as "auth disabled" and warns. Add the auth vars


### PR DESCRIPTION
Ends the one genuinely risky thing about this staging tier: it has been sharing the **development** database with the laptop, including a single `worker_heartbeat` row. That made it a poor place to rehearse anything dangerous — a rehearsed migration landed on the database the laptop develops against.

## What changes

`staging.helldivers.bot` now uses **`helldiversbot_staging`** on **`db-staging`** (huginn `10.0.0.40:5433`), a Postgres cluster dedicated to the staging tier, separate from the dev instance on `:5432`.

Cross-database isolation is enforced and **verified**, not assumed: `helldiversbot_user` reaches `helldiversbot_staging` and is refused by `descent_staging`; `descent_user` the reverse.

The secret is renamed `helldiversbot_postgres_url` → `helldiversbot_database_url` to match the `[appname]_[secretName]` convention the swarm settled on. The env var stays `POSTGRES_URL_FILE` — that is what the app actually reads, and renaming it would be an app change for no gain.

## The data, and what was deliberately left out

Loaded from a filtered **production** dump: all 52 migrations plus the `h1_*` game tables — 43,086 `h1_status`, 29,862 `h1_statistic`, 19,707 `h1_event_progress`, 6,060 `h1_event`, 160 `h1_season`. 15 tables, 8 foreign keys, counts verified against the source.

`User`, `Account`, `Session` and `ApiKey` were restored **empty**. The dump carried 12 real users' rows, and `Account.accessToken` is a plain `@db.Text` column with no encryption anywhere in `src/` — so those rows contained **live Google (`ya29.…`) and Discord OAuth tokens belonging to people who are not the operator**. Copying them into a second internet-reachable system widens where other people's credentials live, for no testing benefit. Schema is created for every table; only that data is withheld.

`push_subscription` was already empty in production, which is worth checking on this app every single time: every instance fans notifications out to every row in that table, so a populated staging copy would page real users.

## After merge

Arcane Git Sync redeploys on the commit change, so `helldiversbot_app` restarts onto the new database. **Check `worker_heartbeat` afterwards** — laptop and swarm no longer share that row, so if the swarm is still writing to the dev database, the secret did not take. Rollback is `git revert`; do not `docker service update` this by hand, Git Sync is the writer.

`helldiversbot_postgres_url` (the old dev-pointing secret) is left in place and simply becomes unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
