### PR TITLE
feat(worker): poller lease in Postgres — N replicas, exactly one polls (#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.93.0
+
+### Added
+
+- Poller lease in Postgres (#517): every replica runs the cron thread, but on
+  each poll it must claim the `worker_heartbeat` row (`holder_id`,
+  `lease_until`, 60 s TTL) — one conditional `INSERT … ON CONFLICT DO UPDATE`
+  that Postgres serialises, so exactly one instance polls and a dead holder is
+  replaced within the TTL with no election and no manual step. The poller's
+  state (`prev_events`, `last_season_observed`) lives in the same row, so a
+  new holder inherits the previous snapshot instead of starting blind: a
+  transition across a handover is neither missed nor sent twice. Standby
+  replicas answer `200 { role: 'standby' }` and touch nothing. The admin
+  dashboard shows which host holds the lease.
+
+### Changed
+
+- `checkAndNotify(prevEvents)` takes its baseline as an argument and returns
+  the current snapshot; the module-level `prevEvents` is gone. The route's
+  module-level `lastSeasonObserved` is gone likewise. Heartbeat writes are
+  holder-guarded `updateMany`s, never an unconditional upsert.
+
 ## 0.92.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.92.0",
+    "version": "0.93.0",
     "private": true,
     "license": "AGPL-3.0-only",
     "type": "module",

--- a/prisma/migrations/20260827140000_worker_heartbeat_lease/migration.sql
+++ b/prisma/migrations/20260827140000_worker_heartbeat_lease/migration.sql
@@ -1,0 +1,6 @@
+-- Poller lease (#517): who polls, until when, and the state a successor inherits.
+ALTER TABLE "worker_heartbeat"
+    ADD COLUMN "holder_id" TEXT,
+    ADD COLUMN "lease_until" TIMESTAMP(3),
+    ADD COLUMN "prev_events" JSONB,
+    ADD COLUMN "last_season_observed" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,12 +235,18 @@ model push_subscription {
 
 // #region WORKER HEALTH
 model worker_heartbeat {
-    worker_type      String   @id
-    last_beat        DateTime
-    poll_duration_ms Int?
-    last_error       String?
-    started_at       DateTime
-    updated_at       DateTime @updatedAt
+    worker_type          String    @id
+    last_beat            DateTime
+    poll_duration_ms     Int?
+    last_error           String?
+    started_at           DateTime
+    updated_at           DateTime  @updatedAt
+    // Poller lease (#517): who polls, until when, and the state a successor
+    // inherits — see src/update/lease.mjs.
+    holder_id            String?
+    lease_until          DateTime?
+    prev_events          Json?
+    last_season_observed Int?
 }
 
 // #endregion

--- a/src/__tests__/unit/app/api/h1/update/route.test.mjs
+++ b/src/__tests__/unit/app/api/h1/update/route.test.mjs
@@ -10,10 +10,26 @@ vi.mock('@/update/season', () => ({ updateSeason: vi.fn() }));
 vi.mock('@/update/pushNotifier', () => ({
     checkAndNotify: vi.fn().mockResolvedValue(undefined),
 }));
+// The lease decides whether this instance is the poller. Default: held, fresh
+// state — the shape a single-instance deploy sees on its first poll.
+vi.mock('@/update/lease.mjs', () => ({
+    HOLDER_ID: 'test-host:1:abcd',
+    claimLease: vi.fn().mockResolvedValue({ prevEvents: null, lastSeasonObserved: null }),
+    persistPollerState: vi.fn().mockResolvedValue(undefined),
+}));
+import { claimLease, persistPollerState } from '@/update/lease.mjs';
+import { after } from 'next/server';
+import { checkAndNotify } from '@/update/pushNotifier';
 
 describe('GET /api/h1/update', () => {
     beforeEach(() => {
         vi.stubEnv('UPDATE_KEY', 'test-secret-key');
+        // Mocks are reset between tests; restore the "lease held, fresh state"
+        // default so the holder path is what these tests exercise.
+        vi.mocked(claimLease).mockResolvedValue({
+            prevEvents: null,
+            lastSeasonObserved: null,
+        });
     });
 
     afterEach(() => {
@@ -62,6 +78,54 @@ describe('GET /api/h1/update', () => {
         expectErrorEnvelope(await res.json(), { code: 403 });
         expect(updateStatus).not.toHaveBeenCalled();
         expect(updateSeason).not.toHaveBeenCalled();
+    });
+
+    test('standby replica (lease not acquired) answers 200 and does no work', async () => {
+        vi.mocked(claimLease).mockResolvedValueOnce(null);
+        const req = new Request('http://localhost/api/h1/update', {
+            headers: { Authorization: 'Bearer test-secret-key' },
+        });
+        const res = await GET(req);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expectSuccessEnvelope(body, { code: 200 });
+        expect(body.data.role).toBe('standby');
+        expect(updateStatus).not.toHaveBeenCalled();
+        expect(updateSeason).not.toHaveBeenCalled();
+        expect(checkAndNotify).not.toHaveBeenCalled();
+        expect(persistPollerState).not.toHaveBeenCalled();
+    });
+
+    test('holder diffs against the prevEvents from the lease row and persists the new snapshot', async () => {
+        const prev = [{ event_id: 1, status: 'active' }];
+        const next = [{ event_id: 1, status: 'success' }];
+        vi.mocked(claimLease).mockResolvedValueOnce({
+            prevEvents: prev,
+            lastSeasonObserved: 5,
+        });
+        vi.mocked(checkAndNotify).mockResolvedValueOnce(next);
+        vi.mocked(updateStatus).mockResolvedValue({ season: 5, time: 1000 });
+        vi.mocked(updateSeason).mockResolvedValue({});
+        // `after` is a no-op stub globally; run the deferred work here so the
+        // notify + persist step is observable.
+        let deferred;
+        vi.mocked(after).mockImplementation((fn) => {
+            deferred = fn();
+        });
+
+        const req = new Request('http://localhost/api/h1/update', {
+            headers: { Authorization: 'Bearer test-secret-key' },
+        });
+        const res = await GET(req);
+        await deferred;
+        expect(res.status).toBe(200);
+        expect(checkAndNotify).toHaveBeenCalledWith(prev);
+        expect(persistPollerState).toHaveBeenCalledWith('test-host:1:abcd', {
+            prevEvents: next,
+        });
+        expect(persistPollerState).toHaveBeenCalledWith('test-host:1:abcd', {
+            lastSeasonObserved: 5,
+        });
     });
 
     test('returns 200 with correct key and update data', async () => {
@@ -152,26 +216,14 @@ describe('GET /api/h1/update', () => {
 });
 
 describe('GET /api/h1/update — season transition detection', () => {
-    // The route keeps `lastSeasonObserved` as module-level state to detect
-    // season transitions across polls. These tests reset the route module
-    // between cases via vi.resetModules() so each test starts with a clean
-    // null state.
-
-    let transitionUpdateStatus;
-    let transitionUpdateSeason;
-    let transitionGET;
-
-    beforeEach(async () => {
-        vi.resetModules();
+    // The previous season lives in the lease row (worker_heartbeat), not in
+    // the process — a fresh holder inherits it from the row it just claimed.
+    beforeEach(() => {
         vi.stubEnv('UPDATE_KEY', 'test-secret-key');
-        // Re-import after reset so we get fresh mock instances bound to the
-        // re-imported route module.
-        const statusModule = await import('@/update/status');
-        const seasonModule = await import('@/update/season');
-        const routeModule = await import('@/app/api/h1/update/route');
-        transitionUpdateStatus = statusModule.updateStatus;
-        transitionUpdateSeason = seasonModule.updateSeason;
-        transitionGET = routeModule.GET;
+        vi.mocked(claimLease).mockResolvedValue({
+            prevEvents: null,
+            lastSeasonObserved: null,
+        });
     });
 
     afterEach(() => {
@@ -183,70 +235,54 @@ describe('GET /api/h1/update — season transition detection', () => {
             headers: { Authorization: 'Bearer test-secret-key' },
         });
 
-    test('runs closing pass on outgoing season when current season is higher', async () => {
-        vi.mocked(transitionUpdateStatus)
-            .mockResolvedValueOnce({ season: 156, time: 1000 })
-            .mockResolvedValueOnce({ season: 157, time: 1010 });
-        vi.mocked(transitionUpdateSeason).mockResolvedValue({ season: 0 });
-
-        // Poll 1: no prior observation, no closing pass, only current-season call
-        await transitionGET(makeReq());
-        expect(transitionUpdateSeason).toHaveBeenCalledTimes(1);
-        expect(transitionUpdateSeason).toHaveBeenNthCalledWith(1, 156, {
-            protectedBucket: 900,
+    test('runs closing pass on outgoing season when current season is higher than the row says', async () => {
+        vi.mocked(claimLease).mockResolvedValueOnce({
+            prevEvents: null,
+            lastSeasonObserved: 156,
         });
+        vi.mocked(updateStatus).mockResolvedValueOnce({ season: 157, time: 1010 });
+        vi.mocked(updateSeason).mockResolvedValue({ season: 0 });
 
-        // Poll 2: prior was 156, current is 157 — closing pass (no opts) THEN current season (with protectedBucket)
-        await transitionGET(makeReq());
-        expect(transitionUpdateSeason).toHaveBeenCalledTimes(3);
-        expect(transitionUpdateSeason).toHaveBeenNthCalledWith(2, 156); // closing pass — no protectedBucket
-        expect(transitionUpdateSeason).toHaveBeenNthCalledWith(3, 157, {
-            protectedBucket: 900,
+        await GET(makeReq());
+        expect(updateSeason).toHaveBeenCalledTimes(2);
+        expect(updateSeason).toHaveBeenNthCalledWith(1, 156); // closing pass — no protectedBucket
+        expect(updateSeason).toHaveBeenNthCalledWith(2, 157, { protectedBucket: 900 });
+        expect(persistPollerState).toHaveBeenCalledWith('test-host:1:abcd', {
+            lastSeasonObserved: 157,
         });
     });
 
-    test('does not run closing pass when season stays the same across polls', async () => {
-        vi.mocked(transitionUpdateStatus)
-            .mockResolvedValueOnce({ season: 157, time: 1000 })
-            .mockResolvedValueOnce({ season: 157, time: 1010 });
-        vi.mocked(transitionUpdateSeason).mockResolvedValue({ season: 0 });
+    test('no closing pass when the row has no prior season (fresh lease) or the season is unchanged', async () => {
+        vi.mocked(claimLease)
+            .mockResolvedValueOnce({ prevEvents: null, lastSeasonObserved: null })
+            .mockResolvedValueOnce({ prevEvents: null, lastSeasonObserved: 157 });
+        vi.mocked(updateStatus).mockResolvedValue({ season: 157, time: 1000 });
+        vi.mocked(updateSeason).mockResolvedValue({ season: 0 });
 
-        await transitionGET(makeReq());
-        await transitionGET(makeReq());
+        await GET(makeReq());
+        await GET(makeReq());
 
-        expect(transitionUpdateSeason).toHaveBeenCalledTimes(2);
-        expect(transitionUpdateSeason).toHaveBeenNthCalledWith(1, 157, {
-            protectedBucket: 900,
-        });
-        expect(transitionUpdateSeason).toHaveBeenNthCalledWith(2, 157, {
-            protectedBucket: 900,
-        });
+        expect(updateSeason).toHaveBeenCalledTimes(2);
+        expect(updateSeason).toHaveBeenNthCalledWith(1, 157, { protectedBucket: 900 });
+        expect(updateSeason).toHaveBeenNthCalledWith(2, 157, { protectedBucket: 900 });
     });
 
     test('closing pass failure is non-fatal and current season still processes', async () => {
-        vi.mocked(transitionUpdateStatus)
-            .mockResolvedValueOnce({ season: 156, time: 1000 })
-            .mockResolvedValueOnce({ season: 157, time: 1010 });
-        vi.mocked(transitionUpdateSeason)
-            .mockResolvedValueOnce({ season: 0 }) // poll 1 current
-            .mockRejectedValueOnce(new Error('closing pass API error')) // poll 2 closing
-            .mockResolvedValueOnce({ season: 0 }); // poll 2 current
-
+        vi.mocked(claimLease).mockResolvedValueOnce({
+            prevEvents: null,
+            lastSeasonObserved: 156,
+        });
+        vi.mocked(updateStatus).mockResolvedValueOnce({ season: 157, time: 1010 });
+        vi.mocked(updateSeason)
+            .mockRejectedValueOnce(new Error('closing pass API error'))
+            .mockResolvedValueOnce({ season: 0 });
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-        await transitionGET(makeReq());
-        const res2 = await transitionGET(makeReq());
-
-        // Current season update still succeeded
-        expect(res2.status).toBe(200);
-        expect(transitionUpdateSeason).toHaveBeenCalledTimes(3);
-        // Closing pass for 156 logged the failure
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Closing pass for season 156 failed'),
-            expect.any(String),
-        );
-
+        const res = await GET(makeReq());
+        expect(res.status).toBe(200);
+        expect(updateSeason).toHaveBeenCalledTimes(2);
+        expect(updateSeason).toHaveBeenNthCalledWith(2, 157, { protectedBucket: 900 });
         consoleErrorSpy.mockRestore();
         consoleLogSpy.mockRestore();
     });

--- a/src/__tests__/unit/update/lease.test.mjs
+++ b/src/__tests__/unit/update/lease.test.mjs
@@ -1,0 +1,64 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import db from '@/db/db';
+import {
+    claimLease,
+    persistPollerState,
+    HOLDER_ID,
+    WORKER_TYPE,
+} from '@/update/lease.mjs';
+
+describe('claimLease', () => {
+    beforeEach(() => {
+        vi.mocked(db.$queryRaw).mockReset();
+        vi.mocked(db.$queryRaw).mockResolvedValue([]);
+    });
+
+    test('returns the persisted poller state when the row comes back (lease held)', async () => {
+        const prev = [{ event_id: 1, status: 'active' }];
+        vi.mocked(db.$queryRaw).mockResolvedValue([
+            { holder_id: 'h1', prev_events: prev, last_season_observed: 156 },
+        ]);
+        const state = await claimLease('h1');
+        expect(state).toEqual({ prevEvents: prev, lastSeasonObserved: 156 });
+    });
+
+    test('returns null when no row comes back (another instance holds the lease)', async () => {
+        vi.mocked(db.$queryRaw).mockResolvedValue([]);
+        expect(await claimLease('h1')).toBeNull();
+    });
+
+    test('a fresh row has null state, not undefined', async () => {
+        vi.mocked(db.$queryRaw).mockResolvedValue([
+            { holder_id: 'h1', prev_events: null, last_season_observed: null },
+        ]);
+        expect(await claimLease('h1')).toEqual({
+            prevEvents: null,
+            lastSeasonObserved: null,
+        });
+    });
+
+    test('HOLDER_ID names this process (hostname + pid) so the dashboard can show who polls', () => {
+        expect(HOLDER_ID).toContain(String(process.pid));
+        expect(HOLDER_ID.split(':').length).toBeGreaterThanOrEqual(3);
+    });
+});
+
+describe('persistPollerState', () => {
+    test('writes only through a holder-guarded updateMany, never an unconditional upsert', async () => {
+        const prev = [{ event_id: 2, status: 'success' }];
+        await persistPollerState('h1', { prevEvents: prev, lastSeasonObserved: 157 });
+        expect(db.worker_heartbeat.updateMany).toHaveBeenCalledWith({
+            where: { worker_type: WORKER_TYPE, holder_id: 'h1' },
+            data: { prev_events: prev, last_season_observed: 157 },
+        });
+        expect(db.worker_heartbeat.upsert).not.toHaveBeenCalled();
+    });
+
+    test('omits fields that were not supplied', async () => {
+        await persistPollerState('h1', { lastSeasonObserved: 3 });
+        expect(db.worker_heartbeat.updateMany).toHaveBeenLastCalledWith({
+            where: { worker_type: WORKER_TYPE, holder_id: 'h1' },
+            data: { last_season_observed: 3 },
+        });
+    });
+});

--- a/src/__tests__/unit/update/pushNotifier.test.mjs
+++ b/src/__tests__/unit/update/pushNotifier.test.mjs
@@ -519,7 +519,7 @@ describe('checkAndNotify', () => {
         expect(dbModule.push_subscription.findMany).not.toHaveBeenCalled();
     });
 
-    test('first call (prevEvents=null) ESTABLISHES baseline — does NOT detect changes or send', async () => {
+    test('prevEvents=null ESTABLISHES baseline — no diff, no send — and returns the snapshot', async () => {
         const dbModule = (await import('@/db/db')).default;
         const events = [
             { event_id: 1, status: 'active', enemy: 0, region: 5, type: 'defend' },
@@ -528,18 +528,14 @@ describe('checkAndNotify', () => {
         const { detectChanges } = await import('@/shared/utils/game/detectChanges.mjs');
         const { checkAndNotify } = await import('@/update/pushNotifier');
 
-        await checkAndNotify();
+        const result = await checkAndNotify(null);
 
-        // detectChanges is NOT called on the first run — we just snapshot.
         expect(detectChanges).not.toHaveBeenCalled();
         expect(dbModule.push_subscription.findMany).not.toHaveBeenCalled();
+        expect(result).toEqual(events);
     });
 
-    test('second call: detectChanges is invoked with (prevEvents, currentEvents) in that order', async () => {
-        // Strengthened from "called once" to also assert the actual args:
-        // baseline events FIRST, then the new snapshot. A regression that
-        // swaps the order would still get "called once" but compare the
-        // wrong snapshots.
+    test('with prevEvents: detectChanges is invoked with (prevEvents, currentEvents) in that order', async () => {
         const dbModule = (await import('@/db/db')).default;
         const events1 = [
             { event_id: 1, status: 'active', enemy: 0, region: 5, type: 'defend' },
@@ -547,22 +543,37 @@ describe('checkAndNotify', () => {
         const events2 = [
             { event_id: 1, status: 'active', enemy: 0, region: 5, type: 'defend' },
         ];
-        dbModule.h1_season.findFirst
-            .mockResolvedValueOnce({ events: events1 })
-            .mockResolvedValueOnce({ events: events2 });
+        dbModule.h1_season.findFirst.mockResolvedValueOnce({ events: events2 });
         const { detectChanges } = await import('@/shared/utils/game/detectChanges.mjs');
-        detectChanges.mockReturnValue([]); // No changes between calls.
+        detectChanges.mockReturnValue([]);
         const { checkAndNotify } = await import('@/update/pushNotifier');
 
-        await checkAndNotify(); // baseline
-        await checkAndNotify(); // diff against baseline → no changes
+        const result = await checkAndNotify(events1);
 
         expect(detectChanges).toHaveBeenCalledTimes(1);
         expect(detectChanges).toHaveBeenCalledWith(events1, events2);
         expect(dbModule.push_subscription.findMany).not.toHaveBeenCalled();
+        expect(result).toEqual(events2);
     });
 
-    test('second call WITH changes: fetches subs and sends one batch per change', async () => {
+    test('state is NOT kept in the module: two calls with prevEvents=null never diff', async () => {
+        // The whole point of #517 — a fresh holder must get its baseline from the
+        // lease row, and a module variable would silently re-introduce per-process state.
+        const dbModule = (await import('@/db/db')).default;
+        const events = [
+            { event_id: 1, status: 'active', enemy: 0, region: 5, type: 'defend' },
+        ];
+        dbModule.h1_season.findFirst.mockResolvedValue({ events });
+        const { detectChanges } = await import('@/shared/utils/game/detectChanges.mjs');
+        const { checkAndNotify } = await import('@/update/pushNotifier');
+
+        await checkAndNotify(null);
+        await checkAndNotify(null);
+
+        expect(detectChanges).not.toHaveBeenCalled();
+    });
+
+    test('with changes: fetches subs and sends one batch per change', async () => {
         const dbModule = (await import('@/db/db')).default;
         const webpush = (await import('web-push')).default;
         const events1 = [
@@ -571,10 +582,7 @@ describe('checkAndNotify', () => {
         const events2 = [
             { event_id: 1, status: 'success', enemy: 0, region: 5, type: 'defend' },
         ];
-
-        dbModule.h1_season.findFirst
-            .mockResolvedValueOnce({ events: events1 })
-            .mockResolvedValueOnce({ events: events2 });
+        dbModule.h1_season.findFirst.mockResolvedValueOnce({ events: events2 });
         dbModule.push_subscription.findMany.mockResolvedValue([
             { endpoint: 'e1', keys_p256dh: 'p1', keys_auth: 'a1' },
         ]);
@@ -586,8 +594,7 @@ describe('checkAndNotify', () => {
         webpush.sendNotification.mockResolvedValue({ statusCode: 201 });
 
         const { checkAndNotify } = await import('@/update/pushNotifier');
-        await checkAndNotify(); // baseline
-        await checkAndNotify(); // diff → changes → send
+        await checkAndNotify(events1);
 
         // findMany called ONCE (not per change — it's outside the changes loop).
         expect(dbModule.push_subscription.findMany).toHaveBeenCalledTimes(1);
@@ -603,10 +610,7 @@ describe('checkAndNotify', () => {
         const events2 = [
             { event_id: 1, status: 'success', enemy: 0, region: 5, type: 'defend' },
         ];
-
-        dbModule.h1_season.findFirst
-            .mockResolvedValueOnce({ events: events1 })
-            .mockResolvedValueOnce({ events: events2 });
+        dbModule.h1_season.findFirst.mockResolvedValueOnce({ events: events2 });
         const { detectChanges } = await import('@/shared/utils/game/detectChanges.mjs');
         detectChanges.mockReturnValue([{ kind: 'event_won', event: events2[0] }]);
         dbModule.push_subscription.findMany.mockRejectedValue(
@@ -617,8 +621,7 @@ describe('checkAndNotify', () => {
         webpush.sendNotification.mockClear();
 
         const { checkAndNotify } = await import('@/update/pushNotifier');
-        await checkAndNotify();
-        await expect(checkAndNotify()).resolves.toBeUndefined();
+        await expect(checkAndNotify(events1)).resolves.toEqual(events2);
 
         expect(errSpy).toHaveBeenCalledWith(
             'Failed to fetch push subscriptions:',
@@ -635,19 +638,15 @@ describe('checkAndNotify', () => {
         const events2 = [
             { event_id: 1, status: 'success', enemy: 0, region: 5, type: 'defend' },
         ];
-
-        dbModule.h1_season.findFirst
-            .mockResolvedValueOnce({ events: events1 })
-            .mockResolvedValueOnce({ events: events2 });
+        dbModule.h1_season.findFirst.mockResolvedValueOnce({ events: events2 });
+        dbModule.push_subscription.findMany.mockResolvedValue([]);
         const { detectChanges } = await import('@/shared/utils/game/detectChanges.mjs');
         detectChanges.mockReturnValue([{ kind: 'event_won', event: events2[0] }]);
-        dbModule.push_subscription.findMany.mockResolvedValue([]);
         const webpush = (await import('web-push')).default;
         webpush.sendNotification.mockClear();
 
         const { checkAndNotify } = await import('@/update/pushNotifier');
-        await checkAndNotify();
-        await checkAndNotify();
+        await checkAndNotify(events1);
 
         expect(webpush.sendNotification).not.toHaveBeenCalled();
     });

--- a/src/app/api/h1/update/route.js
+++ b/src/app/api/h1/update/route.js
@@ -14,6 +14,7 @@ import { checkAndNotify } from '@/update/pushNotifier.mjs';
 import { computeBucket } from '@/shared/utils/bucketing.mjs';
 import { cleanupRateLimitWindows } from '@/shared/utils/api/rateLimit.mjs';
 import { isWorkerEnabled } from '@/shared/utils/initializeWorker.mjs';
+import { HOLDER_ID, claimLease, persistPollerState } from '@/update/lease.mjs';
 
 // Custom header set on the very first poll of a worker session so the
 // handler can run a one-time startup pass (e.g. backfill missing seasons).
@@ -23,16 +24,12 @@ import { isWorkerEnabled } from '@/shared/utils/initializeWorker.mjs';
 // match what `request.headers.get(...)` normalises to.
 export const WORKER_STARTUP_HEADER = 'x-worker-startup';
 
-// Tracks the season observed on the previous worker poll so we can detect
-// a season transition and run one final updateSeason() pass on the outgoing
-// season. HD1 writes a final "closing" snapshot to the old season a few
-// minutes after the transition point — without this detection, the worker
-// moves on to the new season before that closing frame is published and it
-// never lands in h1_status. Resets to null on worker restart; the only
-// impact of a restart during the tiny transition window is that the closing
-// snapshot for that single transition is missed, which the admin can recover
-// via the /archives refresh button.
-let lastSeasonObserved = null;
+// The season observed on the previous poll (to detect a transition and run
+// one closing updateSeason() pass on the outgoing season — HD1 writes a final
+// snapshot a few minutes after the transition) and the previous event
+// snapshot (push-notification baseline) both live in the lease row, not in
+// this process — see src/update/lease.mjs (#517). A holder that just took
+// over inherits them, so a transition across a handover is not missed.
 
 // Throttle for the rate-limit window cleanup. The worker polls every ~15s, so
 // we run the purge at most hourly (tracked here, not per-restart) to keep the
@@ -42,27 +39,19 @@ let lastRateLimitCleanup = 0;
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = 3_600_000;
 
 /**
+ * Holder-guarded: the row is created by claimLease(), and started_at is
+ * reset there whenever the holder changes, so this only ever updates.
  * @param {number} start - performance.now() timestamp when the poll began.
- * @param {boolean} isStartup - True on the worker's first poll of a session.
  * @param {string | null} [errorMsg] - Last error message to record, if any.
  */
-async function writeHeartbeat(start, isStartup, errorMsg = null) {
-    const now = new Date();
+async function writeHeartbeat(start, errorMsg = null) {
     const { error } = await tryCatch(
-        db.worker_heartbeat.upsert({
-            where: { worker_type: 'cron_api_poller' },
-            create: {
-                worker_type: 'cron_api_poller',
-                last_beat: now,
+        db.worker_heartbeat.updateMany({
+            where: { worker_type: 'cron_api_poller', holder_id: HOLDER_ID },
+            data: {
+                last_beat: new Date(),
                 poll_duration_ms: Math.round(performance.now() - start),
                 last_error: errorMsg?.slice(0, 500) ?? null,
-                started_at: now,
-            },
-            update: {
-                last_beat: now,
-                poll_duration_ms: Math.round(performance.now() - start),
-                last_error: errorMsg?.slice(0, 500) ?? null,
-                ...(isStartup && { started_at: now }),
             },
         }),
     );
@@ -89,7 +78,17 @@ export async function GET(request) {
     if (!isWorkerEnabled())
         return errorResponse(403, start, 'worker disabled on this instance');
 
-    const isStartup = request.headers.get(WORKER_STARTUP_HEADER) === '1';
+    // Claim (or renew) the poller lease. Every replica polls; only the
+    // holder does the work. A standby answer is deliberately cheap and
+    // touches nothing — the holder's heartbeat row must stay the holder's.
+    const { data: lease, error: leaseError } = await tryCatch(claimLease());
+    if (leaseError) {
+        reportError(leaseError, { route: '/api/h1/update', stage: 'lease' });
+        return errorResponse(500, start, leaseError.message);
+    }
+    if (!lease)
+        return successResponse(200, start, { role: 'standby', holder: HOLDER_ID });
+    const { prevEvents, lastSeasonObserved } = lease;
 
     // Periodic rate-limit window cleanup (at most hourly), off the response path.
     const nowMs = Date.now();
@@ -112,7 +111,7 @@ export async function GET(request) {
     if (statusError) {
         console.error(statusError?.message, statusError?.cause);
         reportError(statusError, { route: '/api/h1/update', stage: 'status' });
-        await writeHeartbeat(start, isStartup, statusError?.message);
+        await writeHeartbeat(start, statusError?.message);
         return errorResponse(500, start, statusError?.message);
     }
     const statusTime = roundedPerformanceTime(start);
@@ -142,7 +141,7 @@ export async function GET(request) {
             });
         }
     }
-    lastSeasonObserved = statusData.season;
+    await persistPollerState(HOLDER_ID, { lastSeasonObserved: statusData.season });
 
     //SEASON
     // Protect the bucket updateStatus() just wrote — stale snapshots from
@@ -158,7 +157,7 @@ export async function GET(request) {
             stage: 'season',
             season: statusData.season,
         });
-        await writeHeartbeat(start, isStartup, seasonError?.message);
+        await writeHeartbeat(start, seasonError?.message);
         return errorResponse(500, start, seasonError?.message);
     }
     const seasonTime = roundedPerformanceTime(start);
@@ -187,15 +186,17 @@ export async function GET(request) {
     // cleanup) without blocking the response — same pattern as the campaign
     // and rebroadcast routes.
     after(async () => {
-        const { error } = await tryCatch(checkAndNotify());
+        const { data: snapshot, error } = await tryCatch(checkAndNotify(prevEvents));
         if (error) {
             console.error('Push notification error:', error.message);
             reportError(error, { route: '/api/h1/update', stage: 'push-notify' });
+            return;
         }
+        if (snapshot) await persistPollerState(HOLDER_ID, { prevEvents: snapshot });
     });
 
     //RESPONSE
-    await writeHeartbeat(start, isStartup);
+    await writeHeartbeat(start);
     return successResponse(200, start, {
         updated: {
             status: statusData,

--- a/src/features/admin/SystemOverview.jsx
+++ b/src/features/admin/SystemOverview.jsx
@@ -60,6 +60,10 @@ export default async function SystemOverview() {
                     label="Uptime"
                     value={heartbeat ? formatUptime(heartbeat.started_at) : '—'}
                 />
+                <AdminStatCard
+                    label="Poller"
+                    value={heartbeat?.holder_id ? heartbeat.holder_id.split(':')[0] : '—'}
+                />
             </div>
 
             {heartbeat?.last_error && (

--- a/src/update/lease.mjs
+++ b/src/update/lease.mjs
@@ -1,0 +1,70 @@
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import db from '@/db/db';
+
+/**
+ * The poller lease (#517). Every replica runs the cron thread; on each poll
+ * it tries to claim this row. Postgres serialises the write, so exactly one
+ * instance holds the lease at a time and the others answer "standby". A dead
+ * holder simply stops renewing and the row is free once `lease_until` passes
+ * — failover is bounded by LEASE_TTL_S, no election, no manual step.
+ *
+ * The poller's state (prev_events, last_season_observed) lives in the same
+ * row: a new holder inherits the last snapshot instead of starting blind,
+ * so a transition across a handover is neither missed nor sent twice.
+ *
+ * Not pg_advisory_lock: those are bound to a session, and Prisma pools
+ * connections.
+ */
+export const WORKER_TYPE = 'cron_api_poller';
+export const LEASE_TTL_S = 60; // 3 polls at the 20 s staging cadence
+export const HOLDER_ID = `${os.hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`;
+
+/**
+ * Claim or renew the lease. Returns the persisted poller state when this
+ * instance holds it, or null when another live holder does.
+ * @param {string} [holderId] - This process's identity; defaults to HOLDER_ID.
+ * @param {number} [ttlSeconds] - How long a claim stays valid without renewal.
+ * @returns {Promise<{ prevEvents: object[] | null, lastSeasonObserved: number | null } | null>}
+ */
+export async function claimLease(holderId = HOLDER_ID, ttlSeconds = LEASE_TTL_S) {
+    // In DO UPDATE, `worker_heartbeat.col` is the OLD row and EXCLUDED the
+    // proposed one — so started_at resets exactly when the holder changes.
+    const rows = await db.$queryRaw`
+        INSERT INTO worker_heartbeat (worker_type, holder_id, lease_until, last_beat, started_at, updated_at)
+        VALUES (${WORKER_TYPE}, ${holderId}, now() + make_interval(secs => ${ttlSeconds}), now(), now(), now())
+        ON CONFLICT (worker_type) DO UPDATE SET
+            holder_id   = EXCLUDED.holder_id,
+            lease_until = EXCLUDED.lease_until,
+            started_at  = CASE
+                WHEN worker_heartbeat.holder_id IS DISTINCT FROM EXCLUDED.holder_id THEN now()
+                ELSE worker_heartbeat.started_at END
+        WHERE worker_heartbeat.holder_id = EXCLUDED.holder_id
+           OR worker_heartbeat.lease_until IS NULL
+           OR worker_heartbeat.lease_until < now()
+        RETURNING holder_id, prev_events, last_season_observed
+    `;
+    const row = rows[0];
+    if (!row) return null;
+    return {
+        prevEvents: row.prev_events ?? null,
+        lastSeasonObserved: row.last_season_observed ?? null,
+    };
+}
+
+/**
+ * Write poller state, but only while still the holder — a lease that expired
+ * mid-poll must not let a stale instance clobber the new holder's snapshot.
+ * @param {string} holderId - Only this holder's row is written.
+ * @param {{ prevEvents?: object[] | null, lastSeasonObserved?: number | null }} state - Fields to persist; omitted ones are left alone.
+ */
+export async function persistPollerState(holderId, state) {
+    const data = {};
+    if ('prevEvents' in state) data.prev_events = state.prevEvents;
+    if ('lastSeasonObserved' in state)
+        data.last_season_observed = state.lastSeasonObserved;
+    await db.worker_heartbeat.updateMany({
+        where: { worker_type: WORKER_TYPE, holder_id: holderId },
+        data,
+    });
+}

--- a/src/update/pushNotifier.mjs
+++ b/src/update/pushNotifier.mjs
@@ -7,7 +7,6 @@ import { EVENT_TYPE } from '@/shared/enums/events.mjs';
 import db from '@/db/db';
 
 const MAX_CONCURRENT = 50;
-let prevEvents = null;
 let configured = false;
 
 export function ensureVapid() {
@@ -108,8 +107,15 @@ export async function sendWithConcurrencyLimit(subscriptions, payload) {
  * Check for event transitions and send push notifications.
  * Called after updateStatus() — async, non-blocking.
  * Fetches current events from DB to avoid coupling with the update pipeline.
+ *
+ * The baseline is an argument, not module state: it comes from the lease row
+ * (#517), so a replica that just took over the poller role diffs against the
+ * previous holder's last snapshot instead of starting blind. Returns the
+ * current snapshot for the caller to persist.
+ * @param {object[] | null} prevEvents - Baseline snapshot from the lease row; null seeds without diffing.
+ * @returns {Promise<object[] | undefined>}
  */
-export async function checkAndNotify() {
+export async function checkAndNotify(prevEvents) {
     if (!ensureVapid()) return;
 
     const { data: season, error: fetchError } = await tryCatch(
@@ -137,7 +143,7 @@ export async function checkAndNotify() {
     if (fetchError || !season) return;
     const currentEvents = season.events;
 
-    if (prevEvents !== null) {
+    if (prevEvents != null) {
         const changes = detectChanges(prevEvents, currentEvents);
 
         if (changes.length > 0) {
@@ -156,5 +162,5 @@ export async function checkAndNotify() {
         }
     }
 
-    prevEvents = currentEvents;
+    return currentEvents;
 }

--- a/vitest.setup.mjs
+++ b/vitest.setup.mjs
@@ -103,6 +103,7 @@ const createModelMock = () => ({
     upsert: vi.fn(() => Promise.resolve({})),
     delete: vi.fn(() => Promise.resolve({})),
     deleteMany: vi.fn(() => Promise.resolve({ count: 0 })),
+    updateMany: vi.fn(() => Promise.resolve({ count: 1 })),
     count: vi.fn(() => Promise.resolve(0)),
 });
 


### PR DESCRIPTION
Implements #517. Follows #520 (the `WORKER_ENABLED` opt-out) and replaces the `worker`-service split that #521 proposed — with the lease, all replicas run the poller code and the row decides who actually polls.

**Mechanism** (`src/update/lease.mjs`): on every poll, one statement —
`INSERT INTO worker_heartbeat … ON CONFLICT (worker_type) DO UPDATE SET holder_id, lease_until = now()+60s … WHERE holder_id = mine OR lease_until < now() RETURNING …`.
Postgres serialises it, so exactly one replica gets a row back and does the work; the rest answer `200 { role: 'standby' }` and write nothing. A dead holder just stops renewing; the next tick after `lease_until` hands the role over. No election, no quorum, nothing to flip. Not `pg_advisory_lock` (session-bound; Prisma pools).

**The part that makes it correct:** `prev_events` and `last_season_observed` move from module state into the same row. `checkAndNotify(prevEvents)` now takes its baseline and returns the snapshot; the route persists both via holder-guarded `updateMany`. A successor inherits the previous snapshot, so a transition across a handover is neither missed (the #517 trap) nor duplicated. `started_at` resets in the claim SQL when the holder changes, so "Uptime" on the dashboard means *this holder's* uptime; a new "Poller" card shows the holder host.

**Migration:** four nullable columns on `worker_heartbeat`. Old code against the migrated DB is fine; **new code against an un-migrated DB is not** (`claimLease` fails → 500 on every poll). Because this PR touches `prisma/`, `bump-staging-tag` will skip with a warning — the deploy order is: merge → wait for `build-migrate` → run the migrate image against the staging DB from an amd64 host → pin the tag by hand. Then `deploy/staging/compose.yaml` can go to `replicas: 3` with a soft spread and **no** `worker` service (#521 will be reworked to that).

Rollout overlap: start-first means the old task (module state) and the new holder overlap for ~30–60 s once, on this deploy only. Staging has no `VAPID_*`, so nothing is sent either way.

**TDD:** `lease.test.mjs`, the rewritten `checkAndNotify` tests and the route tests (standby short-circuit, state-from-row, persistence, season transition from the row) were written first and watched fail. Verified: lint 0 errors (322 pre-existing warnings) · typecheck clean · 190 files / 1976 unit tests · build passes with `POSTGRES_URL` in the env. `0.93.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)