### PR TITLE
chore(deploy): let CI pin the staging image tag for Git Sync

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -18,15 +18,15 @@ on:
         types: [completed]
         branches: [develop]
 
-# Never cancel: deploy-staging runs `docker stack deploy` against a live swarm,
-# and killing that mid-flight leaves the stack half-converged. A second merge
-# to develop queues behind the first instead.
+# Never cancel: bump-staging-tag commits to develop, and two runs racing on
+# that push is a failed push for nothing. A second merge to develop queues
+# behind the first instead.
 concurrency:
     group: build-staging
     cancel-in-progress: false
 
-# Read-only by default; the jobs that touch GHCR say so themselves. This used
-# to grant `contents: write` workflow-wide — nothing here writes contents.
+# Read-only by default; the jobs that touch GHCR say so themselves, and only
+# bump-staging-tag gets `contents: write`.
 permissions:
     contents: read
 
@@ -128,6 +128,7 @@ jobs:
                   registry-token: ${{ secrets.GITHUB_TOKEN }}
                   tags: |
                       ghcr.io/${{ github.repository_owner }}/helldiversbot:staging
+                      ghcr.io/${{ github.repository_owner }}/helldiversbot:sha-${{ env.TESTED_SHA }}
                   build-args: |
                       NODE_ENV=production
                       NEXT_PUBLIC_DEPLOY_ENV=staging
@@ -141,76 +142,48 @@ jobs:
                       sentry_org=${{ secrets.SENTRY_ORG }}
                       sentry_project=${{ secrets.SENTRY_PROJECT }}
 
