### PR TITLE
feat(deploy): app ×3 behind the service VIP — the lease decides who polls

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,17 +14,22 @@ Arcane applies it on every commit to `develop`, and CI writes that commit (`bump
   not in this repo.
 - No published ports. The old LAN `:50001` is gone.
 
-- Swarm stack `helldiversbot`, services `helldiversbot_app` / `helldiversbot_cloudflared`, 1 replica, image pinned to
-  `:sha-<commit>` by CI (multi-arch, pulls anonymously from GHCR — the packages are public, no
-  registry auth needed).
+- Swarm stack `helldiversbot`: `helldiversbot_app` ×3 (soft-spread across nodes) and
+  `helldiversbot_cloudflared` ×2, image pinned to `:sha-<commit>` by CI (multi-arch, pulls
+  anonymously from GHCR — the packages are public, no registry auth needed). Load balancing is the
+  Swarm service VIP: cloudflared targets `http://app:3000` and Swarm spreads new connections across
+  the replicas (per connection, not per request — cloudflared pools keep-alives).
 - Connected to the **staging** Postgres on huginn (`10.0.0.40:5433/helldiversbot_staging` on the
   `db-staging` cluster) via the `helldiversbot_database_url` Swarm secret — no longer the dev
   instance on `:5432`. Loaded from a filtered production dump: all 52 migrations plus the `h1_*`
   game tables, with `User`/`Account`/`Session`/`ApiKey` deliberately restored **empty** (the dump
   carried real users' plaintext Google and Discord OAuth tokens).
-- `worker: true` — the poller runs and writes `worker_heartbeat` in that DB. After the cutover this
-  is the thing to check: laptop and swarm no longer share that row, so if the swarm is still writing
-  to the dev database the secret did not take.
+- Every replica runs the cron thread, but only the lease holder polls (`src/update/lease.mjs`,
+  #517): `worker_heartbeat.holder_id` names it, `lease_until` is renewed every poll (60 s TTL), and
+  the others answer `200 { role: 'standby' }`. The admin dashboard's "Poller" card shows the host.
+  Kill the holder's task and the row moves to another replica within ~1 min, carrying
+  `prev_events` / `last_season_observed` with it. Staging sets no `VAPID_*`, so push dedup is not
+  observable here — what staging proves is single-holder polling and handover.
 - Auth/Umami/Sentry unset on purpose: the app degrades gracefully and OAuth callbacks need a
   real hostname anyway.
 
@@ -87,10 +92,11 @@ The app reads both as files via the `*_FILE` convention
    the vault's `50-ci-cd`. Until it exists, migrations are a manual one-shot.
 3. **Kuma maintenance banner** (`../.github/scripts/kuma-maintenance.mjs`) unverified —
    Socket.IO event shapes vary by version. Unused until a runner exists.
-4. **The app cannot be scaled past 1 replica** — every instance also *is* the poller, and
-   `checkAndNotify()` diffs against in-memory state, so N replicas means N× duplicate push
-   notifications. A correctness limit, not a capacity one; `cloudflared` has no such constraint
-   (stateless connectors, hence 2 replicas). Tracked as #516 (bug) / #517 (lease-based fix).
+4. **A network partition can briefly yield two holders.** A node cut off from the managers keeps
+   its task running; its lease expires and another replica claims it, and until the partitioned
+   node reconnects both poll. Bounded by the partition length; power loss (this cluster's actual
+   failure mode) does not do this — the task is simply dead. Acceptable for staging; a fencing
+   token on writes would close it if it ever matters.
 
 ## CI flow (live)
 

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -54,10 +54,19 @@ secrets:
     helldiversbot_cloudflared:
         external: true
 
+# One service, N replicas, exactly one poller: every replica runs the cron
+# thread, but each poll must claim the lease row in worker_heartbeat first
+# (src/update/lease.mjs, #517). Postgres serialises the claim, so one instance
+# does the work and the rest answer "standby". A dead holder is replaced
+# within the 60 s TTL with no election. The poller's state lives in the same
+# row, so a handover neither misses nor duplicates a transition.
+#
+# Because of that, no placement constraint and no separate worker service:
+# `docker service scale` is safe at any N.
+
 services:
     app:
-        # Rewritten by CI to :sha-<commit> — see the header. `:staging` only
-        # until the first bump lands.
+        # Rewritten by CI to :sha-<commit> — see the header.
         image: ghcr.io/elfensky/helldiversbot:sha-1049d41d4650e0760336d1da175a7600b0b14d26
         networks: [internal]
         environment:
@@ -68,7 +77,7 @@ services:
             # os.hostname(), which in a container is the container ID — so the
             # server_name tag in GlitchTip changes on every redeploy instead of
             # naming the node the task landed on.
-            SENTRY_SERVER_NAME: '{{.Node.Hostname}}'
+            SENTRY_SERVER_NAME: '{{.Node.Hostname}}-{{.Task.Slot}}'
             # The app reads secrets from files via the `*_FILE` convention
             # (src/shared/utils/hydrateFileSecrets.mjs): if POSTGRES_URL_FILE is set,
             # it populates POSTGRES_URL from that file before Prisma reads it.
@@ -89,8 +98,22 @@ services:
         #
         # Healthcheck is baked into the image (GET /api/healthcheck -> 503 when the
         # DB is unreachable, 200 healthy), so start-first rollout gates on real health.
+        # cloudflared reaches http://app:3000 — the service VIP — and Swarm
+        # spreads NEW connections across every healthy replica (per TCP
+        # connection, not per request; cloudflared pools keep-alives, so the
+        # spread is lumpy). That IS the load balancing; nothing on the
+        # Cloudflare side knows there are three.
+        #
+        # Soft spread, NOT `max_replicas_per_node: 1`: the hard cap plus
+        # start-first never converges on a 3-node swarm — the replacement task
+        # has no node, sits Pending, and Pending is not a failure so rollback
+        # never fires (moby/moby#40797). The preference puts one per node when
+        # three are up and doubles up on a live node when one is down.
         deploy:
-            replicas: 1
+            replicas: 3
+            placement:
+                preferences:
+                    - spread: node.id
             update_config:
                 order: start-first
                 failure_action: rollback


### PR DESCRIPTION
Reworked after #522 (the Postgres lease, #517): **no `worker` service, no `WORKER_ENABLED`, no placement cap.** All three replicas run the poller code; the lease row decides which one actually polls, and a dead holder is replaced within 60 s.

- `app: replicas: 3` with `placement.preferences: spread: node.id` — a soft spread, not `max_replicas_per_node: 1`, because the hard cap plus `start-first` never converges on a 3-node swarm (moby/moby#40797).
- `SENTRY_SERVER_NAME: '{{.Node.Hostname}}-{{.Task.Slot}}'` so three replicas are distinguishable.
- README: what staging proves (single-holder polling + handover) and what it can't (push dedup — no `VAPID_*`).

**Merge order:** only after #522 is merged, the staging DB migrated, and the tag pinned to the lease image. Merging before that puts three lease-less replicas up = three pollers.

Verified: parses with `docker stack config` on swarm01 (read-only). Not deployed.

Expected after merge: `helldiversbot_app` 3/3, one `holder_id` in `worker_heartbeat`, two replicas answering `standby`, and `docker service ps` showing the holder's task killed → another host in `holder_id` within ~1 min with `prev_events` carried over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)