### PR TITLE
fix(lease): UTC timestamps in the claim SQL; holder_id names the node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.93.1
+
+### Fixed
+
+- Lease timestamps are written as `now() AT TIME ZONE 'UTC'`, matching what
+  Prisma writes into the naive `timestamp(3)` columns — a bare `now()` was the
+  session's local time, so `started_at` sat two hours off `last_beat`.
+- `holder_id` prefers the Swarm-provided node name (`SENTRY_SERVER_NAME`) over
+  the container hostname, which in a container is just the container ID.
+
 ## 0.93.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "helldivers.bot",
-    "version": "0.93.0",
+    "version": "0.93.1",
     "private": true,
     "license": "AGPL-3.0-only",
     "type": "module",

--- a/src/__tests__/unit/update/lease.test.mjs
+++ b/src/__tests__/unit/update/lease.test.mjs
@@ -3,6 +3,7 @@ import db from '@/db/db';
 import {
     claimLease,
     persistPollerState,
+    makeHolderId,
     HOLDER_ID,
     WORKER_TYPE,
 } from '@/update/lease.mjs';
@@ -40,6 +41,15 @@ describe('claimLease', () => {
     test('HOLDER_ID names this process (hostname + pid) so the dashboard can show who polls', () => {
         expect(HOLDER_ID).toContain(String(process.pid));
         expect(HOLDER_ID.split(':').length).toBeGreaterThanOrEqual(3);
+    });
+
+    test('makeHolderId prefers the orchestrator-given name over the container hostname', () => {
+        // In a container os.hostname() is the container ID — useless on a
+        // dashboard. Swarm hands the node name in via SENTRY_SERVER_NAME.
+        expect(makeHolderId({ SENTRY_SERVER_NAME: 'swarm02-1' }, 'c0ffee')).toMatch(
+            /^swarm02-1:\d+:[0-9a-f]{8}$/,
+        );
+        expect(makeHolderId({}, 'c0ffee')).toMatch(/^c0ffee:\d+:[0-9a-f]{8}$/);
     });
 });
 

--- a/src/update/lease.mjs
+++ b/src/update/lease.mjs
@@ -18,7 +18,19 @@ import db from '@/db/db';
  */
 export const WORKER_TYPE = 'cron_api_poller';
 export const LEASE_TTL_S = 60; // 3 polls at the 20 s staging cadence
-export const HOLDER_ID = `${os.hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`;
+/**
+ * Host + pid + nonce. In a container os.hostname() is the container ID,
+ * which tells a dashboard nothing; Swarm passes the node name (and task
+ * slot) in via SENTRY_SERVER_NAME, so prefer that when present.
+ * @param {NodeJS.ProcessEnv} [env] - Environment to read the name from.
+ * @param {string} [hostname] - Fallback host name.
+ * @returns {string}
+ */
+export function makeHolderId(env = process.env, hostname = os.hostname()) {
+    const host = env.SENTRY_SERVER_NAME?.trim() || hostname;
+    return `${host}:${process.pid}:${randomUUID().slice(0, 8)}`;
+}
+export const HOLDER_ID = makeHolderId();
 
 /**
  * Claim or renew the lease. Returns the persisted poller state when this
@@ -30,18 +42,28 @@ export const HOLDER_ID = `${os.hostname()}:${process.pid}:${randomUUID().slice(0
 export async function claimLease(holderId = HOLDER_ID, ttlSeconds = LEASE_TTL_S) {
     // In DO UPDATE, `worker_heartbeat.col` is the OLD row and EXCLUDED the
     // proposed one — so started_at resets exactly when the holder changes.
+    //
+    // Every timestamp here is `now() AT TIME ZONE 'UTC'`: the columns are
+    // naive timestamp(3) that Prisma writes in UTC, while a bare now() is
+    // the session's local time — mixing the two put started_at two hours
+    // off last_beat on the dashboard. The lease comparison must use the
+    // same clock it was written with.
     const rows = await db.$queryRaw`
         INSERT INTO worker_heartbeat (worker_type, holder_id, lease_until, last_beat, started_at, updated_at)
-        VALUES (${WORKER_TYPE}, ${holderId}, now() + make_interval(secs => ${ttlSeconds}), now(), now(), now())
+        VALUES (
+            ${WORKER_TYPE}, ${holderId},
+            (now() AT TIME ZONE 'UTC') + make_interval(secs => ${ttlSeconds}),
+            now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'
+        )
         ON CONFLICT (worker_type) DO UPDATE SET
             holder_id   = EXCLUDED.holder_id,
             lease_until = EXCLUDED.lease_until,
             started_at  = CASE
-                WHEN worker_heartbeat.holder_id IS DISTINCT FROM EXCLUDED.holder_id THEN now()
+                WHEN worker_heartbeat.holder_id IS DISTINCT FROM EXCLUDED.holder_id THEN now() AT TIME ZONE 'UTC'
                 ELSE worker_heartbeat.started_at END
         WHERE worker_heartbeat.holder_id = EXCLUDED.holder_id
            OR worker_heartbeat.lease_until IS NULL
-           OR worker_heartbeat.lease_until < now()
+           OR worker_heartbeat.lease_until < now() AT TIME ZONE 'UTC'
         RETURNING holder_id, prev_events, last_season_observed
     `;
     const row = rows[0];


### PR DESCRIPTION
Two things the first live lease row on staging showed (#522 follow-up):

- `lease_until` / `started_at` were written by a bare `now()` — the DB session's **local** time — into naive `timestamp(3)` columns that Prisma writes in **UTC**. The lease comparison was self-consistent (both sides `now()`), but `started_at` sat 2 h off `last_beat`, so the dashboard's Uptime was wrong. Every timestamp in the claim is now `now() AT TIME ZONE 'UTC'`.
- `holder_id` was `51e6b8addc90:1:…` — `os.hostname()` in a container is the container ID. It now prefers the node name Swarm passes in via `SENTRY_SERVER_NAME` (`swarm02-1` with #521's compose). Test written first for `makeHolderId`.

No schema change, so `bump-staging-tag` deploys this on merge. `0.93.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)