-    # ⚠️ DRAFT / UNTESTED until a self-hosted runner exists on a Pi swarm manager.
-    # GitHub's cloud runners cannot reach the home-LAN cluster; this job runs on
-    # the runner installed there. See deploy/README.md for the open TODOs.
-    deploy-staging:
-        name: Deploy to Staging
-        needs: [build-app, build-migrate]
-        # DORMANT until the swarm + self-hosted runner exist. Flip repo variable
-        # STAGING_DEPLOY_ENABLED=true to activate (without it the job skips cleanly
-        # instead of hanging "pending" waiting for a runner that isn't there).
-        # Runs even when build-migrate was skipped — the existing :staging migrate
-        # image is reused. Skips if the app build failed.
-        if: ${{ !cancelled() && needs.build-app.result == 'success' && vars.STAGING_DEPLOY_ENABLED == 'true' }}
-        runs-on: self-hosted
-        # The convergence wait alone can take 5 minutes (30 × 10s).
-        timeout-minutes: 20
+    # The deploy itself is Arcane Git Sync (deploy/README.md): Arcane polls
+    # develop and redeploys the stack when the commit changes. A rebuilt
+    # floating `:staging` tag is invisible to it, so the only thing this job
+    # has to do is write the immutable tag into the compose and commit.
+    #
+    # GITHUB_TOKEN pushes never trigger workflows (GitHub's recursion guard),
+    # `[skip ci]` is belt and braces. No rebase-retry on a push race: the run
+    # fails visibly and the next merge to develop re-bumps.
+    #
+    # Gated on "no migration in this merge": the swarm is arm64 and the
+    # migrate image is amd64-only (see build-migrate), and a cloud runner
+    # cannot reach the LAN database anyway — so a merge that carries a
+    # migration must be migrated by hand first, then bumped by hand.
+    bump-staging-tag:
+        name: Bump Staging Tag
+        needs: [detect-migration, build-app]
+        if: ${{ !cancelled() && needs.build-app.result == 'success' }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
         permissions:
-            contents: read
-            packages: read # docker pull from GHCR
+            contents: write
         steps:
-            - name: Checkout code
+            - name: Migration in this merge — not bumping
+              if: needs.detect-migration.outputs.migrate == 'true'
+              run: |
+                  echo "::warning title=staging not bumped::${TESTED_SHA} touches prisma/ — run helldiversbot-migrate:staging against the staging DB from an amd64 host, then set image to :sha-${TESTED_SHA} in deploy/staging/compose.yaml and commit."
+
+            - name: Checkout develop
+              if: needs.detect-migration.outputs.migrate != 'true'
               uses: actions/checkout@v7.0.1
               with:
-                  ref: ${{ env.TESTED_SHA }}
+                  ref: develop
 
-            - name: Log in to GHCR
-              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-            - name: Maintenance banner ON (optional — skipped if Kuma unset)
-              if: ${{ vars.KUMA_URL != '' }}
+            - name: Pin the tested image and commit
+              if: needs.detect-migration.outputs.migrate != 'true'
               run: |
-                  npm i socket.io-client@4 --no-save --silent
-                  node .github/scripts/kuma-maintenance.mjs start
-              env:
-                  KUMA_URL: ${{ vars.KUMA_URL }}
-                  KUMA_USERNAME: ${{ secrets.KUMA_USERNAME }}
-                  KUMA_PASSWORD: ${{ secrets.KUMA_PASSWORD }}
-                  KUMA_MONITOR_IDS: ${{ vars.KUMA_STAGING_MONITOR_IDS }}
-
-            - name: Run migrations (one-shot, before the stack)
-              run: |
-                  docker pull ghcr.io/${{ github.repository_owner }}/helldiversbot-migrate:staging
-                  docker run --rm \
-                    -e POSTGRES_URL="${{ secrets.STAGING_POSTGRES_URL }}" \
-                    -e FORCE_SEED="${{ vars.FORCE_SEED }}" \
-                    ghcr.io/${{ github.repository_owner }}/helldiversbot-migrate:staging
-
-            - name: Deploy the stack
-              run: |
-                  docker pull ghcr.io/${{ github.repository_owner }}/helldiversbot:staging
-                  docker stack deploy --with-registry-auth -c deploy/stack.staging.yml helldivers
-
-            - name: Wait for the app service to converge (healthy)
-              run: |
-                  for i in $(seq 1 30); do
-                    reps=$(docker service ls --filter name=helldivers_app --format '{{.Replicas}}')
-                    echo "helldivers_app: ${reps:-pending}"
-                    [ "$reps" = "1/1" ] && exit 0
-                    sleep 10
-                  done
-                  echo "::error::app service did not converge"; docker service ps helldivers_app --no-trunc; exit 1
-
-            - name: Maintenance banner OFF (always)
-              if: ${{ always() && vars.KUMA_URL != '' }}
-              run: |
-                  npm i socket.io-client@4 --no-save --silent
-                  node .github/scripts/kuma-maintenance.mjs end
-              env:
-                  KUMA_URL: ${{ vars.KUMA_URL }}
-                  KUMA_USERNAME: ${{ secrets.KUMA_USERNAME }}
-                  KUMA_PASSWORD: ${{ secrets.KUMA_PASSWORD }}
+                  sed -i -E "s#^(\s*image: ghcr\.io/[^/]+/helldiversbot:).*#\1sha-${TESTED_SHA}#" deploy/staging/compose.yaml
+                  git diff --exit-code --quiet deploy/staging/compose.yaml && { echo "already pinned"; exit 0; }
+                  git config user.name github-actions[bot]
+                  git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+                  git commit -am "chore(deploy): staging → sha-${TESTED_SHA:0:12} [skip ci]"
+                  git push origin develop
 
     cleanup:
         name: Cleanup Untagged Images

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -178,7 +178,7 @@ jobs:
             - name: Pin the tested image and commit
               if: needs.detect-migration.outputs.migrate != 'true'
               run: |
-                  sed -i -E "s#^(\s*image: ghcr\.io/[^/]+/helldiversbot:).*#\1sha-${TESTED_SHA}#" deploy/staging/compose.yaml
+                  sed -i -E "s#^([[:space:]]*image: ghcr\.io/[^/]+/helldiversbot:).*#\1sha-${TESTED_SHA}#" deploy/staging/compose.yaml
                   git diff --exit-code --quiet deploy/staging/compose.yaml && { echo "already pinned"; exit 0; }
                   git config user.name github-actions[bot]
                   git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,8 +1,9 @@
 # Staging deploy — helldivers.bot on the Pi swarm
 
-**Status: deployed manually, CI path still unwired.** `staging/compose.yaml` is live on the
-3-Pi swarm (Arcane Git Sync (manual fallback: `docker stack deploy -c deploy/staging/compose.yaml helldivers`)). The
-`deploy-staging` job in `../.github/workflows/build-staging.yml` has still never run.
+**Status: live, deployed by Git Sync.** `staging/compose.yaml` is the stack on the 3-Pi swarm;
+Arcane applies it on every commit to `develop`, and CI writes that commit (`bump-staging-tag` in
+`../.github/workflows/build-staging.yml`). Manual fallback if Arcane is down:
+`docker stack deploy -c deploy/staging/compose.yaml helldiversbot`.
 
 ## What's live (2026-08-25)
 
@@ -13,8 +14,9 @@
   not in this repo.
 - No published ports. The old LAN `:50001` is gone.
 
-- Swarm stack `helldiversbot`, services `helldiversbot_app` / `helldiversbot_cloudflared`, 1 replica, `:staging` image (multi-arch, pulls
-  anonymously from GHCR — the packages are public, no registry auth needed).
+- Swarm stack `helldiversbot`, services `helldiversbot_app` / `helldiversbot_cloudflared`, 1 replica, image pinned to
+  `:sha-<commit>` by CI (multi-arch, pulls anonymously from GHCR — the packages are public, no
+  registry auth needed).
 - Connected to the **staging** Postgres on huginn (`10.0.0.40:5433/helldiversbot_staging` on the
   `db-staging` cluster) via the `helldiversbot_database_url` Swarm secret — no longer the dev
   instance on `:5432`. Loaded from a filtered production dump: all 52 migrations plus the `h1_*`
@@ -47,6 +49,13 @@ second copy alongside the first rather than renaming anything.
 
 The repo is **public**, so Git Sync needs no token — and nothing secret may enter the compose file.
 
+**Git Sync redeploys on commit change, not on image change.** A rebuilt floating `:staging` tag
+produces no commit, so Arcane would never see it. That is why CI (`bump-staging-tag` in
+`build-staging.yml`) rewrites the `image:` line to the immutable `:sha-<commit>` tag and commits
+it to `develop` after every green build — the commit is the deploy trigger, and `git revert` of
+that commit is the rollback. Do not `docker service update --force` the stack by hand; that is
+the second writer this setup exists to remove.
+
 ## Swarm secrets (external — create once, on a manager, out of band)
 
 ```sh
@@ -68,36 +77,30 @@ The app reads both as files via the `*_FILE` convention
 ## Known gaps
 
 1. **`helldiversbot-migrate:staging` is amd64-only** (`platforms: linux/amd64` in
-   `build-staging.yml`), so it cannot run on the arm64 Pis. Either make that build multi-arch
-   like the app image, or keep running migrations from an amd64 host. Blocking for any
-   automated deploy that has to migrate.
-2. **Own staging database.** It currently points at the *dev* DB, which means laptop and
-   swarm share one database and one worker table. Give staging its own role + database on
-   huginn per the vault handbook before this counts as a real staging tier.
-3. **Floating image tag vs Git Sync.** The compose pins `:staging`, a moving tag — so a new
-   build produces no commit, and Arcane (which redeploys on commit change) will not pick it up.
-   Per `50-ci-cd`, CI should rewrite the tag in this file and commit; until it does, a new
-   `:staging` image needs a manual `docker service update --force helldivers_app`.
-4. **No self-hosted runner** on a Pi manager, so `deploy-staging` (`runs-on: self-hosted`) has
-   nowhere to run. It stays dormant until repo variable `STAGING_DEPLOY_ENABLED=true`.
-5. **Kuma maintenance banner** (`../.github/scripts/kuma-maintenance.mjs`) unverified —
-   Socket.IO event shapes vary by version. Leave `vars.KUMA_URL` unset and it skips cleanly.
-6. **The app cannot be scaled past 1 replica.** `src/shared/utils/initializeWorker.mjs` spawns a
-   cron worker thread on every instance with no advisory lock and no leader election anywhere in
-   `src/` — so N replicas means N pollers hitting the API and racing on the same rows. This is a
-   correctness limit, not a capacity one. `cloudflared` has no such constraint: connectors are
-   stateless and Cloudflare load-balances across them, hence 2 replicas there. Fix is to split the
-   poller into its own 1-replica service; then the web app scales freely.
+   `build-staging.yml`) — `prisma generate` SIGILLs under QEMU arm64 (exit 132), so it is not a
+   one-line fix; a native arm64 runner leg would be needed. Until then it cannot run on the Pis:
+   run it from an amd64 host, and note that `bump-staging-tag` deliberately skips any merge that
+   touches `prisma/` (see § How it is deployed).
+2. **No self-hosted runner** in the LAN (elfensky/helldivers.bot#474). With Git Sync as the
+   writer a runner is no longer needed to *deploy*; it is needed only to run migrations against
+   the LAN database and to take the maintenance banner up/down around a deploy — the shape in
+   the vault's `50-ci-cd`. Until it exists, migrations are a manual one-shot.
+3. **Kuma maintenance banner** (`../.github/scripts/kuma-maintenance.mjs`) unverified —
+   Socket.IO event shapes vary by version. Unused until a runner exists.
+4. **The app cannot be scaled past 1 replica** — every instance also *is* the poller, and
+   `checkAndNotify()` diffs against in-memory state, so N replicas means N× duplicate push
+   notifications. A correctness limit, not a capacity one; `cloudflared` has no such constraint
+   (stateless connectors, hence 2 replicas). Tracked as #516 (bug) / #517 (lease-based fix).
 
-## Intended CI flow (once 1-4 are done)
+## CI flow (live)
 
 ```
-push to develop
-  → build :staging images (cloud runners, multi-arch)
-  → deploy-staging (self-hosted runner on a Pi manager):
-       kuma banner ON (optional)
-       docker run --rm migrate:staging        # migrations, BEFORE the stack (Swarm ignores depends_on)
-       docker stack deploy stack.staging.yml   # start-first + healthcheck + rollback
-       wait for helldivers_app = 1/1
-       kuma banner OFF (always)
+merge to develop
+  → Check: CI green
+  → Build: Staging
+       build :staging + :sha-<commit> app image (multi-arch)
+       bump-staging-tag: pin :sha-<commit> in deploy/staging/compose.yaml, commit [skip ci]
+         (skipped with a warning when the merge touches prisma/ — migrate by hand first)
+  → Arcane Git Sync (polls every 5 min) sees the commit → redeploys the stack
+       start-first + image healthcheck + rollback on failure
 ```

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -32,8 +32,15 @@
 # dashboard, not in this file. Routing changes are made there.
 #
 # Migrations are NOT a service here — Swarm ignores `depends_on`. Run the
-# migrate image as a one-shot BEFORE deploying. It is amd64-only today, so it
-# cannot run on the Pis; run it from an amd64 host. See deploy/README.md.
+# migrate image as a one-shot BEFORE deploying. It is amd64-only (prisma
+# generate SIGILLs under QEMU arm64), so it cannot run on the Pis; run it
+# from an amd64 host. See deploy/README.md.
+#
+# The `image:` line below is written by CI (bump-staging-tag in
+# build-staging.yml): every green develop build pins `:sha-<commit>` here and
+# commits, and that commit is what Git Sync redeploys on. A merge that
+# carries a migration is NOT bumped automatically — migrate by hand, then pin
+# the tag by hand. Rollback is `git revert` of the bump commit.
 
 networks:
     internal:
@@ -49,6 +56,8 @@ secrets:
 
 services:
     app:
+        # Rewritten by CI to :sha-<commit> — see the header. `:staging` only
+        # until the first bump lands.
         image: ghcr.io/elfensky/helldiversbot:staging
         networks: [internal]
         environment:


### PR DESCRIPTION
Git Sync redeploys on **commit** change, so a rebuilt floating `:staging` tag never reached the swarm (gap 3 in `deploy/README.md`). This closes it the way `50-ci-cd` describes:

- `build-app` also pushes `:sha-<commit>`.
- New `bump-staging-tag` job (cloud runner, `contents: write`) rewrites the `image:` line in `deploy/staging/compose.yaml` to `:sha-<commit>` and commits `[skip ci]` to `develop`. Arcane picks the commit up on its next 5-min poll. Rollback = `git revert` the bump.
- Skipped with a `::warning` when the merge touches `prisma/`: the migrate image is amd64-only (`prisma generate` SIGILLs under QEMU arm64) and a cloud runner cannot reach the LAN DB, so a migrating merge is migrated by hand first, then pinned by hand.
- Drops the dormant `deploy-staging` job — it targeted `deploy/stack.staging.yml` / stack `helldivers` (neither exists) from a runner that does not exist, and would have been the second writer Git Sync removes. The runner question stays #474, scoped down to migrations + banner.
- README: staging is on its own DB (#518), gaps renumbered, live flow documented.

Verified: workflow YAML parses; the `sed` was dry-run locally; `npm run lint` 0 errors (322 pre-existing warnings). typecheck/test/build not run — no source changes.

First real exercise is this PR's own merge: expect a bot commit on `develop` pinning `sha-<merge>` and `helldiversbot_app` moving to it within ~5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